### PR TITLE
switchign from == to .equals for string comparison for contentType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [6.3.1]
+- adjusting operator used to check json payloads
+
 ## [6.3.0]
 - Added parsing for JSON payloads when reading inbound SMS signtures
 

--- a/src/main/java/com/vonage/client/auth/RequestSigning.java
+++ b/src/main/java/com/vonage/client/auth/RequestSigning.java
@@ -45,6 +45,7 @@ public class RequestSigning {
 
     public static final String PARAM_SIGNATURE = "sig";
     public static final String PARAM_TIMESTAMP = "timestamp";
+    public static final String APPLICATION_JSON = "application/json";
 
     private static Log log = LogFactory.getLog(RequestSigning.class);
 
@@ -208,7 +209,7 @@ public class RequestSigning {
 
         // Construct a sorted list of the name-value pair parameters supplied in the request, excluding the signature parameter
         Map<String, String> sortedParams = new TreeMap<>();
-        if(request.getContentType()=="application/json"){
+        if(request.getContentType() != null && request.getContentType().equals(APPLICATION_JSON)){
             ObjectMapper mapper = new ObjectMapper();
             try{
                 Map<String,String> params = mapper.readValue(request.getInputStream(), new TypeReference<Map<String,String>>(){});


### PR DESCRIPTION
.NET brain made me forget that `==` operator works on referecnes and not literals in java

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
