### PR TITLE
Ensure User-Agent is set in all request headers and UTF-8 encoding is used

### DIFF
--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -73,6 +73,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
     public ResultT execute(RequestT request) throws VonageResponseParseException, VonageClientException {
         try {
             RequestBuilder requestBuilder = applyAuth(makeRequest(request));
+            requestBuilder.setHeader("User-Agent", httpWrapper.getUserAgent());
             HttpUriRequest httpRequest = requestBuilder.build();
 
             // If we have a URL Encoded form entity, we may need to regenerate it as UTF-8

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -19,11 +19,8 @@ import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.logging.LoggingUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -72,26 +69,11 @@ public abstract class AbstractMethod<RequestT, ResultT> implements Method<Reques
      */
     public ResultT execute(RequestT request) throws VonageResponseParseException, VonageClientException {
         try {
-            RequestBuilder requestBuilder = applyAuth(makeRequest(request));
-            requestBuilder.setHeader("User-Agent", httpWrapper.getUserAgent());
-            HttpUriRequest httpRequest = requestBuilder.build();
+            HttpUriRequest httpRequest = applyAuth(makeRequest(request))
+                    .setHeader("User-Agent", httpWrapper.getUserAgent())
+                    .setCharset(StandardCharsets.UTF_8)
+                    .build();
 
-            // If we have a URL Encoded form entity, we may need to regenerate it as UTF-8
-            // due to a bug (or two!) in RequestBuilder:
-            //
-            // This fix can be removed when HttpClient is upgraded to 4.5, although 4.5 also
-            // has a bug where RequestBuilder.put(uri) and RequestBuilder.post(uri) use the
-            // wrong encoding, whereas RequestBuilder.put().setUri(uri) uses UTF-8.
-            // - MS 2017-04-12
-            if (httpRequest instanceof HttpEntityEnclosingRequest) {
-                HttpEntityEnclosingRequest entityRequest = (HttpEntityEnclosingRequest) httpRequest;
-                HttpEntity entity = entityRequest.getEntity();
-                if (entity instanceof UrlEncodedFormEntity) {
-                    entityRequest.setEntity(new UrlEncodedFormEntity(
-                        requestBuilder.getParameters(), StandardCharsets.UTF_8
-                    ));
-                }
-            }
             LOG.debug("Request: " + httpRequest);
             if (LOG.isDebugEnabled() && httpRequest instanceof HttpEntityEnclosingRequestBase) {
                 HttpEntityEnclosingRequestBase enclosingRequest = (HttpEntityEnclosingRequestBase) httpRequest;

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -33,6 +33,7 @@ public class HttpWrapper {
     private static final String CLIENT_NAME = "vonage-java-sdk";
     private static final String CLIENT_VERSION = "6.5.0";
     private static final String JAVA_VERSION = System.getProperty("java.version");
+    private static final String USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 
     private AuthCollection authCollection;
     private HttpClient httpClient;
@@ -95,10 +96,9 @@ public class HttpWrapper {
 
         RequestConfig requestConfig = RequestConfig.custom().build();
 
-        return HttpClientBuilder
-                .create()
+        return HttpClientBuilder.create()
                 .setConnectionManager(connectionManager)
-                .setUserAgent(String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION))
+                .setUserAgent(USER_AGENT)
                 .setDefaultRequestConfig(requestConfig)
                 .useSystemProperties()
                 .build();
@@ -106,5 +106,9 @@ public class HttpWrapper {
 
     public HttpConfig getHttpConfig() {
         return httpConfig;
+    }
+
+    public String getUserAgent() {
+        return USER_AGENT;
     }
 }

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -93,6 +93,13 @@ public class AbstractMethodTest {
     private HttpClient mockHttpClient;
     private AuthCollection mockAuthMethods;
     private AuthMethod mockAuthMethod;
+    private HttpResponse basicResponse = new BasicHttpResponse(
+            new BasicStatusLine(
+                    new ProtocolVersion("1.1", 1, 1),
+                    200,
+                    "OK"
+            )
+    );
 
     @Before
     public void setUp() throws Exception {
@@ -105,19 +112,7 @@ public class AbstractMethodTest {
         when(LoggingUtils.logResponse(any(HttpResponse.class))).thenReturn("response logged");
         when(mockAuthMethods.getAcceptableAuthMethod(any())).thenReturn(mockAuthMethod);
         when(mockWrapper.getHttpClient()).thenReturn(mockHttpClient);
-        when(mockHttpClient.execute(any(HttpUriRequest.class))).thenReturn(
-            new BasicHttpResponse(
-                new BasicStatusLine(
-                    new ProtocolVersion(
-                    "1.1",
-                        1,
-                        1
-                    ),
-         200,
-       "OK"
-                )
-            )
-        );
+        when(mockHttpClient.execute(any(HttpUriRequest.class))).thenReturn(basicResponse);
         when(mockWrapper.getAuthCollection()).thenReturn(mockAuthMethods);
     }
 
@@ -129,25 +124,11 @@ public class AbstractMethodTest {
                     .map(Object::toString)
                     .collect(Collectors.joining(System.lineSeparator()));
 
-            HttpResponse response = new BasicHttpResponse(
-                new BasicStatusLine(
-                    new ProtocolVersion(
-                            "1.1",
-                            1,
-                            1
-                    ),
-                    200,
-                    "OK"
-                )
-            );
-            response.setEntity(new StringEntity(headers));
-            return response;
+            basicResponse.setEntity(new StringEntity(headers));
+            return basicResponse;
         });
 
-        String javaVersion = System.getProperty("java.version");
-        String userAgent = String.format("%s/%s java/%s", "vonage-java-sdk", "X.Y.Z", javaVersion);
-        assertEquals("vonage-java-sdk/X.Y.Z java/"+javaVersion, userAgent);
-
+        String userAgent = "vonage-java-sdk/X.Y.Z java/"+System.getProperty("java.version");
         when(mockWrapper.getUserAgent()).thenReturn(userAgent);
 
         ConcreteMethod method = new ConcreteMethod(mockWrapper);


### PR DESCRIPTION
This PR is a "just in case" fix for the User-Agent potentially not being set in requests, including a test for it. It also ensures the UTF-8 charset is used, since it appears to be an unresolved bug in `org.apache.http.client.methods.RequestBuilder` constructors.
