### PR TITLE
Fix CreateSessionResponse parsing

### DIFF
--- a/src/main/java/com/vonage/client/video/CreateSessionEndpoint.java
+++ b/src/main/java/com/vonage/client/video/CreateSessionEndpoint.java
@@ -21,7 +21,6 @@ import com.vonage.client.auth.JWTAuthMethod;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
-
 import java.io.IOException;
 
 class CreateSessionEndpoint extends AbstractMethod<CreateSessionRequest, CreateSessionResponse> {

--- a/src/main/java/com/vonage/client/video/CreateSessionResponse.java
+++ b/src/main/java/com/vonage/client/video/CreateSessionResponse.java
@@ -70,7 +70,12 @@ public class CreateSessionResponse {
 	public static CreateSessionResponse fromJson(String json) {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
-			return mapper.readValue(json, CreateSessionResponse.class);
+			CreateSessionResponse[] array = mapper.readValue(json, CreateSessionResponse[].class);
+			if (array == null || array.length == 0) {
+				return new CreateSessionResponse();
+			}
+			assert array.length == 1;
+			return array[0];
 		}
 		catch (IOException ex) {
 			throw new VonageUnexpectedException("Failed to produce CreateSessionResponse from json.", ex);

--- a/src/test/java/com/vonage/client/video/CreateSessionResponseTest.java
+++ b/src/test/java/com/vonage/client/video/CreateSessionResponseTest.java
@@ -35,12 +35,12 @@ public class CreateSessionResponseTest {
 			createDt = "abc123",
 			mediaServerUrl = "ftp://myserver.data/resource";
 
-		CreateSessionResponse response = CreateSessionResponse.fromJson("{\n" +
+		CreateSessionResponse response = CreateSessionResponse.fromJson("[{\n" +
 				"\"session_id\":\""+sessionId+"\",\n" +
 				"\"application_id\":\""+applicationId+"\",\n" +
 				"\"create_dt\":\""+createDt+"\",\n" +
 				"\"media_server_url\":\""+mediaServerUrl+"\"\n" +
-		"}");
+		"}]");
 
 		assertEquals(sessionId, response.getSessionId());
 		assertEquals(applicationId, response.getApplicationId());
@@ -55,7 +55,7 @@ public class CreateSessionResponseTest {
 
 	@Test
 	public void testFromJsonEmpty() {
-		CreateSessionResponse response = CreateSessionResponse.fromJson("{}");
+		CreateSessionResponse response = CreateSessionResponse.fromJson("[{}]");
 		assertNull(response.getApplicationId());
 		assertNull(response.getSessionId());
 		assertNull(response.getMediaServerUrl());

--- a/src/test/java/com/vonage/client/video/VideoClientTest.java
+++ b/src/test/java/com/vonage/client/video/VideoClientTest.java
@@ -127,12 +127,12 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 		CreateSessionRequest request = CreateSessionRequest.builder().build();
 		String msUrl = "http://example.com/resource",
 			createDt = "abc123",
-			responseJson = "{\n" +
+			responseJson = "[{\n" +
 				"    \"session_id\": \""+sessionId+"\",\n" +
 				"    \"application_id\": \""+ applicationId +"\",\n" +
 				"    \"create_dt\": \""+createDt+"\",\n" +
 				"    \"media_server_url\": \""+msUrl+"\"\n" +
-				"}";
+				"}]";
 
 		stubResponse(responseJson);
 		CreateSessionResponse response = client.createSession(request);


### PR DESCRIPTION
[The endpoint for creating video sessions returns a response wrapped in an array](https://developer.vonage.com/api/video#session-create). This PR fixes the parsing failing due to expecting a non-wrapped JSON response instead.
