### PR TITLE
Automate release to Maven Central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Maven Repository
+name: Publish to Nexus
 on:
   release:
     types: [published]
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Install bump2version
         run: |
           python -m pip install --upgrade pip
@@ -23,6 +23,7 @@ jobs:
           pip install bump2version
       - name: Bump Version
         run: bump2version --new-version ${{ github.event.release.tag_name }} patch &&
+             git tag ${{ github.event.release.tag_name }} -f &&
              git push && git push --tags origin --force
       - name: Setup Java
         uses: actions/setup-java@v3
@@ -46,4 +47,4 @@ jobs:
         run: |
           OSS_USERNAME=$OSS_USERNAME OSS_PASSWORD=$OSS_PASSWORD
           signingKey=$signingKey signingPassword=$signingPassword
-          gradle publish --info
+          gradle publishToSonatype closeAndReleaseSonatypeStagingRepository --info

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <img src="https://developer.nexmo.com/assets/images/Vonage_Nexmo.svg" height="48px" alt="Nexmo is now known as Vonage" />
 
-You can use this Java Server SDK to add [Vonage APIs](https://developer.nexmo.com/api) to your application. To use this, you'll
-need a Vonage account. Sign up [for free at nexmo.com][signup].
+You can use this Java Server SDK to add [Vonage APIs](https://developer.vonage.com/api) to your application. To use this, you'll
+need a Vonage account. Sign up [for free at vonage.com][signup].
 
 * [Installation](#installation)
 * [Usage](#usage)

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ plugins {
     id 'jacoco'
     id 'signing'
     id 'maven-publish'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
 group = "com.vonage"
@@ -132,13 +133,13 @@ publishing {
             }
         }
     }
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-            def snapshotsRepoUrl = uri("https://oss.sonatype.org/content/repositories/snapshots/")
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials.username(System.getenv("OSS_USERNAME"))
-            credentials.password(System.getenv("OSS_PASSWORD"))
+        sonatype {
+            username = System.getenv("OSS_USERNAME")
+            password = System.getenv("OSS_PASSWORD")
         }
     }
 }


### PR DESCRIPTION
This PR uses the [Gradle Nexus Publish plugin](https://github.com/gradle-nexus/publish-plugin/) to simplify releasing to Maven Central, by not requiring manual login to the Nexus repository manager web interface to perform the release.
