### PR TITLE
Fix unparameterised Class[] usage and re-use BasicResponseHandler

### DIFF
--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -27,6 +27,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
@@ -51,9 +52,10 @@ import java.util.Set;
  */
 public abstract class AbstractMethod<RequestT, ResultT> implements Method<RequestT, ResultT> {
     private static final Log LOG = LogFactory.getLog(AbstractMethod.class);
+    protected static final BasicResponseHandler basicResponseHandler = new BasicResponseHandler();
 
     protected final HttpWrapper httpWrapper;
-    private Set<Class> acceptable;
+    private Set<Class<?>> acceptable;
 
     public AbstractMethod(HttpWrapper httpWrapper) {
         this.httpWrapper = httpWrapper;
@@ -137,7 +139,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      *
      * @throws VonageClientException If no AuthMethod is available from the provided array of acceptableAuthMethods.
      */
-    protected AuthMethod getAuthMethod(Class[] acceptableAuthMethods) throws VonageClientException {
+    protected AuthMethod getAuthMethod(Class<?>[] acceptableAuthMethods) throws VonageClientException {
         if (acceptable == null) {
             acceptable = new HashSet<>();
             Collections.addAll(acceptable, acceptableAuthMethods);
@@ -150,7 +152,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
         httpWrapper.setHttpClient(client);
     }
 
-    protected abstract Class[] getAcceptableAuthMethods();
+    protected abstract Class<?>[] getAcceptableAuthMethods();
 
     /**
      * Construct and return a RequestBuilder instance from the provided request.

--- a/src/main/java/com/vonage/client/HttpConfig.java
+++ b/src/main/java/com/vonage/client/HttpConfig.java
@@ -20,9 +20,9 @@ public class HttpConfig {
     private static final String DEFAULT_REST_BASE_URI = "https://rest.nexmo.com";
     private static final String DEFAULT_SNS_BASE_URI = "https://sns.nexmo.com";
 
-    private String apiBaseUri;
-    private String restBaseUri;
-    private String snsBaseUri;
+    private final String apiBaseUri;
+    private final String restBaseUri;
+    private final String snsBaseUri;
 
     private HttpConfig(Builder builder) {
         apiBaseUri = builder.apiBaseUri;

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -35,7 +35,7 @@ public class HttpWrapper {
     private static final String JAVA_VERSION = System.getProperty("java.version");
 
     private AuthCollection authCollection;
-    private HttpClient httpClient = null;
+    private HttpClient httpClient;
     private HttpConfig httpConfig;
 
     public HttpWrapper(AuthCollection authCollection) {
@@ -83,10 +83,11 @@ public class HttpWrapper {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         connectionManager.setDefaultMaxPerRoute(200);
         connectionManager.setMaxTotal(200);
-        connectionManager.setDefaultConnectionConfig(ConnectionConfig
-                .custom()
+        connectionManager.setDefaultConnectionConfig(
+            ConnectionConfig.custom()
                 .setCharset(StandardCharsets.UTF_8)
-                .build());
+                .build()
+        );
         connectionManager.setDefaultSocketConfig(SocketConfig.custom().setTcpNoDelay(true).build());
 
         // Need to work out a good value for the following:

--- a/src/main/java/com/vonage/client/account/BalanceEndpoint.java
+++ b/src/main/java/com/vonage/client/account/BalanceEndpoint.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/get-balance";
 
@@ -36,7 +35,7 @@ class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -53,6 +52,6 @@ class BalanceEndpoint extends AbstractMethod<Void, BalanceResponse> {
 
     @Override
     public BalanceResponse parseResponse(HttpResponse response) throws IOException {
-        return BalanceResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return BalanceResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/account/CreateSecretEndpoint.java
+++ b/src/main/java/com/vonage/client/account/CreateSecretEndpoint.java
@@ -25,14 +25,13 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class CreateSecretEndpoint extends AbstractMethod<CreateSecretRequest, SecretResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/accounts/%s/secrets";
 
@@ -41,7 +40,7 @@ class CreateSecretEndpoint extends AbstractMethod<CreateSecretRequest, SecretRes
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -68,7 +67,7 @@ class CreateSecretEndpoint extends AbstractMethod<CreateSecretRequest, SecretRes
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return SecretResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SecretResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 
     @Override

--- a/src/main/java/com/vonage/client/account/FullPricingEndpoint.java
+++ b/src/main/java/com/vonage/client/account/FullPricingEndpoint.java
@@ -20,12 +20,11 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 
 class FullPricingEndpoint extends AbstractMethod<FullPricingRequest, PricingResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/get-full-pricing/outbound/%s";
 
@@ -34,7 +33,7 @@ class FullPricingEndpoint extends AbstractMethod<FullPricingRequest, PricingResp
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -47,6 +46,6 @@ class FullPricingEndpoint extends AbstractMethod<FullPricingRequest, PricingResp
 
     @Override
     public PricingResponse parseResponse(HttpResponse response) throws IOException {
-        return PricingResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return PricingResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/account/GetSecretEndpoint.java
+++ b/src/main/java/com/vonage/client/account/GetSecretEndpoint.java
@@ -23,14 +23,13 @@ import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class GetSecretEndpoint extends AbstractMethod<SecretRequest, SecretResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/accounts/%s/secrets/%s";
 
@@ -39,7 +38,7 @@ class GetSecretEndpoint extends AbstractMethod<SecretRequest, SecretResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -66,7 +65,7 @@ class GetSecretEndpoint extends AbstractMethod<SecretRequest, SecretResponse> {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
-        return SecretResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SecretResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 
     @Override

--- a/src/main/java/com/vonage/client/account/ListSecretsEndpoint.java
+++ b/src/main/java/com/vonage/client/account/ListSecretsEndpoint.java
@@ -23,14 +23,13 @@ import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ListSecretsEndpoint extends AbstractMethod<String, ListSecretsResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/accounts/%s/secrets";
 
@@ -39,7 +38,7 @@ class ListSecretsEndpoint extends AbstractMethod<String, ListSecretsResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -60,7 +59,7 @@ class ListSecretsEndpoint extends AbstractMethod<String, ListSecretsResponse> {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return ListSecretsResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return ListSecretsResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 
     @Override

--- a/src/main/java/com/vonage/client/account/PrefixPricingEndpoint.java
+++ b/src/main/java/com/vonage/client/account/PrefixPricingEndpoint.java
@@ -20,12 +20,11 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 
 class PrefixPricingEndpoint extends AbstractMethod<PrefixPricingRequest, PrefixPricingResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/get-prefix-pricing/outbound/%s";
 
@@ -34,7 +33,7 @@ class PrefixPricingEndpoint extends AbstractMethod<PrefixPricingRequest, PrefixP
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -48,6 +47,6 @@ class PrefixPricingEndpoint extends AbstractMethod<PrefixPricingRequest, PrefixP
 
     @Override
     public PrefixPricingResponse parseResponse(HttpResponse response) throws IOException {
-        return PrefixPricingResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return PrefixPricingResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/account/PricingEndpoint.java
+++ b/src/main/java/com/vonage/client/account/PricingEndpoint.java
@@ -20,12 +20,11 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 
 class PricingEndpoint extends AbstractMethod<PricingRequest, PricingResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/get-pricing/outbound/%s";
 
@@ -34,7 +33,7 @@ class PricingEndpoint extends AbstractMethod<PricingRequest, PricingResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -48,6 +47,6 @@ class PricingEndpoint extends AbstractMethod<PricingRequest, PricingResponse> {
 
     @Override
     public PricingResponse parseResponse(HttpResponse response) throws IOException {
-        return PricingResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return PricingResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/account/RevokeSecretEndpoint.java
+++ b/src/main/java/com/vonage/client/account/RevokeSecretEndpoint.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class RevokeSecretEndpoint extends AbstractMethod<SecretRequest, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/accounts/%s/secrets/%s";
 
@@ -38,7 +38,7 @@ class RevokeSecretEndpoint extends AbstractMethod<SecretRequest, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/account/SettingsEndpoint.java
+++ b/src/main/java/com/vonage/client/account/SettingsEndpoint.java
@@ -21,14 +21,13 @@ import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class SettingsEndpoint extends AbstractMethod<SettingsRequest, SettingsResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/settings";
 
@@ -37,7 +36,7 @@ class SettingsEndpoint extends AbstractMethod<SettingsRequest, SettingsResponse>
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -55,6 +54,6 @@ class SettingsEndpoint extends AbstractMethod<SettingsRequest, SettingsResponse>
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
-        return SettingsResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SettingsResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/account/TopUpEndpoint.java
+++ b/src/main/java/com/vonage/client/account/TopUpEndpoint.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class TopUpEndpoint extends AbstractMethod<TopUpRequest, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/account/top-up";
 
@@ -37,7 +37,7 @@ class TopUpEndpoint extends AbstractMethod<TopUpRequest, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/application/CreateApplicationEndpoint.java
+++ b/src/main/java/com/vonage/client/application/CreateApplicationEndpoint.java
@@ -22,14 +22,13 @@ import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class CreateApplicationEndpoint extends ApplicationMethod<Application, Application> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/applications";
 
@@ -38,7 +37,7 @@ class CreateApplicationEndpoint extends ApplicationMethod<Application, Applicati
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -57,6 +56,6 @@ class CreateApplicationEndpoint extends ApplicationMethod<Application, Applicati
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return Application.fromJson(new BasicResponseHandler().handleResponse(response));
+        return Application.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/application/DeleteApplicationEndpoint.java
+++ b/src/main/java/com/vonage/client/application/DeleteApplicationEndpoint.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class DeleteApplicationEndpoint extends ApplicationMethod<String, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/applications/%s";
 
@@ -36,7 +36,7 @@ class DeleteApplicationEndpoint extends ApplicationMethod<String, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/application/GetApplicationEndpoint.java
+++ b/src/main/java/com/vonage/client/application/GetApplicationEndpoint.java
@@ -21,14 +21,13 @@ import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class GetApplicationEndpoint extends ApplicationMethod<String, Application> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/applications/%s";
 
@@ -37,7 +36,7 @@ class GetApplicationEndpoint extends ApplicationMethod<String, Application> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -54,6 +53,6 @@ class GetApplicationEndpoint extends ApplicationMethod<String, Application> {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return Application.fromJson(new BasicResponseHandler().handleResponse(response));
+        return Application.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/application/ListApplicationsEndpoint.java
+++ b/src/main/java/com/vonage/client/application/ListApplicationsEndpoint.java
@@ -21,14 +21,13 @@ import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ListApplicationsEndpoint extends ApplicationMethod<ListApplicationRequest, ApplicationList> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/applications";
 
@@ -37,7 +36,7 @@ class ListApplicationsEndpoint extends ApplicationMethod<ListApplicationRequest,
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -66,6 +65,6 @@ class ListApplicationsEndpoint extends ApplicationMethod<ListApplicationRequest,
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return ApplicationList.fromJson(new BasicResponseHandler().handleResponse(response));
+        return ApplicationList.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/application/UpdateApplicationEndpoint.java
+++ b/src/main/java/com/vonage/client/application/UpdateApplicationEndpoint.java
@@ -22,14 +22,13 @@ import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.util.EntityUtils;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class UpdateApplicationEndpoint extends ApplicationMethod<Application, Application> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/applications/%s";
 
@@ -38,7 +37,7 @@ class UpdateApplicationEndpoint extends ApplicationMethod<Application, Applicati
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -57,6 +56,6 @@ class UpdateApplicationEndpoint extends ApplicationMethod<Application, Applicati
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
 
-        return Application.fromJson(new BasicResponseHandler().handleResponse(response));
+        return Application.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/auth/AuthCollection.java
+++ b/src/main/java/com/vonage/client/auth/AuthCollection.java
@@ -24,7 +24,7 @@ import java.util.*;
  * allow for simple selection of an appropriate AuthMethod for a particular REST endpoint.
  */
 public class AuthCollection {
-    private SortedSet<AuthMethod> authList;
+    private final SortedSet<AuthMethod> authList;
 
     /**
      * Create a new AuthCollection with an empty set of AuthMethods.
@@ -70,7 +70,7 @@ public class AuthCollection {
                 return (T) availableAuthMethod;
             }
         }
-        throw new VonageUnacceptableAuthException(authList, new HashSet<>(Arrays.asList(new Class[]{type})));
+        throw new VonageUnacceptableAuthException(authList, new HashSet<>(Arrays.asList(new Class<?>[]{type})));
     }
 
     /**
@@ -82,7 +82,7 @@ public class AuthCollection {
      *
      * @throws VonageUnacceptableAuthException if no appropriate AuthMethod is held by this AuthCollection
      */
-    public AuthMethod getAcceptableAuthMethod(Set<Class> acceptableAuthMethodClasses) throws VonageUnacceptableAuthException {
+    public AuthMethod getAcceptableAuthMethod(Set<Class<?>> acceptableAuthMethodClasses) throws VonageUnacceptableAuthException {
         for (AuthMethod availableAuthMethod : authList) {
             if (acceptableAuthMethodClasses.contains(availableAuthMethod.getClass())) {
                 return availableAuthMethod;

--- a/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
+++ b/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
@@ -20,10 +20,10 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.*;
 
 public class VonageUnacceptableAuthException extends VonageAuthException {
-    private static final Map<Class, String> AUTH_DESCRIPTION_MAP = new HashMap<>();
+    private static final Map<Class<?>, String> AUTH_DESCRIPTION_MAP = new HashMap<>();
 
     private final Iterable<AuthMethod> availableAuths;
-    private final Iterable<Class> acceptableAuthClasses;
+    private final Iterable<Class<?>> acceptableAuthClasses;
 
     static {
         AUTH_DESCRIPTION_MAP.put(TokenAuthMethod.class, "API Key and Secret");
@@ -31,9 +31,7 @@ public class VonageUnacceptableAuthException extends VonageAuthException {
         AUTH_DESCRIPTION_MAP.put(JWTAuthMethod.class, "Application ID and Private Key");
     }
 
-    public VonageUnacceptableAuthException(Collection<AuthMethod> availableAuths, Collection<Class>
-            acceptableAuthClasses) {
-        super();
+    public VonageUnacceptableAuthException(Collection<AuthMethod> availableAuths, Collection<Class<?>> acceptableAuthClasses) {
         this.availableAuths = new ArrayList<>(availableAuths);
         this.acceptableAuthClasses = new ArrayList<>(acceptableAuthClasses);
     }
@@ -49,7 +47,7 @@ public class VonageUnacceptableAuthException extends VonageAuthException {
         }
 
         SortedSet<String> acceptableTypes = new TreeSet<>();
-        for (Class klass : acceptableAuthClasses) {
+        for (Class<?> klass : acceptableAuthClasses) {
             acceptableTypes.add(AUTH_DESCRIPTION_MAP.getOrDefault(klass, klass.getSimpleName()));
         }
 

--- a/src/main/java/com/vonage/client/conversion/ConversionEndpoint.java
+++ b/src/main/java/com/vonage/client/conversion/ConversionEndpoint.java
@@ -31,7 +31,7 @@ import java.text.SimpleDateFormat;
 
 class ConversionEndpoint extends AbstractMethod<ConversionRequest, Void> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/conversions/";
 
@@ -40,7 +40,7 @@ class ConversionEndpoint extends AbstractMethod<ConversionRequest, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightEndpoint.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightEndpoint.java
@@ -21,13 +21,12 @@ import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightRequest, AdvancedInsightResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/ni/advanced/json";
     private static final String ASYNC_PATH = "/ni/advanced/async/json";
@@ -37,7 +36,7 @@ class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightRequest, Adv
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -65,6 +64,6 @@ class AdvancedInsightEndpoint extends AbstractMethod<AdvancedInsightRequest, Adv
 
     @Override
     public AdvancedInsightResponse parseResponse(HttpResponse response) throws IOException {
-        return AdvancedInsightResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return AdvancedInsightResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/insight/BasicInsightEndpoint.java
+++ b/src/main/java/com/vonage/client/insight/BasicInsightEndpoint.java
@@ -21,14 +21,13 @@ import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, BasicInsightResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/ni/basic/json";
 
@@ -37,7 +36,7 @@ class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, BasicInsi
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -56,6 +55,6 @@ class BasicInsightEndpoint extends AbstractMethod<BasicInsightRequest, BasicInsi
 
     @Override
     public BasicInsightResponse parseResponse(HttpResponse response) throws IOException {
-        return BasicInsightResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return BasicInsightResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/insight/StandardInsightEndpoint.java
+++ b/src/main/java/com/vonage/client/insight/StandardInsightEndpoint.java
@@ -21,13 +21,12 @@ import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class StandardInsightEndpoint extends AbstractMethod<StandardInsightRequest, StandardInsightResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/ni/standard/json";
 
@@ -36,7 +35,7 @@ class StandardInsightEndpoint extends AbstractMethod<StandardInsightRequest, Sta
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -58,6 +57,6 @@ class StandardInsightEndpoint extends AbstractMethod<StandardInsightRequest, Sta
 
     @Override
     public StandardInsightResponse parseResponse(HttpResponse response) throws IOException {
-        return StandardInsightResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return StandardInsightResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/numbers/BuyNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/BuyNumberEndpoint.java
@@ -29,14 +29,14 @@ import java.io.UnsupportedEncodingException;
 
 class BuyNumberEndpoint extends AbstractMethod<BuyNumberRequest, Void> {
     private static final String PATH = "/number/buy";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     BuyNumberEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/numbers/CancelNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/CancelNumberEndpoint.java
@@ -29,14 +29,14 @@ import java.io.UnsupportedEncodingException;
 
 class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, Void> {
     private static final String PATH = "/number/cancel";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     CancelNumberEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
@@ -21,21 +21,20 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersResponse> {
     private static final String PATH = "/account/numbers";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     ListNumbersEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -50,6 +49,6 @@ class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersR
 
     @Override
     public ListNumbersResponse parseResponse(HttpResponse response) throws IOException {
-        return ListNumbersResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return ListNumbersResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ListNumbersResponse {
     private int count = 0;
-    private OwnedNumber[] numbers = new OwnedNumber[]{};
+    private OwnedNumber[] numbers = new OwnedNumber[0];
 
     public int getCount() {
         return count;
@@ -45,5 +45,4 @@ public class ListNumbersResponse {
             throw new VonageUnexpectedException("Failed to produce json from ListNumbersResponse object.", jpe);
         }
     }
-
 }

--- a/src/main/java/com/vonage/client/numbers/NumbersClient.java
+++ b/src/main/java/com/vonage/client/numbers/NumbersClient.java
@@ -15,13 +15,14 @@
  */
 package com.vonage.client.numbers;
 
-
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageClient;
 import com.vonage.client.VonageClientException;
 import com.vonage.client.VonageResponseParseException;
 
 /**
- * A client for accessing the Vonage API calls that manage phone numbers.
+ * A client for accessing the Vonage API calls that manage phone numbers. The standard way to obtain an instance of
+ * this class is to use {@link VonageClient#getNumbersClient()}.
  */
 public class NumbersClient {
     final ListNumbersEndpoint listNumbers;

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
@@ -21,21 +21,20 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNumbersResponse> {
     private static final String PATH = "/number/search";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     SearchNumbersEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -50,6 +49,6 @@ class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNu
 
     @Override
     public SearchNumbersResponse parseResponse(HttpResponse response) throws IOException {
-        return SearchNumbersResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SearchNumbersResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/numbers/UpdateNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/UpdateNumberEndpoint.java
@@ -29,7 +29,7 @@ import java.io.UnsupportedEncodingException;
 
 class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Void> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/number/update";
 
@@ -38,7 +38,7 @@ class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/redact/RedactEndpoint.java
+++ b/src/main/java/com/vonage/client/redact/RedactEndpoint.java
@@ -31,7 +31,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class RedactEndpoint extends AbstractMethod<RedactRequest, Void> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/redact/transaction";
 
@@ -40,7 +40,7 @@ class RedactEndpoint extends AbstractMethod<RedactRequest, Void> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/sms/SearchRejectedMessagesEndpoint.java
+++ b/src/main/java/com/vonage/client/sms/SearchRejectedMessagesEndpoint.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejectedMessagesRequest, SearchRejectedMessagesResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/search/rejections";
 
@@ -36,7 +35,7 @@ public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejecte
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -51,6 +50,6 @@ public class SearchRejectedMessagesEndpoint extends AbstractMethod<SearchRejecte
 
     @Override
     public SearchRejectedMessagesResponse parseResponse(HttpResponse response) throws IOException {
-        return SearchRejectedMessagesResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SearchRejectedMessagesResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/sms/SendMessageEndpoint.java
+++ b/src/main/java/com/vonage/client/sms/SendMessageEndpoint.java
@@ -22,14 +22,13 @@ import com.vonage.client.auth.TokenAuthMethod;
 import com.vonage.client.sms.messages.Message;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class SendMessageEndpoint extends AbstractMethod<Message, SmsSubmissionResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/sms/json";
 
@@ -38,7 +37,7 @@ class SendMessageEndpoint extends AbstractMethod<Message, SmsSubmissionResponse>
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -54,6 +53,6 @@ class SendMessageEndpoint extends AbstractMethod<Message, SmsSubmissionResponse>
 
     @Override
     public SmsSubmissionResponse parseResponse(HttpResponse response) throws IOException {
-        return SmsSubmissionResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SmsSubmissionResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/sms/SmsSearchEndpoint.java
+++ b/src/main/java/com/vonage/client/sms/SmsSearchEndpoint.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSmsResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/search/messages";
 
@@ -36,7 +35,7 @@ public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSm
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -51,6 +50,6 @@ public class SmsSearchEndpoint extends AbstractMethod<SearchSmsRequest, SearchSm
 
     @Override
     public SearchSmsResponse parseResponse(HttpResponse response) throws IOException {
-        return SearchSmsResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SearchSmsResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/sms/SmsSingleSearchEndpoint.java
+++ b/src/main/java/com/vonage/client/sms/SmsSingleSearchEndpoint.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSearchResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/search/message";
 
@@ -36,7 +35,7 @@ public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSea
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -50,6 +49,6 @@ public class SmsSingleSearchEndpoint extends AbstractMethod<String, SmsSingleSea
 
     @Override
     public SmsSingleSearchResponse parseResponse(HttpResponse response) throws IOException {
-        return SmsSingleSearchResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SmsSingleSearchResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/sns/SnsEndpoint.java
+++ b/src/main/java/com/vonage/client/sns/SnsEndpoint.java
@@ -30,7 +30,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -42,7 +41,7 @@ import java.util.Map;
 class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
     private static final Log log = LogFactory.getLog(SnsClient.class);
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {SignatureAuthMethod.class, TokenAuthMethod.class};
 
     private static final String PATH = "/sns/xml";
 
@@ -53,7 +52,7 @@ class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -70,7 +69,7 @@ class SnsEndpoint extends AbstractMethod<SnsRequest, SnsResponse> {
 
     @Override
     public SnsResponse parseResponse(HttpResponse response) throws IOException {
-        return parseSubmitResponse(new BasicResponseHandler().handleResponse(response));
+        return parseSubmitResponse(basicResponseHandler.handleResponse(response));
     }
 
     protected SnsResponse parseSubmitResponse(String response) {

--- a/src/main/java/com/vonage/client/verify/CheckEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/CheckEndpoint.java
@@ -20,13 +20,12 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class CheckEndpoint extends AbstractMethod<CheckRequest, CheckResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/verify/check/json";
 
@@ -35,7 +34,7 @@ class CheckEndpoint extends AbstractMethod<CheckRequest, CheckResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -60,6 +59,6 @@ class CheckEndpoint extends AbstractMethod<CheckRequest, CheckResponse> {
 
     @Override
     public CheckResponse parseResponse(HttpResponse response) throws IOException {
-        return CheckResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return CheckResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/verify/ControlEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/ControlEndpoint.java
@@ -21,14 +21,13 @@ import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ControlEndpoint extends AbstractMethod<ControlRequest, ControlResponse> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/verify/control/json";
 
@@ -37,7 +36,7 @@ class ControlEndpoint extends AbstractMethod<ControlRequest, ControlResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -53,7 +52,7 @@ class ControlEndpoint extends AbstractMethod<ControlRequest, ControlResponse> {
 
     @Override
     public ControlResponse parseResponse(HttpResponse response) throws IOException, VonageClientException {
-        ControlResponse controlResponse = ControlResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        ControlResponse controlResponse = ControlResponse.fromJson(basicResponseHandler.handleResponse(response));
         if (!controlResponse.getStatus().equals("0")) {
             throw new VerifyException(controlResponse.getStatus(), controlResponse.getErrorText());
         }

--- a/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
+++ b/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
@@ -26,7 +26,6 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,14 +33,14 @@ import java.io.UnsupportedEncodingException;
 public class Psd2Endpoint extends AbstractMethod<Psd2Request, VerifyResponse> {
 
     private static final String PATH = "/verify/psd2/json";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     public Psd2Endpoint(HttpWrapper wrapper) {
         super(wrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -71,7 +70,7 @@ public class Psd2Endpoint extends AbstractMethod<Psd2Request, VerifyResponse> {
 
     @Override
     public VerifyResponse parseResponse(HttpResponse response) throws IOException {
-        return VerifyResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return VerifyResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 
     private void optionalParams(RequestBuilder builder, String paramName, Object value) {

--- a/src/main/java/com/vonage/client/verify/SearchEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/SearchEndpoint.java
@@ -20,13 +20,12 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class SearchEndpoint extends AbstractMethod<SearchRequest, SearchVerifyResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/verify/search/json";
 
@@ -35,7 +34,7 @@ class SearchEndpoint extends AbstractMethod<SearchRequest, SearchVerifyResponse>
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -58,6 +57,6 @@ class SearchEndpoint extends AbstractMethod<SearchRequest, SearchVerifyResponse>
 
     @Override
     public SearchVerifyResponse parseResponse(HttpResponse response) throws IOException {
-        return SearchVerifyResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return SearchVerifyResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 import org.apache.http.message.BasicNameValuePair;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class VerifyEndpoint extends AbstractMethod<VerifyRequest, VerifyResponse> {
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{TokenAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 
     private static final String PATH = "/verify/json";
 
@@ -36,7 +35,7 @@ class VerifyEndpoint extends AbstractMethod<VerifyRequest, VerifyResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -86,6 +85,6 @@ class VerifyEndpoint extends AbstractMethod<VerifyRequest, VerifyResponse> {
 
     @Override
     public VerifyResponse parseResponse(HttpResponse response) throws IOException {
-        return VerifyResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return VerifyResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/CallModifier.java
+++ b/src/main/java/com/vonage/client/voice/CallModifier.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.VonageUnexpectedException;
 import com.vonage.client.voice.ncco.Ncco;
 
-
 public class CallModifier {
     private final String uuid;
     private final ModifyCallPayload modifyCallPayload;

--- a/src/main/java/com/vonage/client/voice/CreateCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/CreateCallEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,7 +29,7 @@ import java.io.UnsupportedEncodingException;
 class CreateCallEndpoint extends AbstractMethod<Call, CallEvent> {
 
     private static final String PATH = "/calls";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     CreateCallEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -46,12 +45,12 @@ class CreateCallEndpoint extends AbstractMethod<Call, CallEvent> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
     @Override
     public CallEvent parseResponse(HttpResponse response) throws IOException {
-        return CallEvent.fromJson(new BasicResponseHandler().handleResponse(response));
+        return CallEvent.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/DownloadRecordingEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/DownloadRecordingEndpoint.java
@@ -26,7 +26,7 @@ import java.io.UnsupportedEncodingException;
 
 class DownloadRecordingEndpoint extends AbstractMethod<String, Recording> {
 
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     DownloadRecordingEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
@@ -38,7 +38,7 @@ class DownloadRecordingEndpoint extends AbstractMethod<String, Recording> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 

--- a/src/main/java/com/vonage/client/voice/DtmfEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/DtmfEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,7 +29,7 @@ import java.io.UnsupportedEncodingException;
 class DtmfEndpoint extends AbstractMethod<DtmfRequest, DtmfResponse> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
     public static final String DTMF_PATH = "/dtmf";
 
     DtmfEndpoint(HttpWrapper httpWrapper) {
@@ -38,7 +37,7 @@ class DtmfEndpoint extends AbstractMethod<DtmfRequest, DtmfResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -53,6 +52,6 @@ class DtmfEndpoint extends AbstractMethod<DtmfRequest, DtmfResponse> {
 
     @Override
     public DtmfResponse parseResponse(HttpResponse response) throws IOException {
-        return DtmfResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return DtmfResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/ListCallsEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ListCallsEndpoint.java
@@ -24,7 +24,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.client.utils.URIBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -34,14 +33,14 @@ import java.util.List;
 class ListCallsEndpoint extends AbstractMethod<CallsFilter, CallInfoPage> {
 
     private static final String PATH = "/calls";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     ListCallsEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -67,6 +66,6 @@ class ListCallsEndpoint extends AbstractMethod<CallsFilter, CallInfoPage> {
 
     @Override
     public CallInfoPage parseResponse(HttpResponse response) throws IOException {
-        return CallInfoPage.fromJson(new BasicResponseHandler().handleResponse(response));
+        return CallInfoPage.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/ModifyCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,14 +29,14 @@ import java.io.UnsupportedEncodingException;
 class ModifyCallEndpoint extends AbstractMethod<CallModifier, ModifyCallResponse> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     ModifyCallEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -53,7 +52,7 @@ class ModifyCallEndpoint extends AbstractMethod<CallModifier, ModifyCallResponse
     @Override
     public ModifyCallResponse parseResponse(HttpResponse response) throws IOException {
         if (response.getStatusLine().getStatusCode() == 200) {
-            return ModifyCallResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+            return ModifyCallResponse.fromJson(basicResponseHandler.handleResponse(response));
         }
         else {
             return null;

--- a/src/main/java/com/vonage/client/voice/ReadCallEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ReadCallEndpoint.java
@@ -20,21 +20,20 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 
 class ReadCallEndpoint extends AbstractMethod<String, CallInfo> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     ReadCallEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -47,6 +46,6 @@ class ReadCallEndpoint extends AbstractMethod<String, CallInfo> {
 
     @Override
     public CallInfo parseResponse(HttpResponse response) throws IOException {
-        return CallInfo.fromJson(new BasicResponseHandler().handleResponse(response));
+        return CallInfo.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/StartStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StartStreamEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,7 +29,7 @@ import java.io.UnsupportedEncodingException;
 class StartStreamEndpoint extends AbstractMethod<StreamRequest, StreamResponse> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
     private String uri;
 
     StartStreamEndpoint(HttpWrapper httpWrapper) {
@@ -38,7 +37,7 @@ class StartStreamEndpoint extends AbstractMethod<StreamRequest, StreamResponse> 
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -53,6 +52,6 @@ class StartStreamEndpoint extends AbstractMethod<StreamRequest, StreamResponse> 
 
     @Override
     public StreamResponse parseResponse(HttpResponse response) throws IOException {
-        return StreamResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return StreamResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/StartTalkEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StartTalkEndpoint.java
@@ -22,7 +22,6 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,14 +29,14 @@ import java.io.UnsupportedEncodingException;
 class StartTalkEndpoint extends AbstractMethod<TalkRequest, TalkResponse> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     StartTalkEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -52,6 +51,6 @@ class StartTalkEndpoint extends AbstractMethod<TalkRequest, TalkResponse> {
 
     @Override
     public TalkResponse parseResponse(HttpResponse response) throws IOException {
-        return TalkResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return TalkResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/StopStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StopStreamEndpoint.java
@@ -20,7 +20,6 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -29,14 +28,14 @@ class StopStreamEndpoint extends AbstractMethod<String, StreamResponse> {
 
     private static final String PATH = "/calls/";
     public static final String STREAM_PATH = "/stream";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 
     StopStreamEndpoint(HttpWrapper httpWrapper) {
         super(httpWrapper);
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -49,6 +48,6 @@ class StopStreamEndpoint extends AbstractMethod<String, StreamResponse> {
 
     @Override
     public StreamResponse parseResponse(HttpResponse response) throws IOException {
-        return StreamResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return StreamResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/StopTalkEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/StopTalkEndpoint.java
@@ -20,7 +20,6 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.impl.client.BasicResponseHandler;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -28,7 +27,7 @@ import java.io.UnsupportedEncodingException;
 class StopTalkEndpoint extends AbstractMethod<String, TalkResponse> {
 
     private static final String PATH = "/calls/";
-    private static final Class[] ALLOWED_AUTH_METHODS = new Class[]{JWTAuthMethod.class};
+    private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
     public static final String TALK_PATH = "/talk";
 
     StopTalkEndpoint(HttpWrapper httpWrapper) {
@@ -36,7 +35,7 @@ class StopTalkEndpoint extends AbstractMethod<String, TalkResponse> {
     }
 
     @Override
-    protected Class[] getAcceptableAuthMethods() {
+    protected Class<?>[] getAcceptableAuthMethods() {
         return ALLOWED_AUTH_METHODS;
     }
 
@@ -49,6 +48,6 @@ class StopTalkEndpoint extends AbstractMethod<String, TalkResponse> {
 
     @Override
     public TalkResponse parseResponse(HttpResponse response) throws IOException {
-        return TalkResponse.fromJson(new BasicResponseHandler().handleResponse(response));
+        return TalkResponse.fromJson(basicResponseHandler.handleResponse(response));
     }
 }

--- a/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
+++ b/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
@@ -65,10 +65,18 @@ public enum TextToSpeechLanguage {
     UKRAINIAN("uk-UA"),
     VIETNAMESE("vi-VN"),
     CHINESE_YUE("yue-CN"),
+
     @JsonEnumDefaultValue
     UNKNOWN("Unknown");
+
     private final String language;
-    TextToSpeechLanguage(String language){this.language=language;}
+
+    TextToSpeechLanguage(String language) {
+        this.language = language;
+    }
+
     @JsonValue
-    public String getLanguage(){return this.language;}
+    public String getLanguage() {
+        return this.language;
+    }
 }

--- a/src/main/java/com/vonage/client/voice/ncco/NotifyAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/NotifyAction.java
@@ -45,7 +45,7 @@ public class NotifyAction implements Action {
         return ACTION;
     }
 
-    public Map getPayload() {
+    public Map<String, ?> getPayload() {
         return payload;
     }
 

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -55,8 +55,8 @@ public class AbstractMethodTest {
         }
 
         @Override
-        protected Class[] getAcceptableAuthMethods() {
-            return new Class[]{JWTAuthMethod.class};
+        protected Class<?>[] getAcceptableAuthMethods() {
+            return new Class<?>[]{JWTAuthMethod.class};
         }
 
         @Override

--- a/src/test/java/com/vonage/client/account/BalanceEndpointTest.java
+++ b/src/test/java/com/vonage/client/account/BalanceEndpointTest.java
@@ -40,8 +40,8 @@ public class BalanceEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{TokenAuthMethod.class}, auths);
     }
 
 

--- a/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
+++ b/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 public class AuthCollectionTest {
-    private TestUtils testUtils = new TestUtils();
+    private final TestUtils testUtils = new TestUtils();
 
     @Test
     public void testGetAcceptableAuthMethod() throws Exception {
@@ -35,7 +35,7 @@ public class AuthCollectionTest {
         AuthCollection auths = new AuthCollection();
         auths.add(jAuth);
 
-        Set<Class> acceptableAuths = acceptableClassSet(JWTAuthMethod.class);
+        Set<Class<?>> acceptableAuths = acceptableClassSet(JWTAuthMethod.class);
 
         assertEquals(jAuth, auths.getAcceptableAuthMethod(acceptableAuths));
     }
@@ -57,7 +57,7 @@ public class AuthCollectionTest {
     public void testNoAcceptableAuthMethod() throws Exception {
         AuthCollection auths = new AuthCollection();
 
-        Set<Class> acceptableAuths = new HashSet<>();
+        Set<Class<?>> acceptableAuths = new HashSet<>();
         acceptableAuths.add(JWTAuthMethod.class);
 
         try {
@@ -78,7 +78,7 @@ public class AuthCollectionTest {
         auths.add(tAuth);
         auths.add(jAuth);
 
-        Set<Class> acceptableAuths = new HashSet<>();
+        Set<Class<?>> acceptableAuths = new HashSet<>();
         acceptableAuths.add(JWTAuthMethod.class);
 
         assertEquals(jAuth, auths.getAcceptableAuthMethod(acceptableAuths));
@@ -90,7 +90,7 @@ public class AuthCollectionTest {
         AuthCollection auths = new AuthCollection();
         auths.add(tAuth);
 
-        Set<Class> acceptableAuths = new HashSet<>();
+        Set<Class<?>> acceptableAuths = new HashSet<>();
         acceptableAuths.add(JWTAuthMethod.class);
 
         try {
@@ -101,8 +101,8 @@ public class AuthCollectionTest {
         }
     }
 
-    public Set<Class> acceptableClassSet(Class... classes) {
-        Set<Class> result = new HashSet<>();
+    public Set<Class<?>> acceptableClassSet(Class<?>... classes) {
+        Set<Class<?>> result = new HashSet<>();
         Collections.addAll(result, classes);
         return result;
     }

--- a/src/test/java/com/vonage/client/insight/AdvancedInsightEndpointTest.java
+++ b/src/test/java/com/vonage/client/insight/AdvancedInsightEndpointTest.java
@@ -40,8 +40,8 @@ public class AdvancedInsightEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/insight/BasicInsightEndpointTest.java
+++ b/src/test/java/com/vonage/client/insight/BasicInsightEndpointTest.java
@@ -40,8 +40,8 @@ public class BasicInsightEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/insight/StandardInsightEndpointTest.java
+++ b/src/test/java/com/vonage/client/insight/StandardInsightEndpointTest.java
@@ -40,8 +40,8 @@ public class StandardInsightEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{SignatureAuthMethod.class, TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/numbers/UpdateNumberEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/UpdateNumberEndpointTest.java
@@ -39,8 +39,8 @@ public class UpdateNumberEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/sms/SearchRejectedMessagesEndpointTest.java
+++ b/src/test/java/com/vonage/client/sms/SearchRejectedMessagesEndpointTest.java
@@ -43,8 +43,8 @@ public class SearchRejectedMessagesEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/sms/SendMessageEndpointTest.java
+++ b/src/test/java/com/vonage/client/sms/SendMessageEndpointTest.java
@@ -266,7 +266,7 @@ public class SendMessageEndpointTest {
         AuthMethod tokenAuth = new TokenAuthMethod("abcd", "def");
 
         when(wrapper.getAuthCollection()).thenReturn(authCollection);
-        @SuppressWarnings("unchecked") Set<Class> anySet = any(Set.class);
+        @SuppressWarnings("unchecked") Set<Class<?>> anySet = any(Set.class);
         when(authCollection.getAcceptableAuthMethod(anySet)).thenReturn(tokenAuth);
         when(wrapper.getHttpClient()).thenReturn(client);
         when(wrapper.getHttpConfig()).thenReturn(httpConfig);

--- a/src/test/java/com/vonage/client/sms/SmsSearchEndpointTest.java
+++ b/src/test/java/com/vonage/client/sms/SmsSearchEndpointTest.java
@@ -45,8 +45,8 @@ public class SmsSearchEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/verify/ControlEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/ControlEndpointTest.java
@@ -39,8 +39,8 @@ public class ControlEndpointTest {
 
     @Test
     public void testGetAcceptableAuthMethods() throws Exception {
-        Class[] auths = endpoint.getAcceptableAuthMethods();
-        assertArrayEquals(new Class[]{TokenAuthMethod.class}, auths);
+        Class<?>[] auths = endpoint.getAcceptableAuthMethods();
+        assertArrayEquals(new Class<?>[]{TokenAuthMethod.class}, auths);
     }
 
     @Test

--- a/src/test/java/com/vonage/client/voice/ListCallsEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ListCallsEndpointTest.java
@@ -52,7 +52,7 @@ public class ListCallsEndpointTest {
 
     @Test
     public void getAcceptableAuthMethods() throws Exception {
-        assertArrayEquals(new Class[]{JWTAuthMethod.class}, method.getAcceptableAuthMethods());
+        assertArrayEquals(new Class<?>[]{JWTAuthMethod.class}, method.getAcceptableAuthMethods());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/voice/ReadCallEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ReadCallEndpointTest.java
@@ -39,7 +39,7 @@ public class ReadCallEndpointTest {
 
     @Test
     public void getAcceptableAuthMethods() throws Exception {
-        assertArrayEquals(new Class[]{JWTAuthMethod.class}, method.getAcceptableAuthMethods());
+        assertArrayEquals(new Class<?>[]{JWTAuthMethod.class}, method.getAcceptableAuthMethods());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/voice/servlet/AbstractAnswerServletTest.java
+++ b/src/test/java/com/vonage/client/voice/servlet/AbstractAnswerServletTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class AbstractAnswerServletTest {
-    private AbstractAnswerServlet servlet = new AbstractAnswerServlet() {
+    private final AbstractAnswerServlet servlet = new AbstractAnswerServlet() {
         @Override
         protected NccoResponse handleRequest(HttpServletRequest request) {
             return new NccoResponseBuilder().appendNcco(TalkAction.builder("Hello").build()).getValue();


### PR DESCRIPTION
This PR fixes the raw type warnings used in `getAcceptableAuthMethods`. It also declares a static instance of `BasicResponseHandler` in `AbstractMethod` so that it can be re-used by subclasses to avoid unnecessary object creation.
