### PR TITLE
Renamed 6.x to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Java CI
 on:
   push:
     branches:
-      - 6.x
+      - main
   pull_request:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Release](https://maven-badges.herokuapp.com/maven-central/com.vonage/client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.vonage/client)
 [![Build Status](https://github.com/vonage/vonage-java-sdk/workflows/build/badge.svg)](https://github.com/Vonage/vonage-java-sdk/actions?query=workflow%3A"Build+Java+CI")
-[![codecov](https://codecov.io/gh/vonage/vonage-java-sdk/branch/6.x/graph/badge.svg)](https://codecov.io/gh/vonage/vonage-java-sdk)
+[![codecov](https://codecov.io/gh/vonage/vonage-java-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/vonage/vonage-java-sdk)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)][license]
 

--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ publishing {
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"
-                        url = "https://raw.github.com/Vonage/vonage-java-sdk/6.x/LICENCE.txt"
+                        url = "https://raw.github.com/Vonage/vonage-java-sdk/main/LICENCE.txt"
                     }
                 }
                 developers {


### PR DESCRIPTION
This PR changes references to the 6.x branch to `main` so that in the future this won't be needed
