### PR TITLE
Updated assertEquals methods and removed this keyword

### DIFF
--- a/src/test/java/com/vonage/client/account/AccountClientTest.java
+++ b/src/test/java/com/vonage/client/account/AccountClientTest.java
@@ -19,7 +19,6 @@ import com.vonage.client.ClientTest;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
-import junit.framework.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -47,7 +46,7 @@ public class AccountClientTest extends ClientTest<AccountClient> {
     public void testGetBalance() throws Exception {
         BalanceResponse response = client.getBalance();
         verify(client.balance).execute();
-        Assert.assertEquals(sentinel, response);
+        assertEquals(sentinel, response);
     }
 
     @Test
@@ -64,32 +63,32 @@ public class AccountClientTest extends ClientTest<AccountClient> {
                 + "    }  \n" + "  ]\n" + "}\n";
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         PricingResponse response = client.getSmsPrice("US");
-        Assert.assertEquals("1", response.getDialingPrefix());
-        Assert.assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
-        Assert.assertEquals("EUR", response.getCurrency());
-        Assert.assertEquals("United States of America", response.getCountry().getDisplayName());
-        Assert.assertEquals("US", response.getCountry().getCode());
-        Assert.assertEquals("United States", response.getCountry().getName());
+        assertEquals("1", response.getDialingPrefix());
+        assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
+        assertEquals("EUR", response.getCurrency());
+        assertEquals("United States of America", response.getCountry().getDisplayName());
+        assertEquals("US", response.getCountry().getCode());
+        assertEquals("United States", response.getCountry().getName());
 
-        Assert.assertEquals(2, response.getNetworks().size());
+        assertEquals(2, response.getNetworks().size());
         Network first = response.getNetworks().get(0);
-        Assert.assertEquals(Network.Type.MOBILE, first.getType());
-        Assert.assertEquals(new BigDecimal("0.00570000"), first.getPrice());
-        Assert.assertEquals("EUR", first.getCurrency());
-        Assert.assertEquals("987", first.getMcc());
-        Assert.assertEquals("123", first.getMnc());
-        Assert.assertEquals("123456", first.getCode());
-        Assert.assertEquals("Test Mobile", first.getName());
+        assertEquals(Network.Type.MOBILE, first.getType());
+        assertEquals(new BigDecimal("0.00570000"), first.getPrice());
+        assertEquals("EUR", first.getCurrency());
+        assertEquals("987", first.getMcc());
+        assertEquals("123", first.getMnc());
+        assertEquals("123456", first.getCode());
+        assertEquals("Test Mobile", first.getName());
 
 
         Network second = response.getNetworks().get(1);
-        Assert.assertEquals(Network.Type.LANDLINE, second.getType());
-        Assert.assertEquals(new BigDecimal("0.00330000"), second.getPrice());
-        Assert.assertEquals("EUR", second.getCurrency());
-        Assert.assertEquals("123", second.getMcc());
-        Assert.assertEquals("456", second.getMnc());
-        Assert.assertEquals("networkcode", second.getCode());
-        Assert.assertEquals("Test Landline", second.getName());
+        assertEquals(Network.Type.LANDLINE, second.getType());
+        assertEquals(new BigDecimal("0.00330000"), second.getPrice());
+        assertEquals("EUR", second.getCurrency());
+        assertEquals("123", second.getMcc());
+        assertEquals("456", second.getMnc());
+        assertEquals("networkcode", second.getCode());
+        assertEquals("Test Landline", second.getName());
     }
 
     @Test
@@ -106,32 +105,32 @@ public class AccountClientTest extends ClientTest<AccountClient> {
                 + "    }  \n" + "  ]\n" + "}\n";
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         PricingResponse response = client.getVoicePrice("US");
-        Assert.assertEquals("1", response.getDialingPrefix());
-        Assert.assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
-        Assert.assertEquals("EUR", response.getCurrency());
-        Assert.assertEquals("United States of America", response.getCountry().getDisplayName());
-        Assert.assertEquals("US", response.getCountry().getCode());
-        Assert.assertEquals("United States", response.getCountry().getName());
+        assertEquals("1", response.getDialingPrefix());
+        assertEquals(new BigDecimal("0.00570000"), response.getDefaultPrice());
+        assertEquals("EUR", response.getCurrency());
+        assertEquals("United States of America", response.getCountry().getDisplayName());
+        assertEquals("US", response.getCountry().getCode());
+        assertEquals("United States", response.getCountry().getName());
 
-        Assert.assertEquals(2, response.getNetworks().size());
+        assertEquals(2, response.getNetworks().size());
         Network first = response.getNetworks().get(0);
-        Assert.assertEquals(Network.Type.MOBILE, first.getType());
-        Assert.assertEquals(new BigDecimal("0.00570000"), first.getPrice());
-        Assert.assertEquals("EUR", first.getCurrency());
-        Assert.assertEquals("987", first.getMcc());
-        Assert.assertEquals("123", first.getMnc());
-        Assert.assertEquals("123456", first.getCode());
-        Assert.assertEquals("Test Mobile", first.getName());
+        assertEquals(Network.Type.MOBILE, first.getType());
+        assertEquals(new BigDecimal("0.00570000"), first.getPrice());
+        assertEquals("EUR", first.getCurrency());
+        assertEquals("987", first.getMcc());
+        assertEquals("123", first.getMnc());
+        assertEquals("123456", first.getCode());
+        assertEquals("Test Mobile", first.getName());
 
 
         Network second = response.getNetworks().get(1);
-        Assert.assertEquals(Network.Type.LANDLINE, second.getType());
-        Assert.assertEquals(new BigDecimal("0.00330000"), second.getPrice());
-        Assert.assertEquals("EUR", second.getCurrency());
-        Assert.assertEquals("123", second.getMcc());
-        Assert.assertEquals("456", second.getMnc());
-        Assert.assertEquals("networkcode", second.getCode());
-        Assert.assertEquals("Test Landline", second.getName());
+        assertEquals(Network.Type.LANDLINE, second.getType());
+        assertEquals(new BigDecimal("0.00330000"), second.getPrice());
+        assertEquals("EUR", second.getCurrency());
+        assertEquals("123", second.getMcc());
+        assertEquals("456", second.getMnc());
+        assertEquals("networkcode", second.getCode());
+        assertEquals("Test Landline", second.getName());
     }
 
     @Test
@@ -159,41 +158,41 @@ public class AccountClientTest extends ClientTest<AccountClient> {
                 + "}";
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         PrefixPricingResponse response = client.getPrefixPrice(ServiceType.VOICE, "1");
-        Assert.assertEquals(2, response.getCount());
-        Assert.assertEquals(2, response.getCountries().size());
+        assertEquals(2, response.getCount());
+        assertEquals(2, response.getCountries().size());
 
         PricingResponse firstResponse = response.getCountries().get(0);
-        Assert.assertEquals("1", firstResponse.getDialingPrefix());
-        Assert.assertEquals(new BigDecimal("0.01270000"), firstResponse.getDefaultPrice());
-        Assert.assertEquals("EUR", firstResponse.getCurrency());
-        Assert.assertEquals("Canada", firstResponse.getCountry().getDisplayName());
-        Assert.assertEquals("CA", firstResponse.getCountry().getCode());
-        Assert.assertEquals("Canada", firstResponse.getCountry().getName());
+        assertEquals("1", firstResponse.getDialingPrefix());
+        assertEquals(new BigDecimal("0.01270000"), firstResponse.getDefaultPrice());
+        assertEquals("EUR", firstResponse.getCurrency());
+        assertEquals("Canada", firstResponse.getCountry().getDisplayName());
+        assertEquals("CA", firstResponse.getCountry().getCode());
+        assertEquals("Canada", firstResponse.getCountry().getName());
 
-        Assert.assertEquals(2, firstResponse.getNetworks().size());
+        assertEquals(2, firstResponse.getNetworks().size());
         Network firstResponseFirstNetwork = firstResponse.getNetworks().get(0);
-        Assert.assertEquals(Network.Type.MOBILE, firstResponseFirstNetwork.getType());
-        Assert.assertEquals(new BigDecimal("0.01280000"), firstResponseFirstNetwork.getPrice());
-        Assert.assertEquals("EUR", firstResponseFirstNetwork.getCurrency());
-        Assert.assertEquals("302", firstResponseFirstNetwork.getMcc());
-        Assert.assertEquals("702", firstResponseFirstNetwork.getMnc());
-        Assert.assertEquals("302702", firstResponseFirstNetwork.getCode());
-        Assert.assertEquals("BELL ALIANT REGIONAL Communications LP", firstResponseFirstNetwork.getName());
+        assertEquals(Network.Type.MOBILE, firstResponseFirstNetwork.getType());
+        assertEquals(new BigDecimal("0.01280000"), firstResponseFirstNetwork.getPrice());
+        assertEquals("EUR", firstResponseFirstNetwork.getCurrency());
+        assertEquals("302", firstResponseFirstNetwork.getMcc());
+        assertEquals("702", firstResponseFirstNetwork.getMnc());
+        assertEquals("302702", firstResponseFirstNetwork.getCode());
+        assertEquals("BELL ALIANT REGIONAL Communications LP", firstResponseFirstNetwork.getName());
 
 
         Network firstResponseSecondNetwork = firstResponse.getNetworks().get(1);
-        Assert.assertEquals(Network.Type.LANDLINE, firstResponseSecondNetwork.getType());
-        Assert.assertEquals(new BigDecimal("0.01000000"), firstResponseSecondNetwork.getPrice());
-        Assert.assertEquals("EUR", firstResponseSecondNetwork.getCurrency());
-        Assert.assertEquals("CA-FIXED", firstResponseSecondNetwork.getCode());
-        Assert.assertEquals("Canada Landline", firstResponseSecondNetwork.getName());
+        assertEquals(Network.Type.LANDLINE, firstResponseSecondNetwork.getType());
+        assertEquals(new BigDecimal("0.01000000"), firstResponseSecondNetwork.getPrice());
+        assertEquals("EUR", firstResponseSecondNetwork.getCurrency());
+        assertEquals("CA-FIXED", firstResponseSecondNetwork.getCode());
+        assertEquals("Canada Landline", firstResponseSecondNetwork.getName());
 
         PricingResponse secondResponse = response.getCountries().get(1);
-        Assert.assertEquals("1", secondResponse.getDialingPrefix());
-        Assert.assertEquals("EUR", secondResponse.getCurrency());
-        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
-        Assert.assertEquals("UM", secondResponse.getCountry().getCode());
-        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
+        assertEquals("1", secondResponse.getDialingPrefix());
+        assertEquals("EUR", secondResponse.getCurrency());
+        assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
+        assertEquals("UM", secondResponse.getCountry().getCode());
+        assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
     }
 
     @Test
@@ -217,33 +216,33 @@ public class AccountClientTest extends ClientTest<AccountClient> {
                 + "}";
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         PrefixPricingResponse response = client.getPrefixPrice(ServiceType.SMS, "1");
-        Assert.assertEquals(2, response.getCount());
-        Assert.assertEquals(2, response.getCountries().size());
+        assertEquals(2, response.getCount());
+        assertEquals(2, response.getCountries().size());
 
         PricingResponse firstResponse = response.getCountries().get(0);
-        Assert.assertEquals("1", firstResponse.getDialingPrefix());
-        Assert.assertEquals(new BigDecimal("0.00570000"), firstResponse.getDefaultPrice());
-        Assert.assertEquals("EUR", firstResponse.getCurrency());
-        Assert.assertEquals("Canada", firstResponse.getCountry().getDisplayName());
-        Assert.assertEquals("CA", firstResponse.getCountry().getCode());
-        Assert.assertEquals("Canada", firstResponse.getCountry().getName());
+        assertEquals("1", firstResponse.getDialingPrefix());
+        assertEquals(new BigDecimal("0.00570000"), firstResponse.getDefaultPrice());
+        assertEquals("EUR", firstResponse.getCurrency());
+        assertEquals("Canada", firstResponse.getCountry().getDisplayName());
+        assertEquals("CA", firstResponse.getCountry().getCode());
+        assertEquals("Canada", firstResponse.getCountry().getName());
 
-        Assert.assertEquals(1, firstResponse.getNetworks().size());
+        assertEquals(1, firstResponse.getNetworks().size());
         Network network = firstResponse.getNetworks().get(0);
-        Assert.assertEquals(Network.Type.MOBILE, network.getType());
-        Assert.assertEquals(new BigDecimal("0.00570000"), network.getPrice());
-        Assert.assertEquals("EUR", network.getCurrency());
-        Assert.assertEquals("302", network.getMcc());
-        Assert.assertEquals("655", network.getMnc());
-        Assert.assertEquals("302655", network.getCode());
-        Assert.assertEquals("MTS Communications Inc.", network.getName());
+        assertEquals(Network.Type.MOBILE, network.getType());
+        assertEquals(new BigDecimal("0.00570000"), network.getPrice());
+        assertEquals("EUR", network.getCurrency());
+        assertEquals("302", network.getMcc());
+        assertEquals("655", network.getMnc());
+        assertEquals("302655", network.getCode());
+        assertEquals("MTS Communications Inc.", network.getName());
 
         PricingResponse secondResponse = response.getCountries().get(1);
-        Assert.assertEquals("1", secondResponse.getDialingPrefix());
-        Assert.assertEquals("EUR", secondResponse.getCurrency());
-        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
-        Assert.assertEquals("UM", secondResponse.getCountry().getCode());
-        Assert.assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
+        assertEquals("1", secondResponse.getDialingPrefix());
+        assertEquals("EUR", secondResponse.getCurrency());
+        assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getDisplayName());
+        assertEquals("UM", secondResponse.getCountry().getCode());
+        assertEquals("United States Minor Outlying Islands", secondResponse.getCountry().getName());
     }
 
     @Test
