### PR TITLE
Application v2 Basic Auth Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [5.6.0]
+### Changed
+- Changed application requests to use basic auth in header for authentication
+
 ## [5.5.0]
 ### Added
 - Added support for PSD2 verification

--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@
 ## Support Notice
 This library have transitioned into a "Maintenance Only" mode. For the next twelve (12) months, this library will only receive bug or security fixes. This library will officially be End of Life as of October 1st, 2021.
 
-We recommend users begin migrating over to the [Vonage Java Server SDK](https://github.com/vonage/vonage-java-sdk). The Vonage packages fully support the `\Nexmo` namespace and should be a drop-in replacement for the Nexmo packages.
-
-If you have any questions, feel free to reach out to us at devrel@vonage.com or through our Community Slack at https://developer.nexmo.com/community/slack
+We recommend users begin migrating over to the [Vonage Java Server SDK](https://github.com/vonage/vonage-java-sdk). If you have any questions, feel free to reach out to us at devrel@vonage.com or through our Community Slack at https://developer.nexmo.com/community/slack
 
 <hr />
 
@@ -491,6 +489,6 @@ library are always appreciated.
 
 
 [create_account]: https://docs.nexmo.com/tools/dashboard#setting-up-your-nexmo-account
-[signup]: https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=[LANGUAGE]-client-library
-[doc_sms]: https://docs.nexmo.com/api-ref/sms-api?utm_source=DEV_REL&utm_medium=github&utm_campaign=[LANGUAGE]-client-library
+[signup]: https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=java-client-library
+[doc_sms]: https://docs.nexmo.com/api-ref/sms-api?utm_source=DEV_REL&utm_medium=github&utm_campaign=java-client-library
 [license]: LICENSE.txt

--- a/src/main/java/com/nexmo/client/application/ApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/ApplicationMethod.java
@@ -21,44 +21,20 @@
  */
 package com.nexmo.client.application;
 
+import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoBadRequestException;
 import com.nexmo.client.NexmoClientException;
-import com.nexmo.client.auth.TokenAuthMethod;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.util.EntityUtils;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+public abstract class ApplicationMethod<RequestT, ResultT> extends AbstractMethod<RequestT, ResultT> {
 
-class DeleteApplicationMethod extends ApplicationMethod<String, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
-    private static final String PATH = "/applications/%s";
-
-    DeleteApplicationMethod(HttpWrapper httpWrapper) {
+    public ApplicationMethod(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
-        return ALLOWED_AUTH_METHODS;
-    }
-
-    @Override
-    public RequestBuilder makeRequest(String id) throws UnsupportedEncodingException {
-        return RequestBuilder
-                .delete(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + String.format(PATH, id))
-                .setHeader("Content-Type", "application/json");
-    }
-
-    @Override
-    public Void parseResponse(HttpResponse response) throws IOException, NexmoClientException {
-        if (response.getStatusLine().getStatusCode() != 204) {
-            throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
-        }
-
-        return null;
+    protected RequestBuilder applyAuth(RequestBuilder request) throws NexmoClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/nexmo/client/application/CreateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/CreateApplicationMethod.java
@@ -21,7 +21,6 @@
  */
 package com.nexmo.client.application;
 
-import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
 import com.nexmo.client.NexmoClientException;
@@ -35,7 +34,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-class CreateApplicationMethod extends AbstractMethod<Application, Application> {
+class CreateApplicationMethod extends ApplicationMethod<Application, Application> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
     private static final String PATH = "/applications";

--- a/src/main/java/com/nexmo/client/application/GetApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/GetApplicationMethod.java
@@ -21,7 +21,6 @@
  */
 package com.nexmo.client.application;
 
-import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
 import com.nexmo.client.NexmoClientException;
@@ -34,7 +33,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-class GetApplicationMethod extends AbstractMethod<String, Application> {
+class GetApplicationMethod extends ApplicationMethod<String, Application> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
     private static final String PATH = "/applications/%s";

--- a/src/main/java/com/nexmo/client/application/ListApplicationsMethod.java
+++ b/src/main/java/com/nexmo/client/application/ListApplicationsMethod.java
@@ -21,7 +21,6 @@
  */
 package com.nexmo.client.application;
 
-import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
 import com.nexmo.client.NexmoClientException;
@@ -34,7 +33,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-class ListApplicationsMethod extends AbstractMethod<ListApplicationRequest, ApplicationList> {
+class ListApplicationsMethod extends ApplicationMethod<ListApplicationRequest, ApplicationList> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
     private static final String PATH = "/applications";

--- a/src/main/java/com/nexmo/client/application/UpdateApplicationMethod.java
+++ b/src/main/java/com/nexmo/client/application/UpdateApplicationMethod.java
@@ -21,7 +21,6 @@
  */
 package com.nexmo.client.application;
 
-import com.nexmo.client.AbstractMethod;
 import com.nexmo.client.HttpWrapper;
 import com.nexmo.client.NexmoBadRequestException;
 import com.nexmo.client.NexmoClientException;
@@ -35,7 +34,7 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
-class UpdateApplicationMethod extends AbstractMethod<Application, Application> {
+class UpdateApplicationMethod extends ApplicationMethod<Application, Application> {
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
 
     private static final String PATH = "/applications/%s";

--- a/src/test/java/com/nexmo/client/application/ApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/ApplicationMethodTest.java
@@ -22,43 +22,23 @@
 package com.nexmo.client.application;
 
 import com.nexmo.client.HttpWrapper;
-import com.nexmo.client.NexmoBadRequestException;
-import com.nexmo.client.NexmoClientException;
 import com.nexmo.client.auth.TokenAuthMethod;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.util.EntityUtils;
+import org.junit.Test;
 
-import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import static org.junit.Assert.assertEquals;
 
-class DeleteApplicationMethod extends ApplicationMethod<String, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+public class ApplicationMethodTest {
 
-    private static final String PATH = "/applications/%s";
+    @Test
+    public void testApplyAuth() throws Exception {
+        String expectedAuthStr = "Authorization: Basic NHQ4YWVhZ2I6WHlNczJKa21BMVp6OWRVaw==";
+        HttpWrapper wrapper = new HttpWrapper(new TokenAuthMethod("4t8aeagb", "XyMs2JkmA1Zz9dUk"));
+        CreateApplicationMethod method = new CreateApplicationMethod(wrapper);
+        RequestBuilder request = method.makeRequest(Application.builder().build());
+        RequestBuilder requestWithAuth = method.applyAuth(request);
 
-    DeleteApplicationMethod(HttpWrapper httpWrapper) {
-        super(httpWrapper);
-    }
+        assertEquals(expectedAuthStr, String.valueOf(requestWithAuth.getHeaders("Authorization")[0]));
 
-    @Override
-    protected Class[] getAcceptableAuthMethods() {
-        return ALLOWED_AUTH_METHODS;
-    }
-
-    @Override
-    public RequestBuilder makeRequest(String id) throws UnsupportedEncodingException {
-        return RequestBuilder
-                .delete(httpWrapper.getHttpConfig().getVersionedApiBaseUri("v2") + String.format(PATH, id))
-                .setHeader("Content-Type", "application/json");
-    }
-
-    @Override
-    public Void parseResponse(HttpResponse response) throws IOException, NexmoClientException {
-        if (response.getStatusLine().getStatusCode() != 204) {
-            throw new NexmoBadRequestException(EntityUtils.toString(response.getEntity()));
-        }
-
-        return null;
     }
 }

--- a/src/test/java/com/nexmo/client/application/CreateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/CreateApplicationMethodTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class CreateApplicationMethodTest {
+public class CreateApplicationMethodTest extends ApplicationMethodTest {
     private CreateApplicationMethod method;
 
     @Before

--- a/src/test/java/com/nexmo/client/application/DeleteApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/DeleteApplicationMethodTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class DeleteApplicationMethodTest {
+public class DeleteApplicationMethodTest extends ApplicationMethodTest {
     private DeleteApplicationMethod method;
 
     @Before

--- a/src/test/java/com/nexmo/client/application/GetApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/GetApplicationMethodTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class GetApplicationMethodTest {
+public class GetApplicationMethodTest extends ApplicationMethodTest {
     private GetApplicationMethod method;
 
     @Before

--- a/src/test/java/com/nexmo/client/application/ListApplicationsMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/ListApplicationsMethodTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class ListApplicationsMethodTest {
+public class ListApplicationsMethodTest extends ApplicationMethodTest {
     private ListApplicationsMethod method;
 
     @Before

--- a/src/test/java/com/nexmo/client/application/UpdateApplicationMethodTest.java
+++ b/src/test/java/com/nexmo/client/application/UpdateApplicationMethodTest.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-public class UpdateApplicationMethodTest {
+public class UpdateApplicationMethodTest extends ApplicationMethodTest {
     private UpdateApplicationMethod method;
 
     @Before


### PR DESCRIPTION
Changed create application request auth to use basic auth based on changes announced by the Product API team

> As part of releasing an internal security update for the Applications Service, we noticed that v2 of the public-facing Application API was accepting API key/secret as request params for authentication. This has been treated as a bug.
> Request parameter auth was never intended to be supported and was not documented publicly or internally for v2 of the API. We recommend customers use header auth (basic auth) for this API instead. https://developer.nexmo.com/concepts/guides/authentication#header-based-api-key-and-secret-authentication
> 


## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
