### PR TITLE
[DEVX-6070] Update project to work with JDK 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 8.0.x, 9.0.x, 11.0.x, 14 ]
+        java: [ 8, 11.0.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           git config --global github.token ${{ secrets.GITHUB_TOKEN }}
           pip install bump2version
       - name: Bump Version
-        run: bump2version --new-version ${{ github.event.release.tag_name }} patch && git tag ${{ github.event.release.tag_name }} -f && git push && git push --tags origin --force
+        run: bump2version --new-version ${{ github.event.release.tag_name }} patch && git tag ${{ github.event.release.tag_name }} -f && git push --tags origin --force
       - name: Setup Java
         uses: actions/setup-java@v1
         with:

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,7 +6,7 @@ documentation, or tests are eligible to be added to this list.
 - Mark Smith ([@judy2k](https://github.com/judy2k))
 - Chris Guzman ([@ChrisGuzman](https://github.com/ChrisGuzman))
 - Tim Lytle ([@tjlitle](https://github.com/tjlitle))
-- [@thepeachbeetle](https://github.com/thepeachbeetle)
+- Paul Cook [@thepeachbeetle](https://github.com/thepeachbeetle)
 - Steve Crow ([@cr0wst](https://github.com/cr0wst))
 - Michael Berry ([@berry120](https://github.com/berry120))
 - Arpit Pandey ([@arpitpandey0209](https://github.com/arpitpandey0209))
@@ -36,3 +36,4 @@ documentation, or tests are eligible to be added to this list.
 - Ilya Golovin ([@ilgo0413])(https://github.com/ilgo0413)
 - Joakim Waltersson ([@jwalter](https://github.com/jwalter))
 - Mofi Rahman ([@moficodes](https://github.com/moficodes))
+- Sina Madani ([@SMadani](https://github.com/SMadani))

--- a/build.gradle
+++ b/build.gradle
@@ -1,55 +1,48 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 plugins {
     id 'java-library'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
     id 'jacoco'
     id 'signing'
-    id 'eclipse'
     id 'maven-publish'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 
 group = "com.vonage"
 archivesBaseName = "client"
-version = "6.4.0"
+version = "6.4.1"
 
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
-
-repositories {
-    mavenCentral()
-}
 
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:unchecked"
 }
 
+repositories {
+    mavenCentral()
+}
+
 dependencies {
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
+
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
-    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
     implementation 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.9'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
     implementation 'com.nexmo:jwt:1.0.1'
 
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
-    testImplementation  'junit:junit:4.13.2'
-    testImplementation  'org.mockito:mockito-inline:4.4.0'
-    testImplementation  'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-inline:4.4.0'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.springframework:spring-test:5.3.17'
     testImplementation 'org.springframework:spring-web:5.3.17'
 }
 
 test {
-    jvmArgs "--illegal-access=warn"
     testLogging {
         events "failed"
         exceptionFormat "full"
@@ -70,10 +63,10 @@ javadoc {
 jar {
     manifest {
         attributes(
-                'Created-By': 'Vonage',
-                'Implementation-Vendor': 'Vonage',
-                'Implementation-Title': 'Vonage Java Server SDK',
-                'Implementation-Version': archiveVersion
+            'Created-By': 'Vonage',
+            'Implementation-Vendor': 'Vonage',
+            'Implementation-Title': 'Vonage Java Server SDK',
+            'Implementation-Version': archiveVersion
         )
     }
 }
@@ -92,18 +85,19 @@ task sourcesJar(type: Jar) {
 jacoco {
     toolVersion = "0.8.8"
 }
-
 jacocoTestReport {
     reports {
-        xml.enabled = true
-        html.enabled = true
+        xml.getRequired().set(true)
+        html.getRequired().set(true)
     }
 }
 check.dependsOn jacocoTestReport
-java{
+
+java {
     withSourcesJar()
     withJavadocJar()
 }
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -132,7 +126,6 @@ publishing {
                     developerConnection = "scm:git@github.com:Vonage/vonage-java-sdk"
                     url = "http://github.com:Vonage/vonage-java-sdk"
                 }
-
                 issueManagement {
                     system = "GitHub"
                     url = "https://github.com/vonage/vonage-java-sdk/issues"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ plugins {
     id 'maven-publish'
 }
 
-
 group = "com.vonage"
 archivesBaseName = "client"
 version = "6.4.0"
@@ -30,28 +29,27 @@ tasks.withType(JavaCompile) {
 }
 
 dependencies {
-    implementation 'commons-codec:commons-codec:1.9'
+    implementation 'commons-codec:commons-codec:1.15'
     implementation 'commons-logging:commons-logging:1.2'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.8'
-    implementation 'commons-io:commons-io:2.5'
-    implementation 'org.apache.commons:commons-lang3:3.5'
-    compileOnly 'javax.servlet:javax.servlet-api:3.1.0'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.9'
-    implementation 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.4'
-    implementation 'javax.xml.bind:jaxb-api:2.3.0'
-    implementation "com.nexmo:jwt:1.0.1"
+    implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    implementation 'commons-io:commons-io:2.11.0'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.2.2'
+    implementation 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.9'
+    implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+    implementation 'com.nexmo:jwt:1.0.1'
 
-    testImplementation  "javax.servlet:javax.servlet-api:3.1.0"
-    testImplementation  'junit:junit:4.4'
-    testImplementation  "org.mockito:mockito-core:2.25.1"
+    testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
+    testImplementation  'junit:junit:4.13.2'
+    testImplementation  'org.mockito:mockito-inline:4.4.0'
     testImplementation  'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.springframework:spring-test:5.3.5'
-    testImplementation 'org.springframework:spring-web:5.3.4'
-    testImplementation  group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.7'
-    testImplementation  group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.7'
+    testImplementation 'org.springframework:spring-test:5.3.17'
+    testImplementation 'org.springframework:spring-web:5.3.17'
 }
 
 test {
+    jvmArgs "--illegal-access=warn"
     testLogging {
         events "failed"
         exceptionFormat "full"
@@ -72,7 +70,7 @@ javadoc {
 jar {
     manifest {
         attributes(
-                "Created-By": 'Vonage',
+                'Created-By': 'Vonage',
                 'Implementation-Vendor': 'Vonage',
                 'Implementation-Title': 'Vonage Java Server SDK',
                 'Implementation-Version': archiveVersion
@@ -92,7 +90,7 @@ task sourcesJar(type: Jar) {
 }
 
 jacoco {
-    toolVersion = "0.8.5"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {
@@ -135,15 +133,15 @@ publishing {
                     url = "http://github.com:Vonage/vonage-java-sdk"
                 }
 
-                issueManagement{
+                issueManagement {
                     system = "GitHub"
                     url = "https://github.com/vonage/vonage-java-sdk/issues"
                 }
             }
         }
     }
-    repositories{
-        maven{
+    repositories {
+        maven {
             def releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
             def snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
             credentials.username(System.getenv("OSS_USERNAME"))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Mon Apr 05 10:31:27 EDT 2021
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -31,7 +31,7 @@ import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -84,8 +84,8 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
                 HttpEntityEnclosingRequest entityRequest = (HttpEntityEnclosingRequest) httpRequest;
                 HttpEntity entity = entityRequest.getEntity();
                 if (entity instanceof UrlEncodedFormEntity) {
-                    entityRequest.setEntity(new UrlEncodedFormEntity(requestBuilder.getParameters(),
-                            Charset.forName("UTF-8")
+                    entityRequest.setEntity(new UrlEncodedFormEntity(
+                        requestBuilder.getParameters(), StandardCharsets.UTF_8
                     ));
                 }
             }
@@ -98,7 +98,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
 
             LOG.debug("Response: " + LoggingUtils.logResponse(response));
 
-            try{
+            try {
                 return parseResponse(response);
             }
             catch (IOException io){

--- a/src/test/java/com/vonage/client/ClientTest.java
+++ b/src/test/java/com/vonage/client/ClientTest.java
@@ -23,19 +23,12 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.mockito.Mockito.*;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
 public abstract class ClientTest<T extends AbstractClient> {
     protected HttpWrapper wrapper;
     protected T client;
@@ -47,7 +40,6 @@ public abstract class ClientTest<T extends AbstractClient> {
 
     protected HttpClient stubHttpClient(int statusCode, String content) throws Exception {
         HttpClient result = mock(HttpClient.class);
-        mockStatic(LoggingUtils.class);
 
         HttpResponse response = mock(HttpResponse.class);
         StatusLine sl = mock(StatusLine.class);

--- a/src/test/java/com/vonage/client/LoggingUtilTest.java
+++ b/src/test/java/com/vonage/client/LoggingUtilTest.java
@@ -1,21 +1,32 @@
 package com.vonage.client;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import com.vonage.client.logging.LoggingUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class LoggingUtilTest {
 
+  @BeforeClass
+  public static void setupBeforeClass() {
+    TestUtils.unmockStaticLoggingUtils();
+  }
+
+  @AfterClass
+  public static void cleanupAfterClass() {
+    TestUtils.mockStaticLoggingUtils();
+  }
+
   @Test
   public void testNoContentResponseMethod() {
-
     HttpResponse stubResponse = new BasicHttpResponse(
         new BasicStatusLine(new ProtocolVersion("1.1", 1, 1), 204, "NO CONTENT")
     );
@@ -23,9 +34,8 @@ public class LoggingUtilTest {
     entity.setContent(null);
     stubResponse.setEntity(null);
 
-
     try {
-      String response = LoggingUtils.logResponse(stubResponse);
+      LoggingUtils.logResponse(stubResponse);
     } catch (Exception ex) {
       fail("LoggingUtils Failed for null Response");
     }

--- a/src/test/java/com/vonage/client/VonageClientTest.java
+++ b/src/test/java/com/vonage/client/VonageClientTest.java
@@ -33,14 +33,9 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.message.BasicNameValuePair;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.InvalidKeyException;
@@ -55,17 +50,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
-@PowerMockIgnore("javax.crypto.*")
 public class VonageClientTest {
-    private TestUtils testUtils = new TestUtils();
+    private final TestUtils testUtils = new TestUtils();
 
     private HttpClient stubHttpClient(int statusCode, String content) throws Exception {
         HttpClient result = mock(HttpClient.class);
-        mockStatic(LoggingUtils.class);
 
         HttpResponse response = mock(HttpResponse.class);
         StatusLine sl = mock(StatusLine.class);
@@ -174,8 +164,8 @@ public class VonageClientTest {
         authCollection.getAuth(TokenAuthMethod.class).apply(requestBuilder);
 
         List<NameValuePair> parameters = requestBuilder.getParameters();
-        assertContainsParam(requestBuilder.getParameters(), "api_key", "api-key");
-        assertContainsParam(requestBuilder.getParameters(), "api_secret", "api-secret");
+        assertContainsParam(parameters, "api_key", "api-key");
+        assertContainsParam(parameters, "api_secret", "api-secret");
     }
 
     @Test
@@ -305,7 +295,7 @@ public class VonageClientTest {
     public void testApplicationIdWithCertPathAsString() throws Exception {
       VonageClient vonageClient = VonageClient.builder()
                 .applicationId("app-id")
-                .privateKeyPath(Paths.get(this.getClass().getResource("test/keys/application_key").toURI()).toString())
+                .privateKeyPath(Paths.get(getClass().getResource("test/keys/application_key").toURI()).toString())
                 .build();
         AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
 

--- a/src/test/java/com/vonage/client/numbers/NumbersClientTest.java
+++ b/src/test/java/com/vonage/client/numbers/NumbersClientTest.java
@@ -26,27 +26,21 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
 public class NumbersClientTest {
-    private TestUtils testUtils = new TestUtils();
+    private final TestUtils testUtils = new TestUtils();
 
     private HttpWrapper stubHttpWrapper(int statusCode, String content) throws Exception {
         HttpClient client = mock(HttpClient.class);
-        mockStatic(LoggingUtils.class);
 
         HttpResponse response = mock(HttpResponse.class);
         StatusLine sl = mock(StatusLine.class);
@@ -54,7 +48,7 @@ public class NumbersClientTest {
 
         when(client.execute(any(HttpUriRequest.class))).thenReturn(response);
         when(LoggingUtils.logResponse(any(HttpResponse.class))).thenReturn("response logged");
-        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes("UTF-8")));
+        when(entity.getContent()).thenReturn(new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8)));
         when(sl.getStatusCode()).thenReturn(statusCode);
         when(response.getStatusLine()).thenReturn(sl);
         when(response.getEntity()).thenReturn(entity);

--- a/src/test/java/com/vonage/client/sms/SmsClientTest.java
+++ b/src/test/java/com/vonage/client/sms/SmsClientTest.java
@@ -30,9 +30,6 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import javax.xml.parsers.ParserConfigurationException;
 import java.io.ByteArrayInputStream;
@@ -43,10 +40,7 @@ import java.util.GregorianCalendar;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
 public class SmsClientTest {
     private HttpWrapper wrapper;
     private SmsClient client;
@@ -58,8 +52,6 @@ public class SmsClientTest {
     }
 
     private HttpClient stubHttpClient(int statusCode, String content) throws Exception {
-        //Log log = mock(Log.class);
-        mockStatic(LoggingUtils.class);
         HttpClient result = mock(HttpClient.class);
 
         HttpResponse response = mock(HttpResponse.class);

--- a/src/test/java/com/vonage/client/sns/SnsClientTest.java
+++ b/src/test/java/com/vonage/client/sns/SnsClientTest.java
@@ -30,11 +30,7 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -42,10 +38,7 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
 public class SnsClientTest {
     private HttpWrapper httpWrapper;
     private SnsClient client;
@@ -58,7 +51,6 @@ public class SnsClientTest {
 
     private HttpClient stubHttpClient(int statusCode, String content) throws Exception {
         HttpClient result = mock(HttpClient.class);
-        mockStatic(LoggingUtils.class);
 
         HttpResponse response = mock(HttpResponse.class);
         StatusLine sl = mock(StatusLine.class);
@@ -74,7 +66,6 @@ public class SnsClientTest {
         return result;
     }
 
-    @Ignore
     @Test
     public void testSubscribe() throws Exception {
         httpWrapper.setHttpClient(stubHttpClient(200, "<nexmo-sns>\n" +
@@ -92,7 +83,6 @@ public class SnsClientTest {
     }
 
     @Test
-    @Ignore
     public void testPublish() throws Exception {
         httpWrapper.setHttpClient(stubHttpClient(200, "<nexmo-sns>\n" +
                 "   <command>publish</command>\n" +

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -28,9 +28,6 @@ import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
@@ -39,16 +36,12 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(LoggingUtils.class)
 public class VoiceClientTest {
-    private TestUtils testUtils = new TestUtils();
+    private final TestUtils testUtils = new TestUtils();
 
     private HttpWrapper stubHttpWrapper(int statusCode, String content) throws Exception {
         HttpClient client = mock(HttpClient.class);
-        mockStatic(LoggingUtils.class);
 
         HttpResponse response = mock(HttpResponse.class);
         StatusLine sl = mock(StatusLine.class);


### PR DESCRIPTION
[Link to ticket](https://jira.vonage.com/browse/DEVX-6070)
Currently, the project's tests fail to pass with JDK >= 17 due to outdated libraries using illegal reflective access; support for which was removed and after JDK 16 it is not possible to allow this. This PR updates the Gradle build with the latest version of dependent libraries (which addresses some security vulnerabilities) and removes dependency on PowerMock; instead using Mockito 4.4 for static mocks (which is the only feature of PowerMock that was being used).
The tests now pass on JDK 18.