@@ -454,11 +453,11 @@ public class AccountClientTest extends ClientTest<AccountClient> {
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         SettingsResponse response = client.updateSmsIncomingUrl("https://example.com/webhooks/inbound-sms");
 
-        Assert.assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
-        Assert.assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
-        Assert.assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
-        Assert.assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
-        Assert.assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
+        assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
+        assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
+        assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
+        assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
+        assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
     }
 
     @Test
@@ -473,11 +472,11 @@ public class AccountClientTest extends ClientTest<AccountClient> {
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         SettingsResponse response = client.updateDeliveryReceiptUrl("https://example.com/webhooks/delivery-receipt");
 
-        Assert.assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
-        Assert.assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
-        Assert.assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
-        Assert.assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
-        Assert.assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
+        assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
+        assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
+        assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
+        assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
+        assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
     }
 
     @Test
@@ -493,10 +492,10 @@ public class AccountClientTest extends ClientTest<AccountClient> {
         wrapper.setHttpClient(this.stubHttpClient(200, json));
         SettingsResponse response = client.updateSettings(new SettingsRequest("https://example.com/webhooks/inbound-sms", "https://example.com/webhooks/delivery-receipt"));
 
-        Assert.assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
-        Assert.assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
-        Assert.assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
-        Assert.assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
-        Assert.assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
+        assertEquals("https://example.com/webhooks/inbound-sms", response.getIncomingSmsUrl());
+        assertEquals("https://example.com/webhooks/delivery-receipt", response.getDeliveryReceiptUrl());
+        assertEquals(Integer.valueOf(30), response.getMaxApiCallsPerSecond());
+        assertEquals(Integer.valueOf(20), response.getMaxInboundMessagesPerSecond());
+        assertEquals(Integer.valueOf(10), response.getMaxOutboundMessagesPerSecond());
     }
 }

--- a/src/test/java/com/vonage/client/account/PrefixPricingMethodTest.java
+++ b/src/test/java/com/vonage/client/account/PrefixPricingMethodTest.java
@@ -28,7 +28,7 @@ public class PrefixPricingMethodTest {
 
     @Before
     public void setUp() {
-        this.method = new PrefixPricingMethod(new HttpWrapper());
+        method = new PrefixPricingMethod(new HttpWrapper());
     }
 
     @Test


### PR DESCRIPTION
Replaced <code>assertEquals</code> methods in <i>AccountClientTest.java</i>. Removed <code>this</code> keyword from <i>PrefixPricingMethodTest.java</i> on line 31; as requested here #339. 