### PR TITLE
Remove redundant enum parsing code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,8 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.5.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.springframework:spring-test:5.3.19'
-    testImplementation 'org.springframework:spring-web:5.3.19'
+    testImplementation 'org.springframework:spring-test:5.3.20'
+    testImplementation 'org.springframework:spring-web:5.3.20'
 }
 
 test {

--- a/src/main/java/com/vonage/client/AbstractClient.java
+++ b/src/main/java/com/vonage/client/AbstractClient.java
@@ -18,7 +18,7 @@ package com.vonage.client;
 /**
  * Abstract class for different API clients.
  * <p>
- * Currently this class simply provides boiler-plate for storing an {@link HttpWrapper} object, which is required by
+ * Currently, this class simply provides boilerplate for storing an {@link HttpWrapper} object, which is required by
  * all client implementations.
  */
 public abstract class AbstractClient {

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -113,7 +113,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
     }
 
     /**
-     * Apply an appropriate authentication method (specified by {@link #getAcceptableAuthMethods()} to the provided
+     * Apply an appropriate authentication method (specified by {@link #getAcceptableAuthMethods()}) to the provided
      * {@link RequestBuilder}, and return the result.
      *
      * @param request A RequestBuilder which has not yet had authentication information applied

--- a/src/main/java/com/vonage/client/account/Network.java
+++ b/src/main/java/com/vonage/client/account/Network.java
@@ -21,8 +21,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Network {
@@ -67,14 +65,6 @@ public class Network {
     enum Type {
         MOBILE, LANDLINE, PAGER, LANDLINE_TOLLFREE, UNKNOWN;
 
-        private static final Map<String, Type> typesIndex = new HashMap<>();
-
-        static {
-            for (Type type : Type.values()) {
-                typesIndex.put(type.toString(), type);
-            }
-        }
-
         @Override
         @JsonValue
         public String toString() {
@@ -83,8 +73,12 @@ public class Network {
 
         @JsonCreator
         public static Type fromString(String type) {
-            Type foundType = typesIndex.get(type);
-            return (foundType != null) ? foundType : Type.UNKNOWN;
+            try {
+                return Type.valueOf(type.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
         }
     }
 }

--- a/src/main/java/com/vonage/client/common/HttpMethod.java
+++ b/src/main/java/com/vonage/client/common/HttpMethod.java
@@ -17,10 +17,6 @@ package com.vonage.client.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.stream.Collectors;
-
 /**
  * Enumeration representing various HTTP Methods
  */
@@ -32,13 +28,13 @@ public enum HttpMethod {
     PATCH,
     UNKNOWN;
 
-    private static final Map<String, HttpMethod> HTTP_METHOD_INDEX =
-            Arrays.stream(HttpMethod.values()).collect(
-                    Collectors.toMap(HttpMethod::name, hm -> hm)
-            );
-
     @JsonCreator
     public static HttpMethod fromString(String name) {
-        return HTTP_METHOD_INDEX.getOrDefault(name.toUpperCase(), UNKNOWN);
+        try {
+            return HttpMethod.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/common/Webhook.java
+++ b/src/main/java/com/vonage/client/common/Webhook.java
@@ -17,8 +17,10 @@ package com.vonage.client.common;
 
 import com.fasterxml.jackson.annotation.*;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Data class which can be deserialized into a webhook for the Vonage API.
@@ -56,13 +58,10 @@ public class Webhook {
 
         private final String name;
 
-        private static final Map<String, Type> TYPE_INDEX = new HashMap<>();
-
-        static {
-            for (Type type : Type.values()) {
-                TYPE_INDEX.put(type.name, type);
-            }
-        }
+        private static final Map<String, Type> TYPE_INDEX =
+            Arrays.stream(Type.values()).collect(Collectors.toMap(
+                    Type::getName, Function.identity()
+            ));
 
         Type(String name) {
             this.name = name;
@@ -75,8 +74,7 @@ public class Webhook {
 
         @JsonCreator
         public static Type fromName(String name) {
-            Type foundType = TYPE_INDEX.get(name.toLowerCase());
-            return (foundType != null) ? foundType : UNKNOWN;
+            return TYPE_INDEX.getOrDefault(name.toLowerCase(), UNKNOWN);
         }
     }
 }

--- a/src/main/java/com/vonage/client/incoming/CallDirection.java
+++ b/src/main/java/com/vonage/client/incoming/CallDirection.java
@@ -17,23 +17,16 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum CallDirection {
     OUTBOUND, INBOUND, UNKNOWN;
 
-    private static final Map<String, CallDirection> CALL_DIRECTION_INDEX = new HashMap<>();
-
-    static {
-        for (CallDirection callDirection : CallDirection.values()) {
-            CALL_DIRECTION_INDEX.put(callDirection.name(), callDirection);
-        }
-    }
-
     @JsonCreator
     public static CallDirection fromString(String name) {
-        CallDirection foundCallDirection = CALL_DIRECTION_INDEX.get(name.toUpperCase());
-        return (foundCallDirection != null) ? foundCallDirection : UNKNOWN;
+        try {
+            return CallDirection.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
@@ -17,9 +17,6 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum CallStatusDetail {
     /**
      * no detail field present
@@ -62,22 +59,17 @@ public enum CallStatusDetail {
      * **/
     UNAVAILABLE;
 
-    private static final Map<String, CallStatusDetail> CALL_DETAIL_INDEX = new HashMap<>();
-
-    static {
-        for (CallStatusDetail detail : CallStatusDetail.values()) {
-            CALL_DETAIL_INDEX.put(detail.name(), detail);
-        }
-    }
 
     @JsonCreator
     public static CallStatusDetail fromString(String detail) {
-        if(detail == null)
+        if (detail == null) {
             return NO_DETAIL;
-        CallStatusDetail foundCallStatusDetail = CALL_DETAIL_INDEX.get(detail.toUpperCase());
-        if(foundCallStatusDetail == null){
-            foundCallStatusDetail = UNMAPPED_DETAIL;
         }
-        return foundCallStatusDetail;
+        try {
+            return CallStatusDetail.valueOf(detail.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNMAPPED_DETAIL;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/incoming/MessageType.java
+++ b/src/main/java/com/vonage/client/incoming/MessageType.java
@@ -17,23 +17,17 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum MessageType {
     TEXT, UNICODE, BINARY, UNKNOWN;
 
-    private static final Map<String, MessageType> MESSAGE_TYPE_INDEX = new HashMap<>();
-
-    static {
-        for (MessageType messageType : MessageType.values()) {
-            MESSAGE_TYPE_INDEX.put(messageType.name(), messageType);
-        }
-    }
 
     @JsonCreator
     public static MessageType fromString(String name) {
-        MessageType foundMessageType = MESSAGE_TYPE_INDEX.get(name.toUpperCase());
-        return (foundMessageType != null) ? foundMessageType : UNKNOWN;
+        try {
+            return MessageType.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
@@ -63,7 +63,7 @@ public class AdvancedInsightRequest extends BaseInsightRequest {
      * Construct a AdvancedInsightRequest with a number and country.
      *
      * @param number  A single phone number that you need insight about in national or international format.
-     * @param country If a number does not have a country code or it is uncertain, set the two-character country code.
+     * @param country If a number does not have a country code, or it is uncertain, set the two-character country code.
      *
      * @return A new {@link AdvancedInsightRequest} object.
      */
@@ -97,7 +97,7 @@ public class AdvancedInsightRequest extends BaseInsightRequest {
         }
 
         /**
-         * @param country If a number does not have a country code or it is uncertain, set the two-character country
+         * @param country If a number does not have a country code, or it is uncertain, set the two-character country
          *                code.
          *
          * @return The {@link Builder} to keep building.

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
@@ -22,8 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.VonageUnexpectedException;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AdvancedInsightResponse extends StandardInsightResponse {
@@ -99,55 +97,42 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     public enum PortedStatus {
         UNKNOWN, PORTED, NOT_PORTED, ASSUMED_NOT_PORTED, ASSUMED_PORTED;
 
-        private static final Map<String, PortedStatus> PORTED_STATUS_INDEX = new HashMap<>();
-
-        static {
-            for (PortedStatus portedStatus : PortedStatus.values()) {
-                PORTED_STATUS_INDEX.put(portedStatus.name(), portedStatus);
-            }
-        }
-
         @JsonCreator
         public static PortedStatus fromString(String name) {
-            PortedStatus foundPortedStatus = PORTED_STATUS_INDEX.get(name.toUpperCase());
-            return (foundPortedStatus != null) ? foundPortedStatus : UNKNOWN;
+            try {
+                return PortedStatus.valueOf(name.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
         }
-
     }
 
     public enum Validity {
         UNKNOWN, VALID, NOT_VALID;
 
-        private static final Map<String, Validity> VALIDITY_INDEX = new HashMap<>();
-
-        static {
-            for (Validity validity : Validity.values()) {
-                VALIDITY_INDEX.put(validity.name(), validity);
-            }
-        }
-
         @JsonCreator
         public static Validity fromString(String name) {
-            Validity foundValidity = VALIDITY_INDEX.get(name.toUpperCase());
-            return (foundValidity != null) ? foundValidity : Validity.UNKNOWN;
+            try {
+                return Validity.valueOf(name.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
         }
     }
 
     public enum Reachability {
         UNKNOWN, REACHABLE, UNDELIVERABLE, ABSENT, BAD_NUMBER, BLACKLISTED;
 
-        private static final Map<String, Reachability> REACHABILITY_INDEX = new HashMap<>();
-
-        static {
-            for (Reachability reachability : Reachability.values()) {
-                REACHABILITY_INDEX.put(reachability.name(), reachability);
-            }
-        }
-
         @JsonCreator
         public static Reachability fromString(String name) {
-            Reachability foundReachability = REACHABILITY_INDEX.get(name.toUpperCase());
-            return (foundReachability != null) ? foundReachability : UNKNOWN;
+            try {
+                return Reachability.valueOf(name.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
         }
     }
 }

--- a/src/main/java/com/vonage/client/insight/BasicInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/BasicInsightRequest.java
@@ -36,7 +36,7 @@ public class BasicInsightRequest extends BaseInsightRequest {
      * Construct a BasicInsightRequest with a number and country.
      *
      * @param number  A single phone number that you need insight about in national or international format.
-     * @param country If a number does not have a country code or it is uncertain, set the two-character country code.
+     * @param country If a number does not have a country code, or it is uncertain, set the two-character country code.
      *
      * @return A new {@link BasicInsightRequest} object.
      */
@@ -70,7 +70,7 @@ public class BasicInsightRequest extends BaseInsightRequest {
         }
 
         /**
-         * @param country If a number does not have a country code or it is uncertain, set the two-character country code.
+         * @param country If a number does not have a country code, or it is uncertain, set the two-character country code.
          *
          * @return The {@link Builder} to keep building.
          */

--- a/src/main/java/com/vonage/client/insight/InsightStatus.java
+++ b/src/main/java/com/vonage/client/insight/InsightStatus.java
@@ -17,8 +17,10 @@ package com.vonage.client.insight;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public enum InsightStatus {
     SUCCESS(0),
@@ -31,13 +33,10 @@ public enum InsightStatus {
 
     private final int insightStatus;
 
-    private static final Map<Integer, InsightStatus> INSIGHT_STATUS_INDEX = new HashMap<>();
-
-    static {
-        for (InsightStatus insightStatus : InsightStatus.values()) {
-            INSIGHT_STATUS_INDEX.put(insightStatus.insightStatus, insightStatus);
-        }
-    }
+    private static final Map<Integer, InsightStatus> INSIGHT_STATUS_INDEX =
+        Arrays.stream(InsightStatus.values()).collect(Collectors.toMap(
+            InsightStatus::getInsightStatus, Function.identity()
+        ));
 
     /**
      * Look up the {@link InsightStatus} based on the int value.
@@ -48,8 +47,7 @@ public enum InsightStatus {
      */
     @JsonCreator
     public static InsightStatus fromInt(int insightStatus) {
-        InsightStatus foundInsightStatus = INSIGHT_STATUS_INDEX.get(insightStatus);
-        return (foundInsightStatus != null) ? foundInsightStatus : UNKNOWN;
+        return INSIGHT_STATUS_INDEX.getOrDefault(insightStatus, UNKNOWN);
     }
 
     InsightStatus(int insightStatus) {

--- a/src/main/java/com/vonage/client/insight/RoamingDetails.java
+++ b/src/main/java/com/vonage/client/insight/RoamingDetails.java
@@ -19,26 +19,19 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @JsonDeserialize(using = RoamingDeseriazlizer.class)
 public class RoamingDetails {
     public enum RoamingStatus {
         UNKNOWN, ROAMING, NOT_ROAMING;
 
-        private static final Map<String, RoamingStatus> ROAMING_STATUS_INDEX = new HashMap<>();
-
-        static {
-            for (RoamingStatus roamingStatus : RoamingStatus.values()) {
-                ROAMING_STATUS_INDEX.put(roamingStatus.name(), roamingStatus);
-            }
-        }
-
         @JsonCreator
         public static RoamingStatus fromString(String name) {
-            RoamingStatus foundRoamingStatus = ROAMING_STATUS_INDEX.get(name.toUpperCase());
-            return (foundRoamingStatus != null) ? foundRoamingStatus : UNKNOWN;
+            try {
+                return RoamingStatus.valueOf(name.toUpperCase());
+            }
+            catch (IllegalArgumentException ex) {
+                return UNKNOWN;
+            }
         }
     }
 

--- a/src/main/java/com/vonage/client/numbers/CancelNumberRequest.java
+++ b/src/main/java/com/vonage/client/numbers/CancelNumberRequest.java
@@ -36,6 +36,5 @@ public class CancelNumberRequest {
 
     public void addParams(RequestBuilder request) {
         request.addParameter("country", country).addParameter("msisdn", msisdn);
-
     }
 }

--- a/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
@@ -18,7 +18,6 @@ package com.vonage.client.numbers;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
-import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -52,9 +51,5 @@ class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersR
     @Override
     public ListNumbersResponse parseResponse(HttpResponse response) throws IOException {
         return ListNumbersResponse.fromJson(new BasicResponseHandler().handleResponse(response));
-    }
-
-    ListNumbersResponse listNumbers(ListNumbersFilter request) throws VonageClientException {
-        return execute(request);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/NumbersClient.java
+++ b/src/main/java/com/vonage/client/numbers/NumbersClient.java
@@ -47,7 +47,7 @@ public class NumbersClient {
      * @throws VonageClientException        if an error is returned by the server.
      */
     public ListNumbersResponse listNumbers() throws VonageResponseParseException, VonageClientException {
-        return listNumbers.listNumbers(new ListNumbersFilter());
+        return listNumbers(new ListNumbersFilter());
     }
 
     /**
@@ -61,7 +61,7 @@ public class NumbersClient {
      * @throws VonageClientException        if an error is returned by the server.
      */
     public ListNumbersResponse listNumbers(ListNumbersFilter filter) throws VonageResponseParseException, VonageClientException {
-        return listNumbers.listNumbers(filter);
+        return listNumbers.execute(filter);
     }
 
 
@@ -86,7 +86,7 @@ public class NumbersClient {
      * @throws VonageClientException        if an error is returned by the server.
      */
     public SearchNumbersResponse searchNumbers(SearchNumbersFilter filter) throws VonageResponseParseException, VonageClientException {
-        return searchNumbers.searchNumbers(filter);
+        return searchNumbers.execute(filter);
     }
 
     /**

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
@@ -52,8 +52,4 @@ class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNu
     public SearchNumbersResponse parseResponse(HttpResponse response) throws IOException {
         return SearchNumbersResponse.fromJson(new BasicResponseHandler().handleResponse(response));
     }
-
-    SearchNumbersResponse searchNumbers(SearchNumbersFilter request) {
-        return execute(request);
-    }
 }

--- a/src/main/java/com/vonage/client/numbers/Type.java
+++ b/src/main/java/com/vonage/client/numbers/Type.java
@@ -18,8 +18,10 @@ package com.vonage.client.numbers;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Enumeration representing the type of number.
@@ -30,13 +32,10 @@ public enum Type {
     LANDLINE_TOLL_FREE("landline-toll-free"),
     UNKNOWN("unknown");
 
-    private static final Map<String, Type> TYPE_INDEX = new HashMap<>();
-
-    static {
-        for (Type type : Type.values()) {
-            TYPE_INDEX.put(type.type, type);
-        }
-    }
+    private static final Map<String, Type> TYPE_INDEX =
+        Arrays.stream(Type.values()).collect(Collectors.toMap(
+                Type::getType, Function.identity()
+        ));
 
     private final String type;
 
@@ -51,7 +50,6 @@ public enum Type {
 
     @JsonCreator
     public static Type fromString(String type) {
-        Type foundType = TYPE_INDEX.get(type);
-        return (foundType != null) ? foundType : UNKNOWN;
+        return TYPE_INDEX.getOrDefault(type, UNKNOWN);
     }
 }

--- a/src/main/java/com/vonage/client/sms/MessageStatus.java
+++ b/src/main/java/com/vonage/client/sms/MessageStatus.java
@@ -17,8 +17,10 @@ package com.vonage.client.sms;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public enum MessageStatus {
     OK(0),
@@ -46,13 +48,10 @@ public enum MessageStatus {
 
     private final int messageStatus;
 
-    private static final Map<Integer, MessageStatus> MESSAGE_STATUS_INDEX = new HashMap<>();
-
-    static {
-        for (MessageStatus messageStatus : MessageStatus.values()) {
-            MESSAGE_STATUS_INDEX.put(messageStatus.messageStatus, messageStatus);
-        }
-    }
+    private static final Map<Integer, MessageStatus> MESSAGE_STATUS_INDEX =
+        Arrays.stream(MessageStatus.values()).collect(Collectors.toMap(
+            MessageStatus::getMessageStatus, Function.identity()
+        ));
 
     /**
      * Look up the {@link MessageStatus} based on the int value.
@@ -63,8 +62,7 @@ public enum MessageStatus {
      */
     @JsonCreator
     public static MessageStatus fromInt(int messageStatus) {
-        MessageStatus foundStatus = MESSAGE_STATUS_INDEX.get(messageStatus);
-        return (foundStatus != null) ? foundStatus : UNKNOWN;
+        return MESSAGE_STATUS_INDEX.getOrDefault(messageStatus, UNKNOWN);
     }
 
     MessageStatus(int messageStatus) {

--- a/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
+++ b/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
@@ -24,8 +24,6 @@ package com.vonage.client.verify;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -34,7 +32,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class Psd2Endpoint extends AbstractMethod<Psd2Request, VerifyResponse> {
-    private static final Log LOG = LogFactory.getLog(Psd2Endpoint.class);
 
     private static final String PATH = "/verify/psd2/json";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};

--- a/src/main/java/com/vonage/client/verify/VerifyDetails.java
+++ b/src/main/java/com/vonage/client/verify/VerifyDetails.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VerifyDetails {
@@ -103,13 +105,10 @@ public class VerifyDetails {
 
         private final String status;
 
-        private static final Map<String, Status> stringStatusValues = new HashMap<>();
-
-        static {
-            for (Status status : Status.values()) {
-                stringStatusValues.put(status.status, status);
-            }
-        }
+        private static final Map<String, Status> stringStatusValues =
+            Arrays.stream(Status.values()).collect(Collectors.toMap(
+                    Status::getStatus, Function.identity()
+            ));
 
         /**
          * Look up the {@link Status} based on the string value.

--- a/src/main/java/com/vonage/client/verify/VerifyStatus.java
+++ b/src/main/java/com/vonage/client/verify/VerifyStatus.java
@@ -17,8 +17,10 @@ package com.vonage.client.verify;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-import java.util.HashMap;
+import java.util.Arrays;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @JsonDeserialize(using = VerifyStatusDeserializer.class)
 public enum VerifyStatus {
@@ -37,17 +39,16 @@ public enum VerifyStatus {
     INVALID_CODE(16),
     WRONG_CODE_THROTTLED(17),
     TOO_MANY_DESTINATIONS(18),
-    NO_RESPONSE(101), COMMS_FAILURE(-1), UNKNOWN(Integer.MAX_VALUE);
+    NO_RESPONSE(101),
+    COMMS_FAILURE(-1),
+    UNKNOWN(Integer.MAX_VALUE);
 
     private final int verifyStatus;
 
-    private static final Map<Integer, VerifyStatus> VERIFY_STATUS_INDEX = new HashMap<>();
-
-    static {
-        for (VerifyStatus verifyStatus : VerifyStatus.values()) {
-            VERIFY_STATUS_INDEX.put(verifyStatus.verifyStatus, verifyStatus);
-        }
-    }
+    private static final Map<Integer, VerifyStatus> VERIFY_STATUS_INDEX =
+        Arrays.stream(VerifyStatus.values()).collect(Collectors.toMap(
+                VerifyStatus::getVerifyStatus, Function.identity()
+        ));
 
     /**
      * Look up the {@link VerifyStatus} based on the int value.
@@ -57,8 +58,7 @@ public enum VerifyStatus {
      * @return VerifyStatus based on the int value given.
      */
     public static VerifyStatus fromInt(int verifyStatus) {
-        VerifyStatus foundVerifyStatus = VERIFY_STATUS_INDEX.get(verifyStatus);
-        return (foundVerifyStatus != null) ? foundVerifyStatus : UNKNOWN;
+        return VERIFY_STATUS_INDEX.getOrDefault(verifyStatus, UNKNOWN);
     }
 
     VerifyStatus(int verifyStatus) {

--- a/src/main/java/com/vonage/client/voice/CallDirection.java
+++ b/src/main/java/com/vonage/client/voice/CallDirection.java
@@ -18,21 +18,10 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum CallDirection {
     OUTBOUND,
     INBOUND,
     UNKNOWN;
-
-    private static final Map<String, CallDirection> CALL_DIRECTION_INDEX = new HashMap<>();
-
-    static {
-        for (CallDirection callDirection : CallDirection.values()) {
-            CALL_DIRECTION_INDEX.put(callDirection.name(), callDirection);
-        }
-    }
 
     @JsonValue
     @Override
@@ -42,7 +31,11 @@ public enum CallDirection {
 
     @JsonCreator
     public static CallDirection fromString(String name) {
-        CallDirection foundCallDirection = CALL_DIRECTION_INDEX.get(name.toUpperCase());
-        return (foundCallDirection != null) ? foundCallDirection : UNKNOWN;
+        try {
+            return CallDirection.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/voice/CallStatus.java
+++ b/src/main/java/com/vonage/client/voice/CallStatus.java
@@ -18,9 +18,6 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum CallStatus {
     STARTED,
     RINGING,
@@ -34,14 +31,6 @@ public enum CallStatus {
     CANCELLED,
     UNKNOWN;
 
-    private static final Map<String, CallStatus> CALL_STATUS_INDEX = new HashMap<>();
-
-    static {
-        for (CallStatus callStatus : CallStatus.values()) {
-            CALL_STATUS_INDEX.put(callStatus.name(), callStatus);
-        }
-    }
-
     @JsonValue
     @Override
     public String toString() {
@@ -50,7 +39,11 @@ public enum CallStatus {
 
     @JsonCreator
     public static CallStatus fromString(String name) {
-        CallStatus foundCallStatus = CALL_STATUS_INDEX.get(name.toUpperCase());
-        return (foundCallStatus != null) ? foundCallStatus : UNKNOWN;
+        try {
+            return CallStatus.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/voice/CreateCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/CreateCallEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class CreateCallEndpoint extends AbstractMethod<Call, CallEvent> {
-    private static final Log LOG = LogFactory.getLog(CreateCallEndpoint.class);
 
     private static final String PATH = "/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/DownloadRecordingEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/DownloadRecordingEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 
@@ -27,7 +25,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class DownloadRecordingEndpoint extends AbstractMethod<String, Recording> {
-    private static final Log LOG = LogFactory.getLog(DownloadRecordingEndpoint.class);
 
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
 

--- a/src/main/java/com/vonage/client/voice/DtmfEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/DtmfEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class DtmfEndpoint extends AbstractMethod<DtmfRequest, DtmfResponse> {
-    private static final Log LOG = LogFactory.getLog(DtmfEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/ListCallsEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ListCallsEndpoint.java
@@ -20,8 +20,6 @@ import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.VonageUnexpectedException;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
@@ -34,7 +32,6 @@ import java.net.URISyntaxException;
 import java.util.List;
 
 class ListCallsEndpoint extends AbstractMethod<CallsFilter, CallInfoPage> {
-    private static final Log LOG = LogFactory.getLog(CreateCallEndpoint.class);
 
     private static final String PATH = "/calls";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/MachineDetection.java
+++ b/src/main/java/com/vonage/client/voice/MachineDetection.java
@@ -18,19 +18,8 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum MachineDetection {
     CONTINUE, HANGUP, UNKNOWN;
-
-    private static final Map<String, MachineDetection> MACHINE_DETECTION_INDEX = new HashMap<>();
-
-    static {
-        for (MachineDetection machineDetection : MachineDetection.values()) {
-            MACHINE_DETECTION_INDEX.put(machineDetection.name(), machineDetection);
-        }
-    }
 
     @JsonValue
     @Override
@@ -40,7 +29,11 @@ public enum MachineDetection {
 
     @JsonCreator
     public static MachineDetection fromString(String name) {
-        MachineDetection foundMachineDetection = MACHINE_DETECTION_INDEX.get(name.toUpperCase());
-        return (foundMachineDetection != null) ? foundMachineDetection : UNKNOWN;
+        try {
+            return MachineDetection.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/voice/ModifyCallAction.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallAction.java
@@ -18,19 +18,8 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum ModifyCallAction {
     HANGUP, MUTE, UNMUTE, EARMUFF, UNEARMUFF, TRANSFER, UNKNOWN;
-
-    private static final Map<String, ModifyCallAction> MODIFY_CALL_ACTION_INDEX = new HashMap<>();
-
-    static {
-        for (ModifyCallAction modifyCallAction : ModifyCallAction.values()) {
-            MODIFY_CALL_ACTION_INDEX.put(modifyCallAction.name(), modifyCallAction);
-        }
-    }
 
     @JsonValue
     @Override
@@ -40,7 +29,11 @@ public enum ModifyCallAction {
 
     @JsonCreator
     public static ModifyCallAction fromString(String name) {
-        ModifyCallAction foundModifyCallAction = MODIFY_CALL_ACTION_INDEX.get(name.toUpperCase());
-        return (foundModifyCallAction != null) ? foundModifyCallAction : UNKNOWN;
+        try {
+            return ModifyCallAction.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/voice/ModifyCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ModifyCallEndpoint extends AbstractMethod<CallModifier, ModifyCallResponse> {
-    private static final Log LOG = LogFactory.getLog(ModifyCallEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/ReadCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ReadCallEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -27,7 +25,6 @@ import org.apache.http.impl.client.BasicResponseHandler;
 import java.io.IOException;
 
 class ReadCallEndpoint extends AbstractMethod<String, CallInfo> {
-    private static final Log LOG = LogFactory.getLog(ReadCallEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/StartStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StartStreamEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class StartStreamEndpoint extends AbstractMethod<StreamRequest, StreamResponse> {
-    private static final Log LOG = LogFactory.getLog(StartStreamEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/StartTalkEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StartTalkEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class StartTalkEndpoint extends AbstractMethod<TalkRequest, TalkResponse> {
-    private static final Log LOG = LogFactory.getLog(StartTalkEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/StopStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StopStreamEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -28,7 +26,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class StopStreamEndpoint extends AbstractMethod<String, StreamResponse> {
-    private static final Log LOG = LogFactory.getLog(StopStreamEndpoint.class);
 
     private static final String PATH = "/calls/";
     public static final String STREAM_PATH = "/stream";

--- a/src/main/java/com/vonage/client/voice/StopTalkEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StopTalkEndpoint.java
@@ -18,8 +18,6 @@ package com.vonage.client.voice;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.BasicResponseHandler;
@@ -28,7 +26,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class StopTalkEndpoint extends AbstractMethod<String, TalkResponse> {
-    private static final Log LOG = LogFactory.getLog(StopTalkEndpoint.class);
 
     private static final String PATH = "/calls/";
     private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};

--- a/src/main/java/com/vonage/client/voice/VoiceName.java
+++ b/src/main/java/com/vonage/client/voice/VoiceName.java
@@ -18,9 +18,6 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Voice used to deliver text to a {@link Call} in a {@link TalkRequest}.
  */
@@ -124,14 +121,6 @@ public enum VoiceName {
     ZUZANA("Zuzana"),
     UNKNOWN("Unknown");
 
-    private static final Map<String, VoiceName> voiceNameIndex = new HashMap<>();
-
-    static {
-        for (VoiceName voiceName : VoiceName.values()) {
-            voiceNameIndex.put(voiceName.name(), voiceName);
-        }
-    }
-
     private final String displayName;
 
     VoiceName(String displayName) {
@@ -145,8 +134,12 @@ public enum VoiceName {
 
     @JsonCreator
     public static VoiceName fromString(String name) {
-        VoiceName foundVoiceName = voiceNameIndex.get(name.toUpperCase());
-        return (foundVoiceName != null) ? foundVoiceName : UNKNOWN;
+        try {
+            return VoiceName.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 
     @JsonValue

--- a/src/main/java/com/vonage/client/voice/ncco/RecordingFormat.java
+++ b/src/main/java/com/vonage/client/voice/ncco/RecordingFormat.java
@@ -18,19 +18,8 @@ package com.vonage.client.voice.ncco;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum RecordingFormat {
     MP3, WAV, OGG, UNKNOWN;
-
-    private static final Map<String, RecordingFormat> RECORDING_FORMAT_INDEX = new HashMap<>();
-
-    static {
-        for (RecordingFormat recordingFormat : RecordingFormat.values()) {
-            RECORDING_FORMAT_INDEX.put(recordingFormat.name(), recordingFormat);
-        }
-    }
 
     @JsonValue
     @Override
@@ -40,7 +29,11 @@ public enum RecordingFormat {
 
     @JsonCreator
     public static RecordingFormat fromString(String name) {
-        RecordingFormat foundRecordingFormat = RECORDING_FORMAT_INDEX.get(name.toUpperCase());
-        return (foundRecordingFormat != null) ? foundRecordingFormat : UNKNOWN;
+        try {
+            return RecordingFormat.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
     }
 }

--- a/src/main/java/com/vonage/client/voice/servlet/AbstractAnswerServlet.java
+++ b/src/main/java/com/vonage/client/voice/servlet/AbstractAnswerServlet.java
@@ -51,7 +51,7 @@ public abstract class AbstractAnswerServlet extends HttpServlet {
     /**
      * Handle a request for NCCO instructions from the Vonage Voice API.
      * <p>
-     * Implementations should return an NccoResponse object (most easily constructed using {@link NccoResponseBuilder}.
+     * Implementations should return an NccoResponse object (most easily constructed using {@link NccoResponseBuilder}).
      *
      * @param request the HttpServletRequest parsed from the request made by the Vonage Voice API
      * @return An NccoResponse containing Ncco instructions for the Vonage Voice API

--- a/src/test/java/com/vonage/client/incoming/InputEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/InputEventTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 public class InputEventTest {
 
     private static final Log LOG = LogFactory.getLog(InputEventTest.class);
+
     @Test
     public void testDeserializeInputEvent() {
         String inputJsonStr = getInputEventJsonString().toString();

--- a/src/test/java/com/vonage/client/voice/CreateCallEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/CreateCallEndpointTest.java
@@ -62,6 +62,7 @@ import static org.junit.Assert.assertEquals;
 
 public class CreateCallEndpointTest {
     private static final Log LOG = LogFactory.getLog(CreateCallEndpointTest.class);
+
     private CreateCallEndpoint method;
 
     @Before

--- a/src/test/java/com/vonage/client/voice/ListCallsEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ListCallsEndpointTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ListCallsEndpointTest {
     private static final Log LOG = LogFactory.getLog(ListCallsEndpointTest.class);
+
     private ListCallsEndpoint method;
 
     @Before

--- a/src/test/java/com/vonage/client/voice/ModifyCallEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ModifyCallEndpointTest.java
@@ -19,8 +19,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.RequestBuilder;
@@ -39,7 +37,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 public class ModifyCallEndpointTest {
-    private static final Log LOG = LogFactory.getLog(ModifyCallEndpointTest.class);
 
     private ModifyCallEndpoint method;
 

--- a/src/test/java/com/vonage/client/voice/StopTalkEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/StopTalkEndpointTest.java
@@ -17,8 +17,6 @@ package com.vonage.client.voice;
 
 import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.RequestBuilder;
@@ -35,10 +33,10 @@ import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class StopTalkEndpointTest {
-    private static final Log LOG = LogFactory.getLog(StopTalkEndpointTest.class);
 
     private StopTalkEndpoint method;
 


### PR DESCRIPTION
Most enums in the SDK create a map from the name to the enum itself to make it possible to get an instance of the enum from a String. This functionality is already provided by the `valueOf` built-in method on all enum types, so the Map is unnecessary. The PR also removes unused loggers in the endpoint classes.
