### PR TITLE
Use Vonage JWT library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [7.0.0]
 - Removed SMS Search API
 - Deprecated Redact client
+- Use `vonage-jwt-jdk:1.0.2` library instead of `nexmo-jwt-jdk:1.0.1`
 - Allow alphanumeric characters for SMS and MMS sender fields in Messages API
 - Made `WhatsappTemplateRequest` parameters more permissive
 - Removed dependency on `commons-io` and `commons-lang3`

--- a/build.gradle
+++ b/build.gradle
@@ -30,14 +30,14 @@ dependencies {
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
     implementation 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.9'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
-    implementation 'com.nexmo:jwt:1.0.1'
+    implementation 'com.vonage:jwt:1.0.2'
 
     testImplementation 'javax.servlet:javax.servlet-api:4.0.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.6.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.springframework:spring-test:5.3.20'
-    testImplementation 'org.springframework:spring-web:5.3.20'
+    testImplementation 'org.springframework:spring-test:5.3.22'
+    testImplementation 'org.springframework:spring-web:5.3.22'
 }
 
 test {

--- a/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
@@ -15,7 +15,7 @@
  */
 package com.vonage.client.auth;
 
-import com.nexmo.jwt.Jwt;
+import com.vonage.jwt.Jwt;
 import org.apache.http.client.methods.RequestBuilder;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/src/main/java/com/vonage/client/verify/BaseRequest.java
+++ b/src/main/java/com/vonage/client/verify/BaseRequest.java
@@ -28,7 +28,6 @@ import java.util.Locale;
  * @since 5.5.0
  */
 public class BaseRequest {
-
     private final String number;
     private Integer length;
     private Locale locale;

--- a/src/main/java/com/vonage/client/verify/BaseResult.java
+++ b/src/main/java/com/vonage/client/verify/BaseResult.java
@@ -19,7 +19,6 @@ package com.vonage.client.verify;
 /**
  * An abstract base class for verification results.
  *
- *
  */
 public abstract class BaseResult {
     /**

--- a/src/main/java/com/vonage/client/verify/CheckEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/CheckEndpoint.java
@@ -25,7 +25,6 @@ import java.io.UnsupportedEncodingException;
 
 class CheckEndpoint extends AbstractMethod<CheckRequest, CheckResponse> {
     private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
-
     private static final String PATH = "/verify/check/json";
 
     CheckEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/verify/ControlEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/ControlEndpoint.java
@@ -25,9 +25,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class ControlEndpoint extends AbstractMethod<ControlRequest, ControlResponse> {
-
     private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
-
     private static final String PATH = "/verify/control/json";
 
     ControlEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/verify/ControlResponse.java
+++ b/src/main/java/com/vonage/client/verify/ControlResponse.java
@@ -34,7 +34,6 @@ public class ControlResponse {
             @JsonProperty("command") VerifyControlCommand command) {
         this.status = status;
         this.command = command;
-        this.errorText = null;
     }
 
     @JsonProperty

--- a/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
+++ b/src/main/java/com/vonage/client/verify/Psd2Endpoint.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 class Psd2Endpoint extends AbstractMethod<Psd2Request, VerifyResponse> {
-
     private static final String PATH = "/verify/psd2/json";
     private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
 

--- a/src/main/java/com/vonage/client/verify/Psd2Request.java
+++ b/src/main/java/com/vonage/client/verify/Psd2Request.java
@@ -29,7 +29,6 @@ import java.util.Locale;
  * @since 5.5.0
  */
 public class Psd2Request extends BaseRequest {
-
     private Double amount;
     private String payee;
     private Workflow workflow;

--- a/src/main/java/com/vonage/client/verify/SearchEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/SearchEndpoint.java
@@ -25,7 +25,6 @@ import java.io.UnsupportedEncodingException;
 
 class SearchEndpoint extends AbstractMethod<SearchRequest, SearchVerifyResponse> {
     private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
-
     private static final String PATH = "/verify/search/json";
 
     SearchEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/verify/SearchVerifyResponseDeserializer.java
+++ b/src/main/java/com/vonage/client/verify/SearchVerifyResponseDeserializer.java
@@ -25,6 +25,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 
 public class SearchVerifyResponseDeserializer extends JsonDeserializer<SearchVerifyResponse> {
+
     @Override
     public SearchVerifyResponse deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         JsonNode node = p.getCodec().readTree(p);

--- a/src/main/java/com/vonage/client/verify/VerifyDetails.java
+++ b/src/main/java/com/vonage/client/verify/VerifyDetails.java
@@ -25,7 +25,6 @@ import java.util.stream.Collectors;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class VerifyDetails {
-
     private String requestId;
     private String accountId;
     private String number;

--- a/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
@@ -26,7 +26,6 @@ import java.io.UnsupportedEncodingException;
 
 class VerifyEndpoint extends AbstractMethod<VerifyRequest, VerifyResponse> {
     private static final Class<?>[] ALLOWED_AUTH_METHODS = {TokenAuthMethod.class};
-
     private static final String PATH = "/verify/json";
 
     VerifyEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/verify/VerifyStatusDeserializer.java
+++ b/src/main/java/com/vonage/client/verify/VerifyStatusDeserializer.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
 
 public class VerifyStatusDeserializer extends JsonDeserializer<VerifyStatus> {
+
     @Override
     public VerifyStatus deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
         // Perform the conversion using parseInt so that potential number format exceptions can be converted into a default


### PR DESCRIPTION
This PR updates the dependency on [nexmo-jwt-jdk](https://github.com/Nexmo/nexmo-jwt-jdk) to use [vonage-jwt-jdk](https://github.com/Vonage/vonage-jwt-jdk).