### PR TITLE
Be more permissive with SMS and MMS senders

### DIFF
--- a/src/main/java/com/vonage/client/messages/MessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/MessageRequest.java
@@ -79,16 +79,17 @@ public abstract class MessageRequest {
 
 	/**
 	 * This method is used to validate the format of sender and recipient fields. By default,
-	 * this method checks that both the sender and recipient are E164 compliant numbers.
-	 * Subclasses may override this method to change this behaviour, or to re-assign the
-	 * sender and recipient fields to be well-formed / standardised / compliant.
+	 * this method checks that the recipient is an E164-compliant number and that the sender is not blank.
+	 * Subclasses may re-assign the sender and recipient fields to be well-formed / standardised / compliant.
 	 *
 	 * @param from The sender number or ID passed in from the builder.
 	 * @param to The recipient number or ID passed in from the builder.
 	 * @throws IllegalArgumentException If the sender or recipient are invalid / malformed.
 	 */
 	protected void validateSenderAndRecipient(String from, String to) throws IllegalArgumentException {
-		this.from = new E164(from).toString();
+		if (from == null || from.isEmpty()) {
+			throw new IllegalArgumentException("Sender cannot be empty");
+		}
 		this.to = new E164(to).toString();
 	}
 

--- a/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
@@ -17,9 +17,9 @@ package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
-import com.vonage.client.messages.MessageRequest;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class MmsRequest extends MessageRequest {

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -17,8 +17,8 @@ package com.vonage.client.messages.sms;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.Text;
 

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
@@ -16,24 +16,15 @@
 package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.Channel;
+import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.MessageType;
-import com.vonage.client.messages.internal.E164;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class WhatsappRequest extends MessageRequest {
 
 	protected WhatsappRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.WHATSAPP, messageType);
-	}
-
-	@Override
-	protected void validateSenderAndRecipient(String from, String to) throws IllegalArgumentException {
-		if (from == null || from.isEmpty()) {
-			throw new IllegalArgumentException("Sender number or ID cannot be empty");
-		}
-		this.to = new E164(to).toString();
 	}
 
 	protected abstract static class Builder<M extends WhatsappRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {

--- a/src/test/java/com/vonage/client/messages/MessageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/MessageRequestTest.java
@@ -101,10 +101,10 @@ public class MessageRequestTest {
 				.from("447900000009").to("").build();
 	}
 
-	@Test(expected = NullPointerException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testConstructNullNumber() {
 		ConcreteMessageRequest.builder(MessageType.CUSTOM, Channel.WHATSAPP)
-				.from(null).to("447900000009").build();
+				.to("447900000009").from(null).build();
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -116,7 +116,7 @@ public class MessageRequestTest {
 	@Test(expected = IllegalArgumentException.class)
 	public void testConstructInvalidNumber() {
 		ConcreteMessageRequest.builder(MessageType.FILE, Channel.MESSENGER)
-				.to("447900000001").from("+0 NaN").build();
+				.from("447900000001").to("+0 NaN").build();
 	}
 
 	@Test
@@ -124,7 +124,7 @@ public class MessageRequestTest {
 		String json = ConcreteMessageRequest.builder(MessageType.AUDIO, Channel.WHATSAPP)
 				.from("+44 7900090000").to("+1 900-900-0000").build().toJson();
 
-		assertTrue(json.contains("\"from\":\"447900090000\""));
+		assertTrue(json.contains("\"from\":\"+44 7900090000\""));
 		assertTrue(json.contains("\"to\":\"19009000000\""));
 		assertTrue(json.contains("\"message_type\":\"audio\""));
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));


### PR DESCRIPTION
This PR allows any string to be used for the sender field by default in `MessageRequest`, since the [API spec ](https://developer.vonage.com/api/messages-olympus) does not strictly prohibit non-E164 numbers to be used as the `from` field in SMS and MMS requests.
