### PR TITLE
number insight parsing update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.0]
+- Adding extra parsing for top level Roaming Status in Advanced Number Insights
+
 ## [6.2.0]
 - Adding ContentId and EntityId to message class for DLT
 - Adding Detail enum and string for certain voice webhooks

--- a/src/main/java/com/vonage/client/insight/RoamingDeseriazlizer.java
+++ b/src/main/java/com/vonage/client/insight/RoamingDeseriazlizer.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2021 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.insight;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+
+import java.io.IOException;
+
+public class RoamingDeseriazlizer extends StdDeserializer<RoamingDetails> {
+    public RoamingDeseriazlizer(){
+        this(null);
+    }
+
+    @Override
+    public RoamingDetails deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        JsonNode node = p.getCodec().readTree(p);
+        RoamingDetails.RoamingStatus status = RoamingDetails.RoamingStatus.UNKNOWN;
+        String roamingCountryCode = null;
+        String roamingNetworkCode = null;
+        String roamingNetworkName = null;
+        if (node.getNodeType() == JsonNodeType.STRING){
+            status = RoamingDetails.RoamingStatus.fromString(node.asText());
+        }
+        else if(node.getNodeType() == JsonNodeType.OBJECT){
+            status = RoamingDetails.RoamingStatus.fromString(node.get("status").asText());
+            if(!(node.get("roaming_country_code") == null)){
+                roamingCountryCode = node.get("roaming_country_code").asText();
+            }
+            if(!(node.get("roaming_network_code") == null)){
+                roamingNetworkCode = node.get("roaming_network_code").asText();
+            }
+            if(!(node.get("roaming_network_name") == null)){
+                roamingNetworkName = node.get("roaming_network_name").asText();
+            }
+        }
+        RoamingDetails details = new RoamingDetails(status,roamingCountryCode,roamingNetworkCode,roamingNetworkName);
+        return details;
+    }
+
+    public RoamingDeseriazlizer(Class<?> vc){
+        super(vc);
+    }
+
+
+}

--- a/src/main/java/com/vonage/client/insight/RoamingDetails.java
+++ b/src/main/java/com/vonage/client/insight/RoamingDetails.java
@@ -17,10 +17,12 @@ package com.vonage.client.insight;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.util.HashMap;
 import java.util.Map;
 
