### PR TITLE
Update Verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.1.0]
+- Fixed parsing `MessageResponseException` when entity body is empty
+- Added toggle for using Messages API Sandbox to `MessagesClient`
+- Deprecated `request_type` in `VerifyRequest`
+- Fixed incorrect `Content-Type` header in `VerifyEndpoint`
+- Added `network` field to `VerifyResponse`
+
 ## [7.0.0]
 - Removed SMS Search API
 - Deprecated Redact client

--- a/src/main/java/com/vonage/client/messages/MessagesClient.java
+++ b/src/main/java/com/vonage/client/messages/MessagesClient.java
@@ -24,7 +24,7 @@ public class MessagesClient {
 	final SendMessageEndpoint sendMessage;
 
 	/**
-	 * Create a new SmsClient.
+	 * Create a new MessagesClient.
 	 * @param httpWrapper Http Wrapper used to create a Message requests
 	 */
 	public MessagesClient(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/messages/package-info.java
+++ b/src/main/java/com/vonage/client/messages/package-info.java
@@ -41,6 +41,11 @@
  * When calling {@link com.vonage.client.messages.MessagesClient#sendMessage(com.vonage.client.messages.MessageRequest)},
  * it is advised that the user catches {@link com.vonage.client.messages.MessageResponseException} to handle cases
  * where the message was not sent successfully.
+ * <br>
+ *
+ * Note that the <a href=https://dashboard.nexmo.com/messages/sandbox>Messages Sandbox</a> uses
+ * a different URL. Users can easily switch to this endpoint by calling
+ * {@link com.vonage.client.messages.MessagesClient#useSandboxEndpoint()}.
  *
  * @since 6.5.0
  */

--- a/src/main/java/com/vonage/client/verify/BaseRequest.java
+++ b/src/main/java/com/vonage/client/verify/BaseRequest.java
@@ -27,7 +27,7 @@ import java.util.Locale;
  * Base request class for {@link VerifyRequest} and {@link Psd2Request}
  * @since 5.5.0
  */
-public class BaseRequest {
+public abstract class BaseRequest {
     private final String number;
     private Integer length;
     private Locale locale;

--- a/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
+++ b/src/main/java/com/vonage/client/verify/VerifyEndpoint.java
@@ -20,7 +20,6 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-import org.apache.http.message.BasicNameValuePair;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
@@ -41,43 +40,9 @@ class VerifyEndpoint extends AbstractMethod<VerifyRequest, VerifyResponse> {
     public RequestBuilder makeRequest(VerifyRequest request) throws UnsupportedEncodingException {
         RequestBuilder result = RequestBuilder
                 .post(httpWrapper.getHttpConfig().getApiBaseUri() + PATH)
-                .setHeader("Content-Type", "application/json")
-                .setHeader("Accept", "application/json")
-                .addParameter("number", request.getNumber())
-                .addParameter("brand", request.getBrand());
-
-        if (request.getFrom() != null) {
-            result.addParameter("sender_id", request.getFrom());
-        }
-
-        if (request.getLength() != null && request.getLength() > 0) {
-            result.addParameter("code_length", Integer.toString(request.getLength()));
-        }
-
-        if (request.getLocale() != null) {
-            result.addParameter(new BasicNameValuePair("lg", (request.getDashedLocale())));
-        }
-
-        if (request.getType() != null) {
-            result.addParameter("require_type", request.getType().toString());
-        }
-
-        if (request.getCountry() != null) {
-            result.addParameter("country", request.getCountry());
-        }
-
-        if (request.getPinExpiry() != null) {
-            result.addParameter("pin_expiry", request.getPinExpiry().toString());
-        }
-
-        if (request.getNextEventWait() != null) {
-            result.addParameter("next_event_wait", request.getNextEventWait().toString());
-        }
-
-        if (request.getWorkflow() != null) {
-            result.addParameter("workflow_id", String.valueOf(request.getWorkflow().getId()));
-        }
-
+                .setHeader("Content-Type", "application/x-www-form-urlencoded")
+                .setHeader("Accept", "application/json");
+        request.addParams(result);
         return result;
     }
 

--- a/src/main/java/com/vonage/client/verify/VerifyRequest.java
+++ b/src/main/java/com/vonage/client/verify/VerifyRequest.java
@@ -16,6 +16,8 @@
 package com.vonage.client.verify;
 
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.message.BasicNameValuePair;
 import java.util.Locale;
 
 /**
@@ -26,7 +28,6 @@ public class VerifyRequest extends BaseRequest {
     private String brand;
     private String from;
     private Workflow workflow;
-
 
     public VerifyRequest(Builder builder) {
         super(builder.number, builder.length, builder.locale, builder.country, builder.pinExpiry, builder.nextEventWait);
@@ -43,16 +44,16 @@ public class VerifyRequest extends BaseRequest {
         return this.brand;
     }
 
-
     /**
      * @return the type of network the verification will be restricted to. This value has no effect unless it has been
      * enabled by contacting {@code support@nexmo.com}.
+     *
+     * @deprecated This is no longer used and will be removed in the next major release.
      */
+    @Deprecated
     public LineType getType() {
         return type;
     }
-
-
 
     /**
      * @return the short alphanumeric string to specify the SenderID for SMS sent by Verify, or {@code null} if one was
@@ -63,7 +64,6 @@ public class VerifyRequest extends BaseRequest {
     public String getFrom() {
         return from;
     }
-
 
     /**
      * Types of phone line to be specified for {@link VerifyRequest#type}. This option is not generally available. It will
@@ -79,6 +79,32 @@ public class VerifyRequest extends BaseRequest {
      */
     public Workflow getWorkflow() {
         return workflow;
+    }
+
+    protected void addParams(RequestBuilder result) {
+        result.addParameter("number", getNumber()).addParameter("brand", getBrand());
+
+        if (getFrom() != null) {
+            result.addParameter("sender_id", getFrom());
+        }
+        if (getLength() != null && getLength() > 0) {
+            result.addParameter("code_length", Integer.toString(getLength()));
+        }
+        if (getLocale() != null) {
+            result.addParameter(new BasicNameValuePair("lg", getDashedLocale()));
+        }
+        if (getCountry() != null) {
+            result.addParameter("country", getCountry());
+        }
+        if (getPinExpiry() != null) {
+            result.addParameter("pin_expiry", getPinExpiry().toString());
+        }
+        if (getNextEventWait() != null) {
+            result.addParameter("next_event_wait", getNextEventWait().toString());
+        }
+        if (getWorkflow() != null) {
+            result.addParameter("workflow_id", String.valueOf(getWorkflow().getId()));
+        }
     }
 
     /**
@@ -136,17 +162,11 @@ public class VerifyRequest extends BaseRequest {
      * @since 5.5.0
      */
     public static class Builder {
-
-        private String brand;
-        private String senderId;
+        private String brand, senderId, number, country;
+        private Integer length, pinExpiry, nextEventWait;
         private LineType type;
         private Workflow workflow;
-        private String number;
         private Locale locale;
-        private Integer length;
-        private Integer pinExpiry;
-        private Integer nextEventWait;
-        private String country;
 
         /**
          * @param number (required) The recipient's phone number in <a href="https://en.wikipedia.org/wiki/E.164">E.164</a>
@@ -172,8 +192,12 @@ public class VerifyRequest extends BaseRequest {
         /**
          * @param type the type of network the verification will be restricted to. This value has no effect unless it has been
          *        enabled by contacting {@code support@nexmo.com}.
+         *
+         * @deprecated This is no longer used and will be removed in the next major release.
+         *
          * @return {@link Builder}
          **/
+        @Deprecated
         public Builder type(LineType type) {
             this.type = type;
             return this;

--- a/src/main/java/com/vonage/client/verify/VerifyRequest.java
+++ b/src/main/java/com/vonage/client/verify/VerifyRequest.java
@@ -31,7 +31,9 @@ public class VerifyRequest extends BaseRequest {
 
     public VerifyRequest(Builder builder) {
         super(builder.number, builder.length, builder.locale, builder.country, builder.pinExpiry, builder.nextEventWait);
-        brand = builder.brand;
+        if ((brand = builder.brand) != null && brand.length() > 18) {
+            throw new IllegalArgumentException("Brand '"+brand+"' is longer than 18 characters");
+        }
         from = builder.senderId;
         type = builder.type;
         workflow = builder.workflow;

--- a/src/main/java/com/vonage/client/verify/VerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/VerifyResponse.java
@@ -24,9 +24,8 @@ import com.vonage.client.VonageUnexpectedException;
 import java.io.IOException;
 
 public class VerifyResponse {
-    private String requestId;
     private VerifyStatus status;
-    private String errorText;
+    private String requestId, errorText, network;
 
     @JsonCreator
     public VerifyResponse(@JsonProperty(value = "status", required = true) VerifyStatus status) {
@@ -45,6 +44,11 @@ public class VerifyResponse {
     @JsonProperty("error_text")
     public String getErrorText() {
         return errorText;
+    }
+
+    @JsonProperty("network")
+    public String getNetwork() {
+        return network;
     }
 
     public static VerifyResponse fromJson(String json) {

--- a/src/test/java/com/vonage/client/verify/VerifyEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyEndpointTest.java
@@ -20,14 +20,13 @@ import com.vonage.client.HttpWrapper;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import java.util.List;
 import java.util.Locale;
-import static org.junit.Assert.assertEquals;
 
 public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
-
     private VerifyRequest verifyRequest;
 
     @Before
@@ -38,7 +37,6 @@ public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
                 .senderId("Your friend")
                 .length(4)
                 .locale(new Locale("en", "gb"))
-                .type(VerifyRequest.LineType.MOBILE)
                 .build();
     }
 
@@ -52,7 +50,6 @@ public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
         assertContainsParam(params, "sender_id", "Your friend");
         assertContainsParam(params, "code_length", "4");
         assertContainsParam(params, "lg", "en-gb");
-        assertContainsParam(params, "require_type", "MOBILE");
     }
 
     @Test
@@ -95,7 +92,7 @@ public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
         assertContainsParam(params, "code_length", "6");
         assertContainsParam(params, "sender_id", "VERIFICATION");
         assertContainsParam(params, "lg", "en-gb");
-        assertContainsParam(params, "require_type", "LANDLINE");
+        assertParamMissing(params, "require_type");
         assertContainsParam(params, "country", "GB");
         assertContainsParam(params, "pin_expiry", "60");
         assertContainsParam(params, "next_event_wait", "90");
@@ -106,7 +103,7 @@ public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
     public void testDefaultUri() throws Exception {
         RequestBuilder builder = method.makeRequest(verifyRequest);
         assertEquals("POST", builder.getMethod());
-        assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
+        assertEquals(ContentType.APPLICATION_FORM_URLENCODED.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
         assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
         assertEquals("https://api.nexmo.com/verify/json",
                 builder.build().getURI().toString()

--- a/src/test/java/com/vonage/client/verify/VerifyEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyEndpointTest.java
@@ -99,6 +99,11 @@ public class VerifyEndpointTest extends MethodTest<VerifyEndpoint> {
         assertContainsParam(params, "workflow_id", "3");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidBrand() {
+        VerifyRequest.builder("4477990090090", "A very looooooooooooooong brand name").build();
+    }
+
     @Test
     public void testDefaultUri() throws Exception {
         RequestBuilder builder = method.makeRequest(verifyRequest);

--- a/src/test/java/com/vonage/client/verify/VerifyResponseTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyResponseTest.java
@@ -1,0 +1,51 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.verify;
+
+import com.vonage.client.VonageResponseParseException;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+public class VerifyResponseTest {
+
+	@Test
+	public void testFromJsonAllFields() {
+		String
+			errorText = "The number you are trying to verify is blacklisted for verification",
+			network = "25503", requestId = "abcdef0123456789abcdef0123456789",
+			json = "{\"status\":\"7\",\"error_text\":" + "\""+errorText+"\"," + "\"network\":\""+network+"\", \"request_id\":\""+requestId+"\"}";
+
+		VerifyResponse response = VerifyResponse.fromJson(json);
+		assertEquals(VerifyStatus.NUMBER_BARRED, response.getStatus());
+		assertEquals(7, response.getStatus().getVerifyStatus());
+		assertEquals(errorText, response.getErrorText());
+		assertEquals(requestId, response.getRequestId());
+		assertEquals(network, response.getNetwork());
+	}
+
+	@Test(expected = VonageResponseParseException.class)
+	public void testFromJsonEmptyThrows() {
+		VerifyResponse.fromJson("{}");
+	}
+
+	@Test
+	public void testFromJsonStatusOnly() {
+		VerifyResponse response = VerifyResponse.fromJson("{\"status\":\"4\"}");
+		assertEquals(VerifyStatus.INVALID_CREDENTIALS, response.getStatus());
+		assertEquals(4, response.getStatus().getVerifyStatus());
+	}
+
+}


### PR DESCRIPTION
Seems like the `require_type` parameter is no longer used as it's missing from [the spec](https://developer.vonage.com/api/verify#requests). This PR also fixes the incorrect `Content-Type` header for Verify requests (see #405).