### PR TITLE
Don't use GitHub Packages & fix bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,10 @@
 [bumpversion]
 commit = True
-tag = True
+tag = False
 current_version = v7.1.0
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize = 
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
+serialize =
+	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:file:build.gradle]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,9 +43,7 @@ jobs:
           signingPassword: ${{secrets.SIGNING_PASSWORD}}
           OSS_USERNAME: ${{secrets.OSS_USERNAME}}
           OSS_PASSWORD: ${{secrets.OSS_PASSWORD}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
           OSS_USERNAME=$OSS_USERNAME OSS_PASSWORD=$OSS_PASSWORD
           signingKey=$signingKey signingPassword=$signingPassword
-          GITHUB_TOKEN=$GITHUB_TOKEN GITHUB_ACTOR=$GITHUB_ACTOR
           gradle publish --info

--- a/README.md
+++ b/README.md
@@ -427,8 +427,7 @@ SecretResponse response = client.getAccountClient().getSecret(API_KEY, SECRET_ID
 
 The Vonage Video API (formerly OpenTok) is currently in beta. You can try it out by using a beta version.
 Usage instructions can be found on the [8.x-beta branch](https://github.com/Vonage/vonage-java-sdk/tree/8.x-beta#video-api).
-The dependency artifact resides on [GitHub Packages](https://github.com/orgs/Vonage/packages?repo_name=vonage-java-sdk),
-not Maven Central. See the [Releases page](https://github.com/Vonage/vonage-java-sdk/releases) for more information.
+See the [Releases page](https://github.com/Vonage/vonage-java-sdk/releases) for more information.
 
 
 ### Custom HTTP Configuration

--- a/build.gradle
+++ b/build.gradle
@@ -136,22 +136,9 @@ publishing {
         maven {
             def releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
             def snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-            def githubRepoUrl = uri("https://maven.pkg.github.com/$githubPath")
-            def userEnv, passEnv
-
-            if (version.endsWith('beta')) {
-                userEnv = "GITHUB_ACTOR"
-                passEnv = "GITHUB_TOKEN"
-                url = githubRepoUrl
-            }
-            else {
-                userEnv = "OSS_USERNAME"
-                passEnv = "OSS_PASSWORD"
-                url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            }
-
-            credentials.username(System.getenv(userEnv))
-            credentials.password(System.getenv(passEnv))
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials.username(System.getenv("OSS_USERNAME"))
+            credentials.password(System.getenv("OSS_PASSWORD"))
         }
     }
 }


### PR DESCRIPTION
Given [the current deficiency in GitHub Packages](https://github.com/orgs/community/discussions/26634), releasing preview versions to GitHub Packages instead of Maven Central is unsuitable. This PR reverts the change made in #419. It also fixes the bump2version configuration, which currently does not support non-final release versions, making beta versioning impossible. It disables tagging to fix the issue where duplicate tags are pushed after a release.