+@JsonDeserialize(using = RoamingDeseriazlizer.class)
 public class RoamingDetails {
     public enum RoamingStatus {
         UNKNOWN, ROAMING, NOT_ROAMING;
@@ -38,6 +40,13 @@ public class RoamingDetails {
             RoamingStatus foundRoamingStatus = ROAMING_STATUS_INDEX.get(name.toUpperCase());
             return (foundRoamingStatus != null) ? foundRoamingStatus : UNKNOWN;
         }
+    }
+
+    public RoamingDetails(RoamingStatus status, String roamingCountryCode, String roamingNetworkCode, String roamingNetworkName){
+        this.status = status;
+        this.roamingCountryCode = roamingCountryCode;
+        this.roamingNetworkCode = roamingNetworkCode;
+        this.roamingNetworkName = roamingNetworkName;
     }
 
     private RoamingStatus status;

--- a/src/test/java/com/vonage/client/insight/AdvancedInsightResponseTest.java
+++ b/src/test/java/com/vonage/client/insight/AdvancedInsightResponseTest.java
@@ -101,6 +101,152 @@ public class AdvancedInsightResponseTest {
     }
 
     @Test
+    public void testFromJsonUnknownRoaming() throws Exception {
+        AdvancedInsightResponse response = AdvancedInsightResponse.fromJson("{\n" +
+                "    \"status\": 0,\n" +
+                "    \"status_message\": \"Success\",\n" +
+                "    \"lookup_outcome\": 1,\n" +
+                "    \"lookup_outcome_message\": \"Partial success - some fields populated\",\n" +
+                "    \"request_id\": \"0c082a69-85df-4bbc-aae6-ee998e17e5a4\",\n" +
+                "    \"international_format_number\": \"441632960960\",\n" +
+                "    \"national_format_number\": \"01632 960960\",\n" +
+                "    \"country_code\": \"GB\",\n" +
+                "    \"country_code_iso3\": \"GBR\",\n" +
+                "    \"country_name\": \"United Kingdom\",\n" +
+                "    \"country_prefix\": \"44\",\n" +
+                "    \"request_price\": \"0.03000000\",\n" +
+                "    \"remaining_balance\": \"18.30908949\",\n" +
+                "    \"current_carrier\": {\n" +
+                "        \"network_code\": \"GB-FIXED-RESERVED\",\n" +
+                "        \"name\": \"United Kingdom Landline Reserved\",\n" +
+                "        \"country\": \"GB\",\n" +
+                "        \"network_type\": \"landline\"\n" +
+                "    },\n" +
+                "    \"original_carrier\": {\n" +
+                "        \"network_code\": \"GB-HAPPY-RESERVED\",\n" +
+                "        \"name\": \"United Kingdom Mobile Reserved\",\n" +
+                "        \"country\": \"GB\",\n" +
+                "        \"network_type\": \"mobile\"\n" +
+                "    },\n" +
+                "    \"valid_number\": \"valid\",\n" +
+                "    \"reachable\": \"unknown\",\n" +
+                "    \"ported\": \"assumed_not_ported\",\n" +
+                "    \"roaming\": \"unknown\",\n" +
+                "    \"first_name\": \"Bob\",\n" +
+                "    \"last_name\": \"Atkey\",\n" +
+                "    \"caller_name\": \"Monads, Incorporated\",\n" +
+                "    \"caller_type\": \"unknown\"\n" +
+                "}");
+
+        assertEquals(InsightStatus.SUCCESS, response.getStatus());
+        assertEquals("Success", response.getStatusMessage());
+        assertEquals("0c082a69-85df-4bbc-aae6-ee998e17e5a4", response.getRequestId());
+        assertEquals("441632960960", response.getInternationalFormatNumber());
+        assertEquals("01632 960960", response.getNationalFormatNumber());
+        assertEquals("GB", response.getCountryCode());
+        assertEquals("GBR", response.getCountryCodeIso3());
+        assertEquals("United Kingdom", response.getCountryName());
+        assertEquals("44", response.getCountryPrefix());
+        assertEquals("GB-FIXED-RESERVED", response.getCurrentCarrier().getNetworkCode());
+        assertEquals("United Kingdom Landline Reserved", response.getCurrentCarrier().getName());
+        assertEquals("GB", response.getCurrentCarrier().getCountry());
+        assertEquals("GB-FIXED-RESERVED", response.getCurrentCarrier().getNetworkCode());
+        assertEquals("United Kingdom Landline Reserved", response.getCurrentCarrier().getName());
+        assertEquals("GB", response.getCurrentCarrier().getCountry());
+        assertEquals(CarrierDetails.NetworkType.LANDLINE, response.getCurrentCarrier().getNetworkType());
+
+        assertEquals("GB-HAPPY-RESERVED", response.getOriginalCarrier().getNetworkCode());
+        assertEquals("United Kingdom Mobile Reserved", response.getOriginalCarrier().getName());
+        assertEquals("GB", response.getOriginalCarrier().getCountry());
+        assertEquals(CarrierDetails.NetworkType.MOBILE, response.getOriginalCarrier().getNetworkType());
+
+        assertEquals(new BigDecimal("18.30908949"), response.getRemainingBalance());
+        assertEquals(new BigDecimal("0.03000000"), response.getRequestPrice());
+
+        assertEquals(AdvancedInsightResponse.Validity.VALID, response.getValidNumber());
+        assertEquals(AdvancedInsightResponse.Reachability.UNKNOWN, response.getReachability());
+        assertEquals(AdvancedInsightResponse.PortedStatus.ASSUMED_NOT_PORTED, response.getPorted());
+        assertEquals(RoamingDetails.RoamingStatus.UNKNOWN, response.getRoaming().getStatus());
+        assertEquals(new Integer(1), response.getLookupOutcome());
+        assertEquals("Partial success - some fields populated", response.getLookupOutcomeMessage());
+
+        assertEquals("Bob", response.getFirstName());
+        assertEquals("Atkey", response.getLastName());
+        assertEquals("Monads, Incorporated", response.getCallerName());
+        assertEquals(CallerType.UNKNOWN, response.getCallerType());
+    }
+
+    @Test
+    public void testFromJsonWithoutRoamingReachableOrPorted() throws Exception {
+        AdvancedInsightResponse response = AdvancedInsightResponse.fromJson("{\n" +
+                "    \"status\": 0,\n" +
+                "    \"status_message\": \"Success\",\n" +
+                "    \"lookup_outcome\": 1,\n" +
+                "    \"lookup_outcome_message\": \"Partial success - some fields populated\",\n" +
+                "    \"request_id\": \"0c082a69-85df-4bbc-aae6-ee998e17e5a4\",\n" +
+                "    \"international_format_number\": \"441632960960\",\n" +
+                "    \"national_format_number\": \"01632 960960\",\n" +
+                "    \"country_code\": \"GB\",\n" +
+                "    \"country_code_iso3\": \"GBR\",\n" +
+                "    \"country_name\": \"United Kingdom\",\n" +
+                "    \"country_prefix\": \"44\",\n" +
+                "    \"request_price\": \"0.03000000\",\n" +
+                "    \"remaining_balance\": \"18.30908949\",\n" +
+                "    \"current_carrier\": {\n" +
+                "        \"network_code\": \"GB-FIXED-RESERVED\",\n" +
+                "        \"name\": \"United Kingdom Landline Reserved\",\n" +
+                "        \"country\": \"GB\",\n" +
+                "        \"network_type\": \"landline\"\n" +
+                "    },\n" +
+                "    \"original_carrier\": {\n" +
+                "        \"network_code\": \"GB-HAPPY-RESERVED\",\n" +
+                "        \"name\": \"United Kingdom Mobile Reserved\",\n" +
+                "        \"country\": \"GB\",\n" +
+                "        \"network_type\": \"mobile\"\n" +
+                "    },\n" +
+                "    \"valid_number\": \"valid\",\n" +
+                "    \"first_name\": \"Bob\",\n" +
+                "    \"last_name\": \"Atkey\",\n" +
+                "    \"caller_name\": \"Monads, Incorporated\",\n" +
+                "    \"caller_type\": \"unknown\"\n" +
+                "}");
+
+        assertEquals(InsightStatus.SUCCESS, response.getStatus());
+        assertEquals("Success", response.getStatusMessage());
+        assertEquals("0c082a69-85df-4bbc-aae6-ee998e17e5a4", response.getRequestId());
+        assertEquals("441632960960", response.getInternationalFormatNumber());
+        assertEquals("01632 960960", response.getNationalFormatNumber());
+        assertEquals("GB", response.getCountryCode());
+        assertEquals("GBR", response.getCountryCodeIso3());
+        assertEquals("United Kingdom", response.getCountryName());
+        assertEquals("44", response.getCountryPrefix());
+        assertEquals("GB-FIXED-RESERVED", response.getCurrentCarrier().getNetworkCode());
+        assertEquals("United Kingdom Landline Reserved", response.getCurrentCarrier().getName());
+        assertEquals("GB", response.getCurrentCarrier().getCountry());
+        assertEquals("GB-FIXED-RESERVED", response.getCurrentCarrier().getNetworkCode());
+        assertEquals("United Kingdom Landline Reserved", response.getCurrentCarrier().getName());
+        assertEquals("GB", response.getCurrentCarrier().getCountry());
+        assertEquals(CarrierDetails.NetworkType.LANDLINE, response.getCurrentCarrier().getNetworkType());
+
+        assertEquals("GB-HAPPY-RESERVED", response.getOriginalCarrier().getNetworkCode());
+        assertEquals("United Kingdom Mobile Reserved", response.getOriginalCarrier().getName());
+        assertEquals("GB", response.getOriginalCarrier().getCountry());
+        assertEquals(CarrierDetails.NetworkType.MOBILE, response.getOriginalCarrier().getNetworkType());
+
+        assertEquals(new BigDecimal("18.30908949"), response.getRemainingBalance());
+        assertEquals(new BigDecimal("0.03000000"), response.getRequestPrice());
+
+        assertEquals(AdvancedInsightResponse.Validity.VALID, response.getValidNumber());
+        assertEquals(new Integer(1), response.getLookupOutcome());
+        assertEquals("Partial success - some fields populated", response.getLookupOutcomeMessage());
+
+        assertEquals("Bob", response.getFirstName());
+        assertEquals("Atkey", response.getLastName());
+        assertEquals("Monads, Incorporated", response.getCallerName());
+        assertEquals(CallerType.UNKNOWN, response.getCallerType());
+    }
+
+    @Test
     public void testDeserializeUnknownEnumsFallbackToUnknown() throws Exception {
         AdvancedInsightResponse response = AdvancedInsightResponse.fromJson("{\n" +
                 "    \"valid_number\": \"failed_validity\",\n" +


### PR DESCRIPTION
Parallel update for the Java SDK to coincide with the dotnet SDKs update for the top-level parsing for the Advanced Number Insights Roaming object, also added a couple of tests to validate that we can handle a null Ported/Reachable satus

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
