### PR TITLE
JSON parsing for inbound SMS webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.0]
+- Added parsing for JSON payloads when reading inbound SMS signtures
+
 ## [6.2.0]
 - Adding ContentId and EntityId to message class for DLT
 - Adding Detail enum and string for certain voice webhooks

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     testImplementation  'junit:junit:4.4'
     testImplementation  "org.mockito:mockito-core:2.25.1"
     testImplementation  'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'org.springframework:spring-test:5.3.5'
+    testImplementation 'org.springframework:spring-web:5.3.4'
     testImplementation  group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.7'
     testImplementation  group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.7'
 }

--- a/src/test/java/com/vonage/client/auth/RequestSigningTest.java
+++ b/src/test/java/com/vonage/client/auth/RequestSigningTest.java
@@ -20,8 +20,10 @@ import com.vonage.client.auth.hashutils.HashUtil;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -141,6 +143,12 @@ public class RequestSigningTest {
     }
 
     @Test
+    public void testVerifySignatureRequestJson(){
+        HttpServletRequest request = ConstructDummyRequestJson();
+        assertTrue(RequestSigning.verifyRequestSignature(request,"abcde",2100000, HashUtil.HashType.HMAC_SHA1));
+    }
+
+    @Test
     public void testVerifyRequestSignatureWithHmacSha256Hash() {
         Map<String, String[]> params = constructDummyParams();
         params.put("sig", new String[]{"8d1b0428276b6a070578225914c3502cc0687a454dfbbbb370c76a14234cb546"});
@@ -203,6 +211,16 @@ public class RequestSigningTest {
         return constructDummyRequest(null);
     }
 
+    private String ConstructDummyJsonBody(){
+        return "{\"a\":\"alphabet\",\"b\":\"bananas\",\"timestamp\":\"2100\",\"sig\":\"b7f749de27b4adcf736cc95c9a7e059a16c85127\"}";
+    }
+
+    private HttpServletRequest ConstructDummyRequestJson(){
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContent(ConstructDummyJsonBody().getBytes());
+        request.setContentType("application/json");
+        return request;
+    }
     private Map<String, String[]> constructDummyParams() {
         Map<String, String[]> params = new HashMap<>();
         params.put("a", new String[]{"alphabet"});


### PR DESCRIPTION
Added the ability to verify inbound SMS message signatures when sent in JSON format from a post request.
## Contribution Checklist
* [x] Unit tests!
* [x ] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
