### PR TITLE
Fix WhatsappTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Removed SMS Search API
 - Deprecated Redact client
 - Use `vonage-jwt-jdk:1.0.2` library instead of `nexmo-jwt-jdk:1.0.1`
+- Ensure `User-Agent` is set in request headers
 - Allow alphanumeric characters for SMS and MMS sender fields in Messages API
 - Fixed incorrect restrictions on `WhatsappTemplateRequest` 
   - Policy is now optional
-  - Default locale is `en`
+  - Default locale is now `en`
   - Locale is now an enum rather than String
   - `parameters` is now `List<String>`
 - Removed dependency on `commons-io` and `commons-lang3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed incorrect restrictions on `WhatsappTemplateRequest` 
   - Policy is now optional
   - Default locale is `en`
+  - Locale is now an enum rather than String
   - `parameters` is now `List<String>`
 - Removed dependency on `commons-io` and `commons-lang3`
 - Ensured User-Agent is set in request headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `vonage-jwt-jdk:1.0.2` library instead of `nexmo-jwt-jdk:1.0.1`
 - Ensure `User-Agent` is set in request headers
 - Allow alphanumeric characters for SMS and MMS sender fields in Messages API
+- `WhatsappRequest` sender must now be an E164 number
 - Fixed incorrect restrictions on `WhatsappTemplateRequest` 
   - Policy is now optional
   - Default locale is now `en`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Deprecated Redact client
 - Use `vonage-jwt-jdk:1.0.2` library instead of `nexmo-jwt-jdk:1.0.1`
 - Allow alphanumeric characters for SMS and MMS sender fields in Messages API
-- Made `WhatsappTemplateRequest` parameters more permissive
+- Fixed incorrect restrictions on `WhatsappTemplateRequest` 
+  - Policy is now optional
+  - Default locale is `en`
+  - `parameters` is now `List<String>`
 - Removed dependency on `commons-io` and `commons-lang3`
 - Ensured User-Agent is set in request headers
 - Added Premium text-to-speech flag in `TalkAction` NCCO

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MessengerAudioRequest extends MessengerRequest {
-	MessagePayload audio;
+	final MessagePayload audio;
 
 	MessengerAudioRequest(Builder builder) {
 		super(builder, MessageType.AUDIO);

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MessengerFileRequest extends MessengerRequest {
-	MessagePayload file;
+	final MessagePayload file;
 
 	MessengerFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MessengerImageRequest extends MessengerRequest {
-	MessagePayload image;
+	final MessagePayload image;
 
 	MessengerImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
@@ -23,7 +23,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class MessengerRequest extends MessageRequest {
-	protected Messenger messenger;
+	protected final Messenger messenger;
 
 	protected MessengerRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.MESSENGER, messageType);

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.internal.Text;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MessengerTextRequest extends MessengerRequest {
-	String text;
+	final String text;
 
 	MessengerTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class MessengerVideoRequest extends MessengerRequest {
-	MessagePayload video;
+	final MessagePayload video;
 
 	MessengerVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -24,7 +24,7 @@ import com.vonage.client.messages.internal.Text;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class SmsTextRequest extends MessageRequest {
-	String text;
+	final String text;
 
 	SmsTextRequest(Builder builder) {
 		super(builder, Channel.SMS, MessageType.TEXT);

--- a/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class ViberImageRequest extends ViberRequest {
-	MessagePayload image;
+	final MessagePayload image;
 
 	ViberImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);

--- a/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
@@ -24,7 +24,7 @@ import com.vonage.client.messages.internal.E164;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class ViberRequest extends MessageRequest {
-	protected ViberService viberService;
+	protected final ViberService viberService;
 
 	protected ViberRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.VIBER, messageType);

--- a/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.internal.Text;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class ViberTextRequest extends ViberRequest {
-	String text;
+	final String text;
 
 	ViberTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);

--- a/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
@@ -1,0 +1,112 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages.whatsapp;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum representing BCP-47 locales supported by WhatsApp.
+ * The values are derived from the "Supported Languages" section of the
+ * <a href=https://developers.facebook.com/docs/whatsapp/api/messages/message-templates>
+ * WhatsApp documentation</a>.
+ *
+ * @since 7.0.0
+ */
+public enum Locale {
+	AFRIKAANS("af"),
+	ALBANIAN("sq"),
+	ARABIC("ar"),
+	AZERBAIJANI("az"),
+	BENGALI("bn"),
+	BULGARIAN("bg"),
+	CATALAN("ca"),
+	CHINESE_CHN("zh_CN"),
+	CHINESE_HKG("zh_HK"),
+	CHINESE_TAI("zh_TW"),
+	CROATIAN("hr"),
+	CZECH("cs"),
+	DANISH("da"),
+	DUTCH("nl"),
+	ENGLISH("en"),
+	ENGLISH_UK("en_GB"),
+	ENGLISH_US("en_US"),
+	ESTONIAN("et"),
+	FILIPINO("fil"),
+	FINNISH("fi"),
+	FRENCH("fr"),
+	GEORGIAN("ka"),
+	GERMAN("de"),
+	GREEK("el"),
+	GUJARATI("gu"),
+	HAUSA("ha"),
+	HEBREW("he"),
+	HINDI("hi"),
+	HUNGARIAN("hu"),
+	INDONESIAN("id"),
+	IRISH("ga"),
+	ITALIAN("it"),
+	JAPANESE("ja"),
+	KANNADA("kn"),
+	KAZAKH("kk"),
+	KINYARWANDA("rw_RW"),
+	KOREAN("ko"),
+	KYRGYZ_KYRGYZSTAN("ky_KG"),
+	LAO("lo"),
+	LATVIAN("lv"),
+	LITHUANIAN("lt"),
+	MACEDONIAN("mk"),
+	MALAY("ms"),
+	MALAYALAM("ml"),
+	MARATHI("mr"),
+	NORWEGIAN("nb"),
+	PERSIAN("fa"),
+	POLISH("pl"),
+	PORTUGUESE_BR("pt_BR"),
+	PORTUGUESE_POR("pt_PT"),
+	PUNJABI("pa"),
+	ROMANIAN("ro"),
+	RUSSIAN("ru"),
+	SERBIAN("sr"),
+	SLOVAK("sk"),
+	SLOVENIAN("sl"),
+	SPANISH("es"),
+	SPANISH_ARG("es_AR"),
+	SPANISH_SPA("es_ES"),
+	SPANISH_MEX("es_MX"),
+	SWAHILI("sw"),
+	SWEDISH("sv"),
+	TAMIL("ta"),
+	TELUGU("te"),
+	THAI("th"),
+	TURKISH("tr"),
+	UKRAINIAN("uk"),
+	URDU("ur"),
+	UZBEK("uz"),
+	VIETNAMESE("vi"),
+	ZULU("zu");
+
+	private final String code;
+
+	Locale(String code) {
+		this.code = code;
+	}
+
+	@JsonValue
+	@Override
+	public String toString() {
+		return code;
+	}
+}

--- a/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Enum representing BCP-47 locales supported by WhatsApp.
  * The values are derived from the "Supported Languages" section of the
  * <a href=https://developers.facebook.com/docs/whatsapp/api/messages/message-templates>
- * WhatsApp documentation</a>.
+ * WhatsApp Message Templates documentation</a>.
  *
  * @since 7.0.0
  */

--- a/src/main/java/com/vonage/client/messages/whatsapp/Template.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Template.java
@@ -23,9 +23,9 @@ import java.util.Objects;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class Template {
 	private final String name;
-	private final List<?> parameters;
+	private final List<String> parameters;
 
-	Template(String name, List<?> parameters) {
+	Template(String name, List<String> parameters) {
 		this.name = Objects.requireNonNull(name, "Name cannot be null");
 		this.parameters = parameters;
 	}
@@ -36,7 +36,7 @@ public final class Template {
 	}
 
 	@JsonProperty("parameters")
-	public List<?> getParameters() {
+	public List<String> getParameters() {
 		return parameters;
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
@@ -17,15 +17,14 @@ package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Objects;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class Whatsapp {
 	private final Policy policy;
-	private final String locale;
+	private final Locale locale;
 
-	private Whatsapp(Policy policy, String locale) {
+	private Whatsapp(Policy policy, Locale locale) {
 		this.policy = policy;
 		this.locale = locale;
 	}
@@ -36,15 +35,12 @@ public final class Whatsapp {
 	}
 
 	@JsonProperty("locale")
-	public String getLocale() {
+	public Locale getLocale() {
 		return locale;
 	}
 
-	static Whatsapp construct(Policy policy, String locale) {
+	static Whatsapp construct(Policy policy, Locale locale) {
 		Objects.requireNonNull(locale, "Locale is required");
-		if (locale.length() < 2) {
-			throw new IllegalArgumentException("Invalid locale");
-		}
 		return new Whatsapp(policy, locale);
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
@@ -17,6 +17,7 @@ package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
@@ -24,12 +25,9 @@ public final class Whatsapp {
 	private final Policy policy;
 	private final String locale;
 
-	Whatsapp(Policy policy, String locale) {
-		this.policy = Objects.requireNonNull(policy, "Policy cannot be null");
-		this.locale = Objects.requireNonNull(locale, "Locale cannot be null");
-		if (locale.length() < 4) {
-			throw new IllegalArgumentException("Invalid locale");
-		}
+	private Whatsapp(Policy policy, String locale) {
+		this.policy = policy;
+		this.locale = locale;
 	}
 
 	@JsonProperty("policy")
@@ -40,5 +38,13 @@ public final class Whatsapp {
 	@JsonProperty("locale")
 	public String getLocale() {
 		return locale;
+	}
+
+	static Whatsapp construct(Policy policy, String locale) {
+		Objects.requireNonNull(locale, "Locale is required");
+		if (locale.length() < 2) {
+			throw new IllegalArgumentException("Invalid locale");
+		}
+		return new Whatsapp(policy, locale);
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
@@ -17,6 +17,7 @@ package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Objects;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
@@ -24,9 +25,9 @@ public final class Whatsapp {
 	private final Policy policy;
 	private final Locale locale;
 
-	private Whatsapp(Policy policy, Locale locale) {
+	Whatsapp(Policy policy, Locale locale) {
 		this.policy = policy;
-		this.locale = locale;
+		this.locale = Objects.requireNonNull(locale, "Locale is required");;
 	}
 
 	@JsonProperty("policy")
@@ -37,10 +38,5 @@ public final class Whatsapp {
 	@JsonProperty("locale")
 	public Locale getLocale() {
 		return locale;
-	}
-
-	static Whatsapp construct(Policy policy, Locale locale) {
-		Objects.requireNonNull(locale, "Locale is required");
-		return new Whatsapp(policy, locale);
 	}
 }

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappAudioRequest extends WhatsappRequest {
-	MessagePayload audio;
+	final MessagePayload audio;
 
 	WhatsappAudioRequest(Builder builder) {
 		super(builder, MessageType.AUDIO);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappCustomRequest extends WhatsappRequest {
-	Map<?, ?> custom;
+	final Map<?, ?> custom;
 
 	WhatsappCustomRequest(Builder builder) {
 		super(builder, MessageType.CUSTOM);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappFileRequest extends WhatsappRequest {
-	MessagePayload file;
+	final MessagePayload file;
 
 	WhatsappFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappImageRequest extends WhatsappRequest {
-	MessagePayload image;
+	final MessagePayload image;
 
 	WhatsappImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
@@ -19,12 +19,19 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.vonage.client.messages.Channel;
 import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.internal.E164;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public abstract class WhatsappRequest extends MessageRequest {
 
 	protected WhatsappRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.WHATSAPP, messageType);
+	}
+
+	@Override
+	protected void validateSenderAndRecipient(String from, String to) throws IllegalArgumentException {
+		this.from = new E164(from).toString();
+		this.to = new E164(to).toString();
 	}
 
 	protected abstract static class Builder<M extends WhatsappRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -28,7 +28,7 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 	WhatsappTemplateRequest(Builder builder) {
 		super(builder, MessageType.TEMPLATE);
 		template = new Template(builder.name, builder.parameters);
-		whatsapp = new Whatsapp(builder.policy, builder.locale);
+		whatsapp = Whatsapp.construct(builder.policy, builder.locale);
 	}
 
 	@JsonProperty("template")
@@ -46,10 +46,9 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 	}
 
 	public static final class Builder extends WhatsappRequest.Builder<WhatsappTemplateRequest, Builder> {
-		String name;
-		List<?> parameters;
-		Policy policy = Policy.DETERMINISTIC;
-		String locale = "en_GB";
+		String name, locale = "en";
+		List<String> parameters;
+		Policy policy;
 
 		Builder() {}
 
@@ -68,23 +67,22 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 
 		/**
 		 * (OPTIONAL)
-		 * The parameters are an array of objects, with the first object being used for {{1}} in the template,
-		 * with the second being {{2}} etc. You can find the full list of supported parameters on WhatsApp's
+		 * The parameters are an array of strings, with the first being substituted for {{1}} in the template,
+		 * the second being {{2}} etc. You can find the full list of supported parameters on WhatsApp's
 		 * <a href=https://developers.facebook.com/docs/whatsapp/on-premises/reference/messages#message-templates>
 		 * messages parameters documentation</a>.
 		 *
-		 * @param parameters The serializable list of objects.
+		 * @param parameters The list of template parameters.
 		 * @return This builder.
 		 */
-		public Builder parameters(List<?> parameters) {
+		public Builder parameters(List<String> parameters) {
 			this.parameters = parameters;
 			return this;
 		}
 
 		/**
-		 * (REQUIRED)
+		 * (OPTIONAL)
 		 * Policy for resolving what language template to use.
-		 * Defaults to {@link Policy#DETERMINISTIC} if not set.
 		 *
 		 * @param policy The policy field.
 		 * @return This builder.
@@ -96,7 +94,9 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 
 		/**
 		 * (REQUIRED)
-		 * The BCP 47 language of the template.
+		 * The BCP 47 language of the template. Defaults to <code>en</code> if not set.
+		 * See <a href=https://developers.facebook.com/docs/whatsapp/api/messages/message-templates>
+		 *     the documentation</a> for supported language options.
 		 * 
 		 * @param locale The BCP-47 locale.
 		 * @return This builder.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -46,8 +46,9 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 	}
 
 	public static final class Builder extends WhatsappRequest.Builder<WhatsappTemplateRequest, Builder> {
-		String name, locale = "en";
+		String name;
 		List<String> parameters;
+		Locale locale = Locale.ENGLISH;
 		Policy policy;
 
 		Builder() {}
@@ -94,14 +95,12 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 
 		/**
 		 * (REQUIRED)
-		 * The BCP 47 language of the template. Defaults to <code>en</code> if not set.
-		 * See <a href=https://developers.facebook.com/docs/whatsapp/api/messages/message-templates>
-		 *     the documentation</a> for supported language options.
+		 * The BCP 47 language of the template. Defaults to {@linkplain Locale#ENGLISH} if not set.
 		 * 
-		 * @param locale The BCP-47 locale.
+		 * @param locale The {@link Locale}.
 		 * @return This builder.
 		 */
-		public Builder locale(String locale) {
+		public Builder locale(Locale locale) {
 			this.locale = locale;
 			return this;
 		}

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -28,7 +28,7 @@ public final class WhatsappTemplateRequest extends WhatsappRequest {
 	WhatsappTemplateRequest(Builder builder) {
 		super(builder, MessageType.TEMPLATE);
 		template = new Template(builder.name, builder.parameters);
-		whatsapp = Whatsapp.construct(builder.policy, builder.locale);
+		whatsapp = new Whatsapp(builder.policy, builder.locale);
 	}
 
 	@JsonProperty("template")

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappTemplateRequest extends WhatsappRequest {
-	Template template;
-	Whatsapp whatsapp;
+	final Template template;
+	final Whatsapp whatsapp;
 
 	WhatsappTemplateRequest(Builder builder) {
 		super(builder, MessageType.TEMPLATE);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.internal.Text;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappTextRequest extends WhatsappRequest {
-	String text;
+	final String text;
 
 	WhatsappTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
@@ -22,7 +22,7 @@ import com.vonage.client.messages.MessageType;
 
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class WhatsappVideoRequest extends WhatsappRequest {
-	MessagePayload video;
+	final MessagePayload video;
 
 	WhatsappVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);

--- a/src/test/java/com/vonage/client/messages/MessagesClientTest.java
+++ b/src/test/java/com/vonage/client/messages/MessagesClientTest.java
@@ -117,7 +117,7 @@ public class MessagesClientTest extends ClientTest<MessagesClient> {
 		assertResponse(WhatsappVideoRequest.builder().url(VIDEO));
 		assertResponse(WhatsappFileRequest.builder().url(FILE));
 		assertResponse(WhatsappCustomRequest.builder().custom(Collections.emptyMap()));
-		assertResponse(WhatsappTemplateRequest.builder().name("fb").locale("en_GB"));
+		assertResponse(WhatsappTemplateRequest.builder().name("fb"));
 	}
 
 	@Test

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequestTest.java
@@ -24,7 +24,7 @@ public class WhatsappAudioRequestTest {
 	public void testSerializeValid() {
 		String url = "file:///path/to/song.mp3";
 		String json = WhatsappAudioRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.url(url).build().toJson();
 		assertTrue(json.contains("\"audio\":{\"url\":\""+url+"\"}"));
 		assertTrue(json.contains("\"message_type\":\"audio\""));

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequestTest.java
@@ -36,7 +36,7 @@ public class WhatsappCustomRequestTest {
 		customObject.put("key3", nestedMap);
 
 		String json = WhatsappCustomRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.custom(customObject).build().toJson();
 
 		assertTrue(json.contains("\"message_type\":\"custom\""));
@@ -47,7 +47,7 @@ public class WhatsappCustomRequestTest {
 	@Test
 	public void testSerializeNoMap() {
 		String json = WhatsappCustomRequest.builder()
-				.from("Acme Corp").to("447900000001").build().toJson();
+				.from("317900000002").to("447900000001").build().toJson();
 
 		assertTrue(json.contains("\"message_type\":\"custom\""));
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
@@ -57,7 +57,7 @@ public class WhatsappCustomRequestTest {
 	@Test
 	public void testSerializeEmptyMap() {
 		String json = WhatsappCustomRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.custom(new HashMap<>(0)).build().toJson();
 
 		assertTrue(json.contains("\"message_type\":\"custom\""));

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappFileRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappFileRequestTest.java
@@ -24,7 +24,7 @@ public class WhatsappFileRequestTest {
 	public void testSerializeValid() {
 		String url = "file:///path/to/attachment.zip", caption = "Srs bzns";
 		String json = WhatsappFileRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.url(url).caption(caption)
 				.build().toJson();
 		assertTrue(json.contains("\"file\":{\"url\":\""+url+"\",\"caption\":\""+caption+"\"}"));

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappImageRequestTest.java
@@ -24,7 +24,7 @@ public class WhatsappImageRequestTest {
 	public void testSerializeValid() {
 		String url = "file:///path/to/picture.jpg", caption = "Cute kittens";
 		String json = WhatsappImageRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.url(url).caption(caption)
 				.build().toJson();
 		assertTrue(json.contains("\"image\":{\"url\":\""+url+"\",\"caption\":\""+caption+"\"}"));
@@ -46,7 +46,7 @@ public class WhatsappImageRequestTest {
 	@Test
 	public void testConstructCaptionLength() {
 		WhatsappImageRequest.Builder builder = WhatsappImageRequest.builder()
-				.url("file:///path/to/picture.png").from("amy").to("447900000001");
+				.url("file:///path/to/picture.png").from("317900000002").to("447900000001");
 
 		assertEquals(12, builder.build().getTo().length());
 

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
@@ -26,7 +26,7 @@ public class WhatsappTemplateRequestTest {
 	public void testSerializeMandatoryFields() {
 		String json = WhatsappTemplateRequest.builder()
 				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB")
+				.name("verify").locale("en-US")
 				.build().toJson();
 
 		assertTrue(json.contains("\"from\":\"Acme Corp\""));
@@ -34,7 +34,7 @@ public class WhatsappTemplateRequestTest {
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
 		assertTrue(json.contains("\"template\":{\"name\":\"verify\"}"));
-		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en-GB\"}"));
+		assertTrue(json.contains("\"whatsapp\":{\"locale\":\"en-US\"}"));
 	}
 
 	@Test
@@ -42,74 +42,61 @@ public class WhatsappTemplateRequestTest {
 		String json = WhatsappTemplateRequest.builder()
 				.from("Acme Corp").to("447900000001")
 				.name("verify").locale("en-GB").policy(Policy.DETERMINISTIC)
-				.parameters(Arrays.asList(Collections.singletonMap("k1", "v1"), "blah"))
+				.parameters(Arrays.asList("{k1}", "blah"))
 				.build().toJson();
 
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[{\"k1\":\"v1\"},\"blah\"]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"{k1}\",\"blah\"]}"));
 		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en-GB\"}"));
 	}
 
 	@Test(expected = NullPointerException.class)
-	public void testConstructNullPolicy() {
-		WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB").policy(null)
-				.build();
-	}
-
-	@Test(expected = NullPointerException.class)
 	public void testConstructNoName() {
-		WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.locale("en-GB").build();
+		WhatsappTemplateRequest.builder().from("Acme Corp").to("447900000001").build();
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testConstructNullLocale() {
 		WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").locale(null).build();
+				.locale(null).name("verify")
+				.from("Acme Corp").to("447900000001").build();
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testConstructEmptyLocale() {
+	public void testConstructInvalidLocale() {
 		WhatsappTemplateRequest.builder()
-				.locale("").name("verify").from("Acme Corp")
-				.to("447900000001").build();
+				.locale(" ").name("verify")
+				.from("Acme Corp").to("447900000001").build();
 	}
 
 	@Test
 	public void testSerializeEmptyParameters() {
 		String json = WhatsappTemplateRequest.builder()
 				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB")
 				.parameters(Collections.emptyList())
-				.build().toJson();
+				.name("verify").build().toJson();
 
 		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[]}"));
 	}
 
 	@Test
-	public void testSerializeParametersEmptyMap() {
+	public void testSerializeParametersEmptyString() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB")
-				.parameters(Collections.singletonList(Collections.emptyMap()))
+				.from("Acme Corp").to("447900000001").name("verify")
+				.parameters(Collections.singletonList(""))
 				.build().toJson();
 
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[{}]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"\"]}"));
 	}
 
 	@Test
-	public void testSerializeParametersMultipleEmptyMaps() {
+	public void testSerializeParametersMultipleStrings() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB")
-				.parameters(Arrays.asList(Collections.emptyMap(), Collections.emptyMap()))
+				.from("Acme Corp").to("447900000001").name("verify")
+				.parameters(Arrays.asList("{1}","{2}"))
 				.build().toJson();
 
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[{},{}]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"{1}\",\"{2}\"]}"));
 	}
 }

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
@@ -22,52 +22,53 @@ import static org.junit.Assert.*;
 
 public class WhatsappTemplateRequestTest {
 
+	private static final String FROM = "12124567890", TO = "447900000001", NAME = "verify";
+
 	@Test
 	public void testSerializeMandatoryFields() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").build().toJson();
+				.from(FROM).to(TO).name(NAME).build().toJson();
 
-		assertTrue(json.contains("\"from\":\"Acme Corp\""));
-		assertTrue(json.contains("\"to\":\"447900000001\""));
+		assertTrue(json.contains("\"from\":\""+FROM+"\""));
+		assertTrue(json.contains("\"to\":\""+TO+"\""));
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\"}"));
+		assertTrue(json.contains("\"template\":{\"name\":\""+NAME+"\"}"));
 		assertTrue(json.contains("\"whatsapp\":{\"locale\":\"en\"}"));
 	}
 
 	@Test
 	public void testSerializeAllFields() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001").name("verify")
+				.from(FROM).to(TO).name("verify")
 				.locale(Locale.ENGLISH_UK).policy(Policy.DETERMINISTIC)
 				.parameters(Arrays.asList("{k1}", "blah"))
 				.build().toJson();
 
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"{k1}\",\"blah\"]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\""+NAME+"\",\"parameters\":[\"{k1}\",\"blah\"]}"));
 		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en_GB\"}"));
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testConstructNoName() {
-		WhatsappTemplateRequest.builder().from("Acme Corp").to("447900000001").build();
+		WhatsappTemplateRequest.builder().from(FROM).to(TO).build();
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void testConstructNullLocale() {
 		WhatsappTemplateRequest.builder()
-				.locale(null).name("verify")
-				.from("Acme Corp").to("447900000001").build();
+				.locale(null).name(NAME)
+				.from(FROM).to(TO).build();
 	}
 
 	@Test
 	public void testSerializeEmptyParameters() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from(FROM).to(TO)
 				.parameters(Collections.emptyList())
-				.name("verify").build().toJson();
+				.name(NAME).build().toJson();
 
 		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[]}"));
 	}
@@ -75,20 +76,20 @@ public class WhatsappTemplateRequestTest {
 	@Test
 	public void testSerializeParametersEmptyString() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001").name("verify")
+				.from(FROM).to(TO).name(NAME)
 				.parameters(Collections.singletonList(""))
 				.build().toJson();
 
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"\"]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\""+NAME+"\",\"parameters\":[\"\"]}"));
 	}
 
 	@Test
 	public void testSerializeParametersMultipleStrings() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001").name("verify")
+				.from(FROM).to(TO).name(NAME)
 				.parameters(Arrays.asList("{1}","{2}"))
 				.build().toJson();
 
-		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"{1}\",\"{2}\"]}"));
+		assertTrue(json.contains("\"template\":{\"name\":\""+NAME+"\",\"parameters\":[\"{1}\",\"{2}\"]}"));
 	}
 }

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
@@ -26,29 +26,28 @@ public class WhatsappTemplateRequestTest {
 	public void testSerializeMandatoryFields() {
 		String json = WhatsappTemplateRequest.builder()
 				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-US")
-				.build().toJson();
+				.name("verify").build().toJson();
 
 		assertTrue(json.contains("\"from\":\"Acme Corp\""));
 		assertTrue(json.contains("\"to\":\"447900000001\""));
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
 		assertTrue(json.contains("\"template\":{\"name\":\"verify\"}"));
-		assertTrue(json.contains("\"whatsapp\":{\"locale\":\"en-US\"}"));
+		assertTrue(json.contains("\"whatsapp\":{\"locale\":\"en\"}"));
 	}
 
 	@Test
 	public void testSerializeAllFields() {
 		String json = WhatsappTemplateRequest.builder()
-				.from("Acme Corp").to("447900000001")
-				.name("verify").locale("en-GB").policy(Policy.DETERMINISTIC)
+				.from("Acme Corp").to("447900000001").name("verify")
+				.locale(Locale.ENGLISH_UK).policy(Policy.DETERMINISTIC)
 				.parameters(Arrays.asList("{k1}", "blah"))
 				.build().toJson();
 
 		assertTrue(json.contains("\"channel\":\"whatsapp\""));
 		assertTrue(json.contains("\"message_type\":\"template\""));
 		assertTrue(json.contains("\"template\":{\"name\":\"verify\",\"parameters\":[\"{k1}\",\"blah\"]}"));
-		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en-GB\"}"));
+		assertTrue(json.contains("\"whatsapp\":{\"policy\":\"deterministic\",\"locale\":\"en_GB\"}"));
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -60,13 +59,6 @@ public class WhatsappTemplateRequestTest {
 	public void testConstructNullLocale() {
 		WhatsappTemplateRequest.builder()
 				.locale(null).name("verify")
-				.from("Acme Corp").to("447900000001").build();
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testConstructInvalidLocale() {
-		WhatsappTemplateRequest.builder()
-				.locale(" ").name("verify")
 				.from("Acme Corp").to("447900000001").build();
 	}
 

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTextRequestTest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.messages.whatsapp;
 
 import org.junit.Test;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -41,7 +42,7 @@ public class WhatsappTextRequestTest {
 				.build();
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test(expected = NullPointerException.class)
 	public void testConstructNoSender() {
 		WhatsappTextRequest.builder()
 				.to("317900000002")

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequestTest.java
@@ -24,7 +24,7 @@ public class WhatsappVideoRequestTest {
 	public void testSerializeValid() {
 		String url = "file:///path/to/clip.mp4", caption = "Cute kittens";
 		String json = WhatsappVideoRequest.builder()
-				.from("Acme Corp").to("447900000001")
+				.from("317900000002").to("447900000001")
 				.url(url).caption(caption)
 				.build().toJson();
 		assertTrue(json.contains("\"video\":{\"url\":\""+url+"\",\"caption\":\""+caption+"\"}"));


### PR DESCRIPTION
This PR fixes some inaccuracies / inconsistencies in `WhatsappTemplateRequest`. Namely, it changes `parameters` to be a `List<String>` instead of `List<?>`, makes `policy` optional and adds enumerations for supported locales. It also restricts the sender field to numbers.
