### PR TITLE
Move Channel and MessageType to Request constructor

### DIFF
--- a/src/main/java/com/vonage/client/messages/MessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/MessageRequest.java
@@ -49,12 +49,14 @@ public abstract class MessageRequest {
 	 * to avoid potentially confusing users on how to construct this object.
 	 *
 	 * @param builder The mutable builder object used to assign this MessageRequest's fields from.
+	 * @param channel The service to send the message through.
+	 * @param messageType The type of message to send.
 	 */
-	protected MessageRequest(Builder<?, ?> builder) {
-		messageType = Objects.requireNonNull(builder.messageType, "Message type cannot be null");
-		channel = Objects.requireNonNull(builder.channel, "Channel cannot be null");
-		if (!channel.getSupportedMessageTypes().contains(builder.messageType)) {
-			throw new IllegalArgumentException(messageType+" cannot be sent via "+channel);
+	protected MessageRequest(Builder<?, ?> builder, Channel channel, MessageType messageType) {
+		this.messageType = Objects.requireNonNull(messageType, "Message type cannot be null");
+		this.channel = Objects.requireNonNull(channel, "Channel cannot be null");
+		if (!this.channel.getSupportedMessageTypes().contains(this.messageType)) {
+			throw new IllegalArgumentException(this.messageType +" cannot be sent via "+ this.channel);
 		}
 		clientRef = validateClientReference(builder.clientRef);
 		from = builder.from;
@@ -147,8 +149,6 @@ public abstract class MessageRequest {
 	 */
 	@SuppressWarnings("unchecked")
 	public abstract static class Builder<M extends MessageRequest, B extends Builder<? extends M, ? extends B>> {
-		final Channel channel;
-		final MessageType messageType;
 		protected String from, to, clientRef;
 
 		/**
@@ -157,23 +157,7 @@ public abstract class MessageRequest {
 		 * the non-abstract subclasses of this builder's parent (declaring) class.
 		 */
 		protected Builder() {
-			messageType = getMessageType();
-			channel = getChannel();
 		}
-
-		/**
-		 * The type of message to send.
-		 *
-		 * @return The MessageType.
-		 */
-		protected abstract MessageType getMessageType();
-
-		/**
-		 * The service to send the message through.
-		 *
-		 * @return The Channel.
-		 */
-		protected abstract Channel getChannel();
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
@@ -25,7 +25,7 @@ public final class MessengerAudioRequest extends MessengerRequest {
 	MessagePayload audio;
 
 	MessengerAudioRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.AUDIO);
 		audio = new MessagePayload(builder.url);
 		audio.validateUrlExtension("mp3");
 		audio.validateUrlLength(10, 2000);
@@ -44,11 +44,6 @@ public final class MessengerAudioRequest extends MessengerRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.AUDIO;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
@@ -25,7 +25,7 @@ public final class MessengerFileRequest extends MessengerRequest {
 	MessagePayload file;
 
 	MessengerFileRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.FILE);
 		file = new MessagePayload(builder.url);
 	}
 
@@ -42,11 +42,6 @@ public final class MessengerFileRequest extends MessengerRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.FILE;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
@@ -25,7 +25,7 @@ public final class MessengerImageRequest extends MessengerRequest {
 	MessagePayload image;
 
 	MessengerImageRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.IMAGE);
 		image = new MessagePayload(builder.url);
 		image.validateUrlExtension("jpg", "jpeg", "png", "gif");
 	}
@@ -43,11 +43,6 @@ public final class MessengerImageRequest extends MessengerRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.IMAGE;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
@@ -19,13 +19,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class MessengerRequest extends MessageRequest {
 	protected Messenger messenger;
 
-	protected MessengerRequest(Builder<?, ?> builder) {
-		super(builder);
+	protected MessengerRequest(Builder<?, ?> builder, MessageType messageType) {
+		super(builder, Channel.MESSENGER, messageType);
 		messenger = Messenger.construct(builder.category, builder.tag);
 	}
 
@@ -50,11 +51,6 @@ public abstract class MessengerRequest extends MessageRequest {
 	protected abstract static class Builder<M extends MessengerRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
 		protected Tag tag;
 		protected Category category;
-
-		@Override
-		protected final Channel getChannel() {
-			return Channel.MESSENGER;
-		}
 
 		/**
 		 * (OPTIONAL, but REQUIRED if Category is {@link Category#MESSAGE_TAG})

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
@@ -25,7 +25,7 @@ public final class MessengerTextRequest extends MessengerRequest {
 	String text;
 
 	MessengerTextRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.TEXT);
 		text = new Text(builder.text, 640).toString();
 	}
 
@@ -42,11 +42,6 @@ public final class MessengerTextRequest extends MessengerRequest {
 		String text;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.TEXT;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
@@ -25,7 +25,7 @@ public final class MessengerVideoRequest extends MessengerRequest {
 	MessagePayload video;
 
 	MessengerVideoRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.VIDEO);
 		video = new MessagePayload(builder.url);
 		video.validateUrlExtension("mp4");
 	}
@@ -43,11 +43,6 @@ public final class MessengerVideoRequest extends MessengerRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.VIDEO;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
@@ -17,14 +17,14 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.internal.MessagePayload;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MmsAudioRequest extends MmsRequest {
 
 	MmsAudioRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.AUDIO);
 		payload = new MessagePayload(builder.url, builder.caption);
 		payload.validateCaptionLength(2000);
 	}
@@ -43,11 +43,6 @@ public final class MmsAudioRequest extends MmsRequest {
 
 		Builder() {}
 
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.AUDIO;
-		}
-
 		/**
 		 * (REQUIRED)
 		 * Sets the URL of the audio attachment.
@@ -56,8 +51,7 @@ public final class MmsAudioRequest extends MmsRequest {
 		 * @return This builder.
 		 */
 		public Builder url(String url) {
-			this.url = url;
-			return this;
+			return super.url(url);
 		}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
@@ -17,14 +17,14 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.internal.MessagePayload;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MmsImageRequest extends MmsRequest {
 
 	MmsImageRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.IMAGE);
 		payload = new MessagePayload(builder.url, builder.caption);
 		payload.validateUrlExtension("jpg", "jpeg", "png", "gif");
 		payload.validateCaptionLength(2000);
@@ -44,11 +44,6 @@ public final class MmsImageRequest extends MmsRequest {
 
 		Builder() {}
 
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.IMAGE;
-		}
-
 		/**
 		 * (REQUIRED)
 		 * Sets the URL of the image attachment. Supports only <code>.jpg</code>,
@@ -58,8 +53,7 @@ public final class MmsImageRequest extends MmsRequest {
 		 * @return This builder.
 		 */
 		public Builder url(String url) {
-			this.url = url;
-			return this;
+			return super.url(url);
 		}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
@@ -17,6 +17,7 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageRequest;
 
@@ -24,16 +25,17 @@ import com.vonage.client.messages.MessageRequest;
 public abstract class MmsRequest extends MessageRequest {
 	MessagePayload payload;
 
-	protected MmsRequest(Builder<?, ?> builder) {
-		super(builder);
+	protected MmsRequest(Builder<?, ?> builder, MessageType messageType) {
+		super(builder, Channel.MMS, messageType);
 	}
 
+	@SuppressWarnings("unchecked")
 	protected abstract static class Builder<M extends MmsRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
 		String url;
 
-		@Override
-		protected final Channel getChannel() {
-			return Channel.MMS;
+		protected B url(String url) {
+			this.url = url;
+			return (B) this;
 		}
 	}
 }

--- a/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
@@ -17,14 +17,14 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.internal.MessagePayload;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MmsVcardRequest extends MmsRequest {
 
 	MmsVcardRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.VCARD);
 		payload = new MessagePayload(builder.url);
 		payload.validateUrlExtension("vcf");
 	}
@@ -41,11 +41,6 @@ public final class MmsVcardRequest extends MmsRequest {
 	public static final class Builder extends MmsRequest.Builder<MmsVcardRequest, Builder> {
 		Builder() {}
 
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.VCARD;
-		}
-
 		/**
 		 * (REQUIRED)
 		 * Sets the URL of the vCard attachment. Supports only <code>.vcf</code> file extension.
@@ -54,8 +49,7 @@ public final class MmsVcardRequest extends MmsRequest {
 		 * @return This builder.
 		 */
 		public Builder url(String url) {
-			this.url = url;
-			return this;
+			return super.url(url);
 		}
 
 		@Override

--- a/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
@@ -17,14 +17,14 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.internal.MessagePayload;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MmsVideoRequest extends MmsRequest {
 
 	MmsVideoRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.VIDEO);
 		payload = new MessagePayload(builder.url, builder.caption);
 		payload.validateCaptionLength(2000);
 	}
@@ -43,11 +43,6 @@ public final class MmsVideoRequest extends MmsRequest {
 
 		Builder() {}
 
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.VIDEO;
-		}
-
 		/**
 		 * (REQUIRED)
 		 * Sets the URL of the video attachment.
@@ -56,8 +51,7 @@ public final class MmsVideoRequest extends MmsRequest {
 		 * @return This builder.
 		 */
 		public Builder url(String url) {
-			this.url = url;
-			return this;
+			return super.url(url);
 		}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -27,7 +27,7 @@ public final class SmsTextRequest extends MessageRequest {
 	String text;
 
 	SmsTextRequest(Builder builder) {
-		super(builder);
+		super(builder, Channel.SMS, MessageType.TEXT);
 		text = new Text(builder.text, 1000).toString();
 	}
 
@@ -44,16 +44,6 @@ public final class SmsTextRequest extends MessageRequest {
 		String text;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.TEXT;
-		}
-
-		@Override
-		protected Channel getChannel() {
-			return Channel.SMS;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
@@ -25,7 +25,7 @@ public final class ViberImageRequest extends ViberRequest {
 	MessagePayload image;
 
 	ViberImageRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.IMAGE);
 		image = new MessagePayload(builder.url);
 		image.validateUrlExtension("jpg", "jpeg", "png");
 	}
@@ -43,11 +43,6 @@ public final class ViberImageRequest extends ViberRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.IMAGE;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
@@ -19,14 +19,15 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.E164;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class ViberRequest extends MessageRequest {
 	protected ViberService viberService;
 
-	protected ViberRequest(Builder<?, ?> builder) {
-		super(builder);
+	protected ViberRequest(Builder<?, ?> builder, MessageType messageType) {
+		super(builder, Channel.VIBER, messageType);
 		viberService = ViberService.construct(builder.category, builder.ttl, builder.viberType);
 	}
 
@@ -51,11 +52,6 @@ public abstract class ViberRequest extends MessageRequest {
 		protected Category category;
 		protected Integer ttl;
 		protected String viberType;
-
-		@Override
-		protected final Channel getChannel() {
-			return Channel.VIBER;
-		}
 
 		/**
 		 * (OPTIONAL)

--- a/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
@@ -25,7 +25,7 @@ public final class ViberTextRequest extends ViberRequest {
 	String text;
 
 	ViberTextRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.TEXT);
 		text = new Text(builder.text, 1000).toString();
 	}
 
@@ -42,11 +42,6 @@ public final class ViberTextRequest extends ViberRequest {
 		String text;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.TEXT;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
@@ -25,7 +25,7 @@ public final class WhatsappAudioRequest extends WhatsappRequest {
 	MessagePayload audio;
 
 	WhatsappAudioRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.AUDIO);
 		audio = new MessagePayload(builder.url);
 		audio.validateUrlExtension("aac", "m4a", "amr", "mp3", "opus");
 		audio.validateUrlLength(10, 2000);
@@ -44,11 +44,6 @@ public final class WhatsappAudioRequest extends WhatsappRequest {
 		String url;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.AUDIO;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
@@ -26,7 +26,7 @@ public final class WhatsappCustomRequest extends WhatsappRequest {
 	Map<?, ?> custom;
 
 	WhatsappCustomRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.CUSTOM);
 		custom = builder.custom;
 	}
 
@@ -43,11 +43,6 @@ public final class WhatsappCustomRequest extends WhatsappRequest {
 		Map<?, ?> custom;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.CUSTOM;
-		}
 
 		/**
 		 * (OPTIONAL)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
@@ -25,7 +25,7 @@ public final class WhatsappFileRequest extends WhatsappRequest {
 	MessagePayload file;
 
 	WhatsappFileRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.FILE);
 		file = new MessagePayload(builder.url, builder.caption);
 	}
 
@@ -42,11 +42,6 @@ public final class WhatsappFileRequest extends WhatsappRequest {
 		String url, caption;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.FILE;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
@@ -25,7 +25,7 @@ public final class WhatsappImageRequest extends WhatsappRequest {
 	MessagePayload image;
 
 	WhatsappImageRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.IMAGE);
 		image = new MessagePayload(builder.url, builder.caption);
 		image.validateUrlExtension("jpg", "jpeg", "png");
 		image.validateCaptionLength(3000);
@@ -44,11 +44,6 @@ public final class WhatsappImageRequest extends WhatsappRequest {
 		String url, caption;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.IMAGE;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
@@ -18,13 +18,14 @@ package com.vonage.client.messages.whatsapp;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.E164;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class WhatsappRequest extends MessageRequest {
 
-	protected WhatsappRequest(Builder<?, ?> builder) {
-		super(builder);
+	protected WhatsappRequest(Builder<?, ?> builder, MessageType messageType) {
+		super(builder, Channel.WHATSAPP, messageType);
 	}
 
 	@Override
@@ -36,10 +37,5 @@ public abstract class WhatsappRequest extends MessageRequest {
 	}
 
 	protected abstract static class Builder<M extends WhatsappRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
-
-		@Override
-		protected final Channel getChannel() {
-			return Channel.WHATSAPP;
-		}
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -28,7 +28,7 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 	Whatsapp whatsapp;
 
 	WhatsappTemplateRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.TEMPLATE);
 		template = new Template(builder.name, builder.parameters);
 		whatsapp = new Whatsapp(builder.policy, builder.locale);
 	}
@@ -106,11 +106,6 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 		public Builder locale(String locale) {
 			this.locale = locale;
 			return this;
-		}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.TEMPLATE;
 		}
 
 		@Override

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
@@ -25,7 +25,7 @@ public final class WhatsappTextRequest extends WhatsappRequest {
 	String text;
 
 	WhatsappTextRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.TEXT);
 		text = new Text(builder.text, 4096).toString();
 	}
 
@@ -42,11 +42,6 @@ public final class WhatsappTextRequest extends WhatsappRequest {
 		String text;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.TEXT;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
@@ -25,7 +25,7 @@ public final class WhatsappVideoRequest extends WhatsappRequest {
 	MessagePayload video;
 
 	WhatsappVideoRequest(Builder builder) {
-		super(builder);
+		super(builder, MessageType.VIDEO);
 		video = new MessagePayload(builder.url, builder.caption);
 		video.validateUrlExtension("mp4", "3gpp");
 	}
@@ -43,11 +43,6 @@ public final class WhatsappVideoRequest extends WhatsappRequest {
 		String url, caption;
 
 		Builder() {}
-
-		@Override
-		protected MessageType getMessageType() {
-			return MessageType.VIDEO;
-		}
 
 		/**
 		 * (REQUIRED)

--- a/src/test/java/com/vonage/client/messages/MessageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/MessageRequestTest.java
@@ -24,20 +24,17 @@ public class MessageRequestTest {
 	static class ConcreteMessageRequest extends MessageRequest {
 
 		static ConcreteMessageRequest.Builder builder(MessageType mt, Channel ct) {
-			return new Builder() {
-				@Override
-				protected MessageType getMessageType() {
-					return mt;
-				}
-
-				@Override
-				protected Channel getChannel() {
-					return ct;
-				}
-			};
+			return new Builder(mt, ct);
 		}
 
-		static abstract class Builder extends MessageRequest.Builder<ConcreteMessageRequest, Builder> {
+		static class Builder extends MessageRequest.Builder<ConcreteMessageRequest, Builder> {
+			final MessageType messageType;
+			final Channel channel;
+
+			Builder(MessageType messageType, Channel channel) {
+				this.messageType = messageType;
+				this.channel = channel;
+			}
 
 			@Override
 			public ConcreteMessageRequest build() {
@@ -46,7 +43,7 @@ public class MessageRequestTest {
 		}
 
 		private ConcreteMessageRequest(Builder builder) {
-			super(builder);
+			super(builder, builder.channel, builder.messageType);
 		}
 	}
 


### PR DESCRIPTION
This PR moves the Channel and Message type in the Messages implementation to be constructor parameters in MessageRequests, which is more appropriate and simpler than having builders override an abstract method to set it, since it's immutable by design.
