### PR TITLE
Allow any object in WhatsappTemplate parameters list

### DIFF
--- a/src/main/java/com/vonage/client/messages/whatsapp/Template.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Template.java
@@ -19,15 +19,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class Template {
 	private final String name;
-	private final List<Map<String, ?>> parameters;
+	private final List<?> parameters;
 
-	Template(String name, List<Map<String, ?>> parameters) {
+	Template(String name, List<?> parameters) {
 		this.name = Objects.requireNonNull(name, "Name cannot be null");
 		this.parameters = parameters;
 	}
@@ -38,7 +37,7 @@ public final class Template {
 	}
 
 	@JsonProperty("parameters")
-	public List<Map<String, ?>> getParameters() {
+	public List<?> getParameters() {
 		return parameters;
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.MessageType;
 
 import java.util.List;
-import java.util.Map;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappTemplateRequest extends WhatsappRequest {
@@ -49,7 +48,7 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 
 	public static final class Builder extends WhatsappRequest.Builder<WhatsappTemplateRequest, Builder> {
 		String name;
-		List<Map<String, ?>> parameters;
+		List<?> parameters;
 		Policy policy = Policy.DETERMINISTIC;
 		String locale = "en_GB";
 
@@ -75,10 +74,10 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 		 * <a href=https://developers.facebook.com/docs/whatsapp/on-premises/reference/messages#message-templates>
 		 * messages parameters documentation</a>.
 		 *
-		 * @param parameters The serializable list of Map objects.
+		 * @param parameters The serializable list of objects.
 		 * @return This builder.
 		 */
-		public Builder parameters(List<Map<String, ?>> parameters) {
+		public Builder parameters(List<?> parameters) {
 			this.parameters = parameters;
 			return this;
 		}

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
@@ -44,15 +44,12 @@ public class WhatsappTemplateRequestTest {
 		String json = WhatsappTemplateRequest.builder()
 				.from("Acme Corp").to("447900000001")
 				.name("verify").locale("en-GB").policy(Policy.DETERMINISTIC)
-				.parameters(Arrays.asList(
-						Collections.singletonMap("key1", "value1"),
-						Collections.singletonMap("key2", "value2")
-				))
+				.parameters(Arrays.asList(Collections.singletonMap("k1", "v1"), "blah"))
 				.build().toJson();
 
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[{\"key1\":\"value1\"},{\"key2\":\"value2\"}]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[{\"k1\":\"v1\"},\"blah\"]}"));
 		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en-GB\"}"));
 	}
 


### PR DESCRIPTION
This PR makes the `parameters` field in `WhatsappTemplateRequest` more permissive.