### PR TITLE
Deprecate Redact client

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,27 +425,6 @@ client.getConversionClient().submitConversion(ConversionRequest.Type.VOICE,
                                      new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").parse("2014-03-04 10:11:12"));
 ```
 
-### Redact Inbound SMS
-
-Submit a request to the Redact API when it has been enabled on your account with:
-```java
-VonageClient client = VonageClient.builder()
-        .apiKey(API_KEY)
-        .apiSecret(API_SECRET)
-        .build();
-client.getRedactClient().redactTransaction(SMS_ID, RedactRequest.Product.SMS, RedactRequest.Type.INBOUND);
-```
-
-### Redact Voice
-
-Submit a request to the Redact API when it has been enabled on your account with:
-```java
-VonageClient client = VonageClient.builder()
-        .apiKey(API_KEY)
-        .apiSecret(API_SECRET)
-        .build();
-client.getRedactClient().redactTransaction(VOICE_ID, RedactRequest.Product.VOICE);
-```
 
 ### Create Secret
 
@@ -532,7 +511,7 @@ The following is a list of Vonage APIs and whether the Java SDK provides support
 | Number Insight API    | General Availability |     ✅      |
 | Number Management API | General Availability |     ✅      |
 | Pricing API           | General Availability |     ✅      |
-| Redact API            | General Availability |     ✅      |
+| Redact API            |  Developer Preview   |     ✅      |
 | Reports API           |         Beta         |     ❌      |
 | SMS API               | General Availability |     ✅      |
 | Verify API            | General Availability |     ✅      |

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -112,6 +112,12 @@ public class VonageClient {
         return conversion;
     }
 
+    /**
+     *
+     * @return The Redact API client.
+     * @deprecated This API will be removed in the next major release.
+     */
+    @Deprecated
     public RedactClient getRedactClient() {
         return redact;
     }

--- a/src/main/java/com/vonage/client/redact/RedactClient.java
+++ b/src/main/java/com/vonage/client/redact/RedactClient.java
@@ -21,11 +21,14 @@ import com.vonage.client.*;
 /**
  * A client for talking to the Vonage Redact API. The standard way to obtain an instance of this class is to use {@link
  * VonageClient#getRedactClient()}.
+ *
+ * @deprecated This API will be removed in the next major release.
  */
+@Deprecated
 public class RedactClient {
-
     final RedactEndpoint redactEndpoint;
 
+    @Deprecated
     public RedactClient(HttpWrapper httpWrapper) {
         redactEndpoint = new RedactEndpoint(httpWrapper);
     }
@@ -39,6 +42,7 @@ public class RedactClient {
      * @throws VonageClientException        if there was a problem with the Vonage request or response objects.
      * @throws VonageResponseParseException if the response from the API could not be parsed.
      */
+    @Deprecated
     public void redactTransaction(String id, RedactRequest.Product product) throws VonageResponseParseException, VonageClientException {
         redactTransaction(new RedactRequest(id, product));
     }
@@ -53,6 +57,7 @@ public class RedactClient {
      * @throws VonageClientException        if there was a problem with the Vonage request or response objects.
      * @throws VonageResponseParseException if the response from the API could not be parsed.
      */
+    @Deprecated
     public void redactTransaction(String id, RedactRequest.Product product, RedactRequest.Type type) throws VonageResponseParseException, VonageClientException {
         RedactRequest request = new RedactRequest(id, product);
         request.setType(type);
@@ -68,6 +73,7 @@ public class RedactClient {
      * @throws VonageClientException        if there was a problem with the Vonage request or response objects.
      * @throws VonageResponseParseException if the response from the API could not be parsed.
      */
+    @Deprecated
     public void redactTransaction(RedactRequest redactRequest) throws VonageResponseParseException, VonageClientException {
         redactEndpoint.execute(redactRequest);
     }

--- a/src/main/java/com/vonage/client/redact/RedactRequest.java
+++ b/src/main/java/com/vonage/client/redact/RedactRequest.java
@@ -23,7 +23,10 @@ import com.vonage.client.VonageUnexpectedException;
 
 /**
  * Represents a request to the Redact API.
+ *
+ * @deprecated This API will be removed in the next major release.
  */
+@Deprecated
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RedactRequest {
 


### PR DESCRIPTION
The [Redact API](https://developer.vonage.com/api/redact) was never GA's (or even enter Beta stage). This PR deprecates it for clarity, with the aim of removing it in a future release.