### PR TITLE
Fix: Error from no-content responses

### DIFF
--- a/src/main/java/com/vonage/client/logging/LoggingUtils.java
+++ b/src/main/java/com/vonage/client/logging/LoggingUtils.java
@@ -26,7 +26,7 @@ public class LoggingUtils {
 
     public static String logResponse(HttpResponse response) throws IOException {
         StringBuilder log = new StringBuilder();
-        String responseBody = EntityUtils.toString(response.getEntity());
+        String responseBody = response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : "";
         int statusCode = response.getStatusLine().getStatusCode();
         String statusLine = response.getStatusLine().getReasonPhrase();
 

--- a/src/test/java/com/vonage/client/LoggingUtilTest.java
+++ b/src/test/java/com/vonage/client/LoggingUtilTest.java
@@ -1,0 +1,50 @@
+package com.vonage.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.vonage.client.logging.LoggingUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.ProtocolVersion;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.message.BasicHttpResponse;
+import org.apache.http.message.BasicStatusLine;
+import org.junit.Test;
+
+public class LoggingUtilTest {
+
+  @Test
+  public void testNoContentResponseMethod() {
+
+    HttpResponse stubResponse = new BasicHttpResponse(
+        new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 204, "NO CONTENT")
+    );
+    BasicHttpEntity entity = new BasicHttpEntity();
+    entity.setContent(null);
+    stubResponse.setEntity(null);
+
+
+    try {
+      String response = LoggingUtils.logResponse(stubResponse);
+    } catch (Exception ex) {
+      fail("LoggingUtils Failed for null Response");
+    }
+  }
+
+
+  @Test
+  public void testContentResponseMethod() {
+
+    HttpResponse stub = TestUtils.makeJsonHttpResponse(200, "{\n" +
+        "  \"value\": BODY_CONTENT,\n" +
+        "  \"otherValue\": false\n" +
+        "}}");
+
+    try {
+      String response = LoggingUtils.logResponse(stub);
+      assertTrue((response.contains("BODY_CONTENT")));
+    } catch (Exception ex) {
+      fail("LoggingUtils Failed for Content Response");
+    }
+  }
+}


### PR DESCRIPTION

_Problem: Logging an empty response was throwing IllegalArgumentException from EntityUtils
  Solution: For an empty response log nothing by adding a Null check_

## Contribution Checklist
* [x] Unit tests!
* [ ] Updated [CHANGELOG.md](CHANGELOG.md)
* [ ] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
