### PR TITLE
Remove Apache Commons dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,6 @@ dependencies {
     compileOnly 'javax.servlet:javax.servlet-api:4.0.1'
 
     implementation 'commons-codec:commons-codec:1.15'
-    implementation 'commons-logging:commons-logging:1.2'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-inline:4.5.1'
+    testImplementation 'org.mockito:mockito-inline:4.6.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.springframework:spring-test:5.3.20'
     testImplementation 'org.springframework:spring-web:5.3.20'

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
 
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'commons-logging:commons-logging:1.2'
-    implementation 'commons-io:commons-io:2.11.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'commons-logging:commons-logging:1.2'
     implementation 'commons-io:commons-io:2.11.0'
-    implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.3'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'

--- a/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
+++ b/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
@@ -15,8 +15,6 @@
  */
 package com.vonage.client.auth;
 
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.*;
 
 public class VonageUnacceptableAuthException extends VonageAuthException {
@@ -51,8 +49,11 @@ public class VonageUnacceptableAuthException extends VonageAuthException {
             acceptableTypes.add(AUTH_DESCRIPTION_MAP.getOrDefault(klass, klass.getSimpleName()));
         }
 
-        return String.format("No acceptable authentication type could be found. Acceptable types are: %s. Supplied " +
-                "types " +
-                "were: %s", StringUtils.join(acceptableTypes, ", "), StringUtils.join(availableTypes, ", "));
+        return String.format(
+                "No acceptable authentication type could be found. " +
+                "Acceptable types are: %s. Supplied types were: %s",
+                String.join(", ", acceptableTypes),
+                String.join(", ", availableTypes)
+        );
     }
 }

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersFilter.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersFilter.java
@@ -15,7 +15,6 @@
  */
 package com.vonage.client.numbers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.RequestBuilder;
 
 /**
@@ -105,7 +104,7 @@ public class SearchNumbersFilter {
     public void addParams(RequestBuilder request) {
         request.addParameter("country", country);
         if (features != null && features.length > 0) {
-            request.addParameter("features", StringUtils.join(features, ","));
+            request.addParameter("features", String.join(",", features));
         }
         if (index != null) {
             request.addParameter("index", index.toString());

--- a/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
@@ -16,8 +16,8 @@
 package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class PhoneEndpoint implements Endpoint {
@@ -64,30 +64,17 @@ public class PhoneEndpoint implements Endpoint {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-        PhoneEndpoint rhs = (PhoneEndpoint) obj;
-        return new EqualsBuilder()
-                .append(this.type, rhs.type)
-                .append(this.number, rhs.number)
-                .append(this.dtmfAnswer, rhs.dtmfAnswer)
-                .isEquals();
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PhoneEndpoint that = (PhoneEndpoint) o;
+        return Objects.equals(type, that.type) &&
+                Objects.equals(number, that.number) &&
+                Objects.equals(dtmfAnswer, that.dtmfAnswer);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder(277, 11)
-                .append(this.type)
-                .append(this.number)
-                .append(this.dtmfAnswer)
-                .toHashCode();
+        return Objects.hash(type, number, dtmfAnswer);
     }
 }

--- a/src/main/java/com/vonage/client/voice/Recording.java
+++ b/src/main/java/com/vonage/client/voice/Recording.java
@@ -15,12 +15,10 @@
  */
 package com.vonage.client.voice;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -33,16 +31,14 @@ public class Recording {
     }
 
     public InputStream getContent() throws IOException {
-        return this.response.getEntity().getContent();
+        return response.getEntity().getContent();
     }
 
     public void save(String path) throws IOException {
-        this.save(FileSystems.getDefault().getPath(path));
+        save(FileSystems.getDefault().getPath(path));
     }
 
     public void save(Path path) throws IOException {
-        try (OutputStream out = Files.newOutputStream(path)) {
-            IOUtils.copy(this.response.getEntity().getContent(), out);
-        }
+        Files.copy(response.getEntity().getContent(), path);
     }
 }

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -20,7 +20,6 @@ import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.auth.JWTAuthMethod;
 import com.vonage.client.logging.LoggingUtils;
 import io.jsonwebtoken.lang.Assert;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
@@ -37,8 +36,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.*;
@@ -78,6 +80,12 @@ public class AbstractMethodTest {
         @Override
         public String parseResponse(HttpResponse response) throws IOException{
             throw new IOException("This is a test io exception from parse");
+        }
+    }
+
+    static String getEntityContentsAsString(HttpEntity entity) throws IOException {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(entity.getContent(), StandardCharsets.UTF_8))) {
+            return br.lines().collect(Collectors.joining(System.lineSeparator()));
         }
     }
 
@@ -156,9 +164,7 @@ public class AbstractMethodTest {
         verify(mockHttpClient).execute(captor.capture());
 
         HttpEntity entity = ((HttpEntityEnclosingRequest) captor.getValue()).getEntity();
-
-        String entityContents = IOUtils.toString(entity.getContent(), StandardCharsets.UTF_8);
-        assertEquals(json, entityContents);
+        assertEquals(json, getEntityContentsAsString(entity));
     }
 
     @Test
@@ -179,10 +185,7 @@ public class AbstractMethodTest {
         verify(mockHttpClient).execute(captor.capture());
 
         HttpEntity entity = ((HttpEntityEnclosingRequest) captor.getValue()).getEntity();
-
-        String entityContents = IOUtils.toString(entity.getContent(), StandardCharsets.UTF_8);
-
-        assertEquals(json, entityContents);
+        assertEquals(json, getEntityContentsAsString(entity));
     }
 
     @Test


### PR DESCRIPTION
The dependencies on Apache Commons libraries is not necessary and can easily be replaced by standard JDK libraries.
