### PR TITLE
changed create application request auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.6.0]
+### Added
+- NotifyEvent structure for Notify Actions
+- SHA256 hashing option
+
+### Changed
+- Create application request use basic auth for authentication
+
+### Fixed
+- Fixed error throw when trying to log No Content responses
+
 ## [5.5.0]
 ### Added
 - Added support for PSD2 verification
-- SHA256 hashing option
 
 ## [5.4.0]
 ### Added

--- a/src/main/java/com/vonage/client/application/CreateApplicationMethod.java
+++ b/src/main/java/com/vonage/client/application/CreateApplicationMethod.java
@@ -59,4 +59,9 @@ class CreateApplicationMethod extends AbstractMethod<Application, Application> {
 
         return Application.fromJson(new BasicResponseHandler().handleResponse(response));
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/main/java/com/vonage/client/application/DeleteApplicationMethod.java
+++ b/src/main/java/com/vonage/client/application/DeleteApplicationMethod.java
@@ -56,4 +56,9 @@ class DeleteApplicationMethod extends AbstractMethod<String, Void> {
 
         return null;
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/main/java/com/vonage/client/application/GetApplicationMethod.java
+++ b/src/main/java/com/vonage/client/application/GetApplicationMethod.java
@@ -57,4 +57,9 @@ class GetApplicationMethod extends AbstractMethod<String, Application> {
 
         return Application.fromJson(new BasicResponseHandler().handleResponse(response));
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/main/java/com/vonage/client/application/ListApplicationsMethod.java
+++ b/src/main/java/com/vonage/client/application/ListApplicationsMethod.java
@@ -69,4 +69,9 @@ class ListApplicationsMethod extends AbstractMethod<ListApplicationRequest, Appl
 
         return ApplicationList.fromJson(new BasicResponseHandler().handleResponse(response));
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/main/java/com/vonage/client/application/UpdateApplicationMethod.java
+++ b/src/main/java/com/vonage/client/application/UpdateApplicationMethod.java
@@ -59,4 +59,9 @@ class UpdateApplicationMethod extends AbstractMethod<Application, Application> {
 
         return Application.fromJson(new BasicResponseHandler().handleResponse(response));
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/test/java/com/vonage/client/application/AppBasicAuthTest.java
+++ b/src/test/java/com/vonage/client/application/AppBasicAuthTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2020  Vonage 
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vonage.client.application;
+
+import com.vonage.client.HttpWrapper;
+import com.vonage.client.auth.TokenAuthMethod;
+import org.apache.http.client.methods.RequestBuilder;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public abstract class AppBasicAuthTest {
+
+    @Test
+    public void testApplyAuth() throws Exception {
+        String expectedAuthStr = "Authorization: Basic NHQ4YWVhZ2I6WHlNczJKa21BMVp6OWRVaw==";
+        HttpWrapper wrapper = new HttpWrapper(new TokenAuthMethod("4t8aeagb", "XyMs2JkmA1Zz9dUk"));
+        CreateApplicationMethod method = new CreateApplicationMethod(wrapper);
+        RequestBuilder request = method.makeRequest(Application.builder().build());
+        RequestBuilder requestWithAuth = method.applyAuth(request);
+
+        assertEquals(expectedAuthStr, String.valueOf(requestWithAuth.getHeaders("Authorization")[0]));
+
+    }
+}

--- a/src/test/java/com/vonage/client/application/CreateApplicationMethodTest.java
+++ b/src/test/java/com/vonage/client/application/CreateApplicationMethodTest.java
@@ -17,13 +17,14 @@ package com.vonage.client.application;
 
 import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.client.methods.RequestBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class CreateApplicationMethodTest {
+public class CreateApplicationMethodTest extends AppBasicAuthTest {
     private CreateApplicationMethod method;
 
     @Before

--- a/src/test/java/com/vonage/client/application/DeleteApplicationMethodTest.java
+++ b/src/test/java/com/vonage/client/application/DeleteApplicationMethodTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class DeleteApplicationMethodTest {
+public class DeleteApplicationMethodTest extends AppBasicAuthTest {
     private DeleteApplicationMethod method;
 
     @Before
@@ -57,4 +57,6 @@ public class DeleteApplicationMethodTest {
         assertEquals("DELETE", builder.getMethod());
         assertEquals("https://example.com/v2/applications/78d335fa323d01149c3dd6f0d48968cf", builder.build().getURI().toString());
     }
+    
+    
 }

--- a/src/test/java/com/vonage/client/application/GetApplicationMethodTest.java
+++ b/src/test/java/com/vonage/client/application/GetApplicationMethodTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class GetApplicationMethodTest {
+public class GetApplicationMethodTest extends AppBasicAuthTest {
     private GetApplicationMethod method;
 
     @Before

--- a/src/test/java/com/vonage/client/application/ListApplicationsMethodTest.java
+++ b/src/test/java/com/vonage/client/application/ListApplicationsMethodTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListApplicationsMethodTest {
+public class ListApplicationsMethodTest extends AppBasicAuthTest {
     private ListApplicationsMethod method;
 
     @Before

--- a/src/test/java/com/vonage/client/application/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/vonage/client/application/UpdateApplicationMethodTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class UpdateApplicationMethodTest {
+public class UpdateApplicationMethodTest extends AppBasicAuthTest {
     private UpdateApplicationMethod method;
 
     @Before


### PR DESCRIPTION
Changed create application request auth to use basic auth based on changes announced by the Product API team

> As part of releasing an internal security update for the Applications Service, we noticed that v2 of the public-facing Application API was accepting API key/secret as request params for authentication. This has been treated as a bug.
Request parameter auth was never intended to be supported and was not documented publicly or internally for v2 of the API. We recommend customers use header auth (basic auth) for this API instead. https://developer.nexmo.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication


## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
