### PR TITLE
Feature/sms dlt fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.2.0]
+- Adding ContentId and EntityId to message class for DLT
+
 ## [6.1.0]
 - Adding Language and Style to the Voice Talk Action and the Talk Request
 - Marking VoiceName as Deprecated

--- a/src/main/java/com/vonage/client/sms/messages/Message.java
+++ b/src/main/java/com/vonage/client/sms/messages/Message.java
@@ -54,6 +54,8 @@ public abstract class Message {
     private MessageClass messageClass = null;
     private Long timeToLive = null;
     private String callbackUrl = null;
+    private String entityId = null;
+    private String contentId = null;
 
     protected Message(final MessageType type,
                       final String from,
@@ -148,6 +150,14 @@ public abstract class Message {
         this.callbackUrl = callbackUrl;
     }
 
+    public String getEntityId() { return entityId; }
+
+    public void setEntityId(String entityId){ this.entityId = entityId; }
+
+    public String getContentId() { return contentId; }
+
+    public void setContentId(String contentId) { this.contentId = contentId; }
+
     /**
      * @return get the value of the 'status-report-req' parameter.
      */
@@ -186,6 +196,12 @@ public abstract class Message {
         }
         if (messageClass != null) {
             request.addParameter("message-class", Integer.toString(messageClass.getMessageClass()));
+        }
+        if(entityId != null){
+            request.addParameter("entity-id", entityId);
+        }
+        if(contentId != null){
+            request.addParameter("content-id", contentId);
         }
     }
 

--- a/src/test/java/com/vonage/client/sms/SendMessageEndpointTest.java
+++ b/src/test/java/com/vonage/client/sms/SendMessageEndpointTest.java
@@ -284,4 +284,34 @@ public class SendMessageEndpointTest {
             assertEquals("application/x-www-form-urlencoded; charset=UTF-8", entity.getContentType().getValue());
         }
     }
+
+    @Test
+    public void testConstructParamsContentId() throws Exception {
+        Message message = new TextMessage("TestSender", "not-a-number", "Test");
+        message.setContentId("abcd-1234");
+        List<NameValuePair> params = endpoint.makeRequest(message).getParameters();
+
+        assertContainsParam(params, "from", "TestSender");
+        assertContainsParam(params, "to", "not-a-number");
+        assertContainsParam(params, "type", "text");
+        assertMissingParam(params, "status-report-req");
+        assertContainsParam(params, "text", "Test");
+        assertContainsParam(params, "content-id","abcd-1234");
+        assertMissingParam(params,"entity-id");
+    }
+
+    @Test
+    public void testConstructParamsEntityId() throws Exception {
+        Message message = new TextMessage("TestSender", "not-a-number", "Test");
+        message.setEntityId("abcd-1234");
+        List<NameValuePair> params = endpoint.makeRequest(message).getParameters();
+
+        assertContainsParam(params, "from", "TestSender");
+        assertContainsParam(params, "to", "not-a-number");
+        assertContainsParam(params, "type", "text");
+        assertMissingParam(params, "status-report-req");
+        assertContainsParam(params, "text", "Test");
+        assertContainsParam(params, "entity-id","abcd-1234");
+        assertMissingParam(params,"content-id");
+    }
 }


### PR DESCRIPTION
Adding `entity-id` and `content-id` fields to the Message class to enable DLT in the Java SDK.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
