### PR TITLE
Manually invoke bump2version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,21 +10,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.release.target_commitish }}
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.11
-      - name: Install bump2version
-        run: |
-          python -m pip install --upgrade pip
-          git config --global user.email "44278943+NexmoDev@users.noreply.github.com"
-          git config --global user.name "NexmoDev"
-          git config --global github.token ${{ secrets.GITHUB_TOKEN }}
-          pip install bump2version
-      - name: Bump Version
-        run: bump2version --new-version ${{ github.event.release.tag_name }} patch &&
-             git tag ${{ github.event.release.tag_name }} -f &&
-             git push --force && git push --tags origin --force
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [7.1.1]
+- Bumped Jackson version to 2.14
+
 ## [7.1.0]
 - Fixed parsing `MessageResponseException` when entity body is empty
 - Added toggle for using Messages API Sandbox to `MessagesClient`

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -1,0 +1,9 @@
+if [ "$1" = "" ]
+then
+  echo "Usage: $0 <new version>"
+  exit 1
+fi
+
+python -m pip install --upgrade pip
+pip install bump2version
+bump2version --new-version "$1" patch


### PR DESCRIPTION
This is a workaround for the branch protection rules not working as intended, where the NexmoDev user can't bypass PR requirements when creating a release. Instead, version bumping will be performed manually, along with changelog updates. This then necessitates a review prior to creating a release, which is probably a good thing.
