### PR TITLE
Fix parsing MessageResponseException with no body

### DIFF
--- a/src/main/java/com/vonage/client/messages/MessageResponseException.java
+++ b/src/main/java/com/vonage/client/messages/MessageResponseException.java
@@ -126,6 +126,9 @@ public final class MessageResponseException extends VonageClientException {
 	 * @return An instance of this class with all known fields populated from the JSON payload, if present.
 	 */
 	public static MessageResponseException fromJson(String json) {
+		if (json == null || json.length() < 2) {
+			return new MessageResponseException();
+		}
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			return mapper.readValue(json, MessageResponseException.class);

--- a/src/main/java/com/vonage/client/messages/SendMessageEndpoint.java
+++ b/src/main/java/com/vonage/client/messages/SendMessageEndpoint.java
@@ -23,7 +23,9 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.stream.Collectors;
 
 class SendMessageEndpoint extends AbstractMethod<MessageRequest, MessageResponse> {
@@ -62,6 +64,9 @@ class SendMessageEndpoint extends AbstractMethod<MessageRequest, MessageResponse
 				json = br.lines().collect(Collectors.joining(System.lineSeparator()));
 			}
 			MessageResponseException mrx = MessageResponseException.fromJson(json);
+			if (mrx.title == null) {
+				mrx.title = response.getStatusLine().getReasonPhrase();
+			}
 			mrx.statusCode = statusCode;
 			throw mrx;
 		}

--- a/src/test/java/com/vonage/client/messages/SendMessageEndpointTest.java
+++ b/src/test/java/com/vonage/client/messages/SendMessageEndpointTest.java
@@ -21,11 +21,11 @@ import com.vonage.client.common.HttpMethod;
 import com.vonage.client.messages.sms.SmsTextRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.util.UUID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 public class SendMessageEndpointTest {
 	final SendMessageEndpoint endpoint = new SendMessageEndpoint(new HttpWrapper());
@@ -60,7 +60,7 @@ public class SendMessageEndpointTest {
 	}
 
 	@Test
-	public void testParseResponse422() throws Exception {
+	public void testParseResponseFull() throws Exception {
 		final int statusCode = 422;
 		final String json = "{\n" +
 				"  \"type\": \"https://developer.nexmo.com/api-errors/messages-olympus#1120\",\n" +
@@ -75,6 +75,21 @@ public class SendMessageEndpointTest {
 		}
 		catch (MessageResponseException mrx) {
 			MessageResponseException expected = MessageResponseException.fromJson(json);
+			expected.statusCode = statusCode;
+			assertEquals(expected, mrx);
+		}
+	}
+
+	@Test
+	public void testParseResponseNoBody() throws Exception {
+		final int statusCode = 429;
+		try {
+			endpoint.parseResponse(TestUtils.makeJsonHttpResponse(statusCode, ""));
+			fail("Expected "+MessageResponseException.class.getName());
+		}
+		catch (MessageResponseException mrx) {
+			MessageResponseException expected = MessageResponseException.fromJson("");
+			expected.title = "OK";  // This is what TestUtils.makeJsonHttpResponse sets it to
 			expected.statusCode = statusCode;
 			assertEquals(expected, mrx);
 		}


### PR DESCRIPTION
This PR fixes parsing error responses from the Messages v1 API ([as reported on the Community Slack](https://vonage-community.slack.com/archives/C9H152ATW/p1660931679229029)) where the response doesn't contain JSON body, leading to `VonageUnexpectedException` being thrown as the response is attempted to be parsed into the `MessageResponseException` object.