### PR TITLE
Add client token generation for Video API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [8.0.0-beta2]
+- Added token generation capability to `VideoClient`
 - Added varargs for `SetStreamLayoutRequest`
 - `listArchives` endpoint takes as input `ListArchivesRequest` using builder pattern
 - Simplified `muteSession` and `muteStream` invocation

--- a/README.md
+++ b/README.md
@@ -445,6 +445,15 @@ VonageClient client = VonageClient.builder()
     .build();
 ```
 
+### Generate a token
+
+Generate a signed JWT to pass to the Vonage Video Client:
+```java
+String jwt = client.getVideoClient().generateToken(SESSION_ID,
+    TokenOptions.builder().expiryLength(Duration.ofHours(6)).build()
+);
+```
+
 ### Create a new Session
 
 Generate a new video session:

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -41,8 +41,8 @@ import java.nio.file.Paths;
  * Construct an instance of this object with one or more {@link AuthMethod}s (providing all the authentication methods
  * for the APIs you wish to use), and then call {@link #getVoiceClient()} to obtain a client for the Vonage Voice API.
  * <p>
- * Currently this object only constructs and provides access to {@link VoiceClient}. In the future it will manage
- * clients for all of the Vonage APIs.
+ * Currently, this object only constructs and provides access to {@link VoiceClient}. In the future it will manage
+ * clients for all Vonage APIs.
  */
 public class VonageClient {
     private final HttpWrapper httpWrapper;
@@ -124,6 +124,7 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Messages client.
      *
      * @return The Messages API client.
      * @since 6.5.0
@@ -132,6 +133,12 @@ public class VonageClient {
         return messages;
     }
 
+    /**
+     * Returns the Video client.
+     *
+     * @return The Video API client.
+     * @since 8.0.0-beta1
+     */
     public VideoClient getVideoClient() {
         return video;
     }
@@ -183,7 +190,7 @@ public class VonageClient {
         /**
          * @param httpClient Custom implementation of {@link HttpClient}.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder httpClient(HttpClient httpClient) {
             this.httpClient = httpClient;
@@ -195,7 +202,7 @@ public class VonageClient {
          *
          * @param applicationId Used to identify each application.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder applicationId(String applicationId) {
             this.applicationId = applicationId;
@@ -208,7 +215,7 @@ public class VonageClient {
          *
          * @param apiKey The API Key found in the dashboard for your account.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder apiKey(String apiKey) {
             this.apiKey = apiKey;
@@ -220,7 +227,7 @@ public class VonageClient {
          *
          * @param apiSecret The API Secret found in the dashboard for your account.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder apiSecret(String apiSecret) {
             this.apiSecret = apiSecret;
@@ -232,7 +239,7 @@ public class VonageClient {
          *
          * @param signatureSecret The Signature Secret found in the dashboard for your account.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder signatureSecret(String signatureSecret) {
             this.signatureSecret = signatureSecret;
@@ -243,7 +250,7 @@ public class VonageClient {
          *
          * @param hashType The hashing strategy for signature keys.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder hashType(HashUtil.HashType hashType) {
             this.hashType = hashType;
@@ -256,7 +263,7 @@ public class VonageClient {
          *
          * @param privateKeyContents The contents of your private key used for JWT generation.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder privateKeyContents(byte[] privateKeyContents) {
             this.privateKeyContents = privateKeyContents;
@@ -269,7 +276,7 @@ public class VonageClient {
          *
          * @param privateKeyContents The contents of your private key used for JWT generation.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          */
         public Builder privateKeyContents(String privateKeyContents) {
             return privateKeyContents(privateKeyContents.getBytes());
@@ -281,7 +288,7 @@ public class VonageClient {
          *
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          *
          * @throws VonageUnableToReadPrivateKeyException if the private key could not be read from the file system.
          */
@@ -299,7 +306,7 @@ public class VonageClient {
          *
          * @param privateKeyPath The path to your private key used for JWT generation.
          *
-         * @return The {@link Builder} to keep building.
+         * @return This builder.
          *
          * @throws VonageUnableToReadPrivateKeyException if the private key could not be read from the file system.
          */

--- a/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
@@ -28,8 +28,7 @@ public class JWTAuthMethod implements AuthMethod {
     private final String applicationId;
 
     public JWTAuthMethod(final String applicationId, final byte[] privateKey) {
-        jwt = Jwt.builder()
-                .applicationId(this.applicationId = applicationId)
+        jwt = Jwt.builder().applicationId(this.applicationId = applicationId)
                 .privateKeyContents(new String(privateKey)).build();
     }
 
@@ -45,11 +44,19 @@ public class JWTAuthMethod implements AuthMethod {
         return applicationId;
     }
 
+    /**
+     * Convenience method for creating custom JWTs.
+     *
+     * @return A new {@link Jwt.Builder} with the application ID and private key already set.
+     * @since 8.0.0-beta2
+     */
+    public Jwt.Builder newJwt() {
+        return Jwt.builder().applicationId(applicationId).privateKeyContents(jwt.getPrivateKeyContents());
+    }
+
     @Override
     public RequestBuilder apply(RequestBuilder request) {
-        String token = jwt.generate();
-        request.setHeader("Authorization", "Bearer " + token);
-        return request;
+        return request.setHeader("Authorization", "Bearer " + generateToken());
     }
 
     @Override

--- a/src/main/java/com/vonage/client/video/Role.java
+++ b/src/main/java/com/vonage/client/video/Role.java
@@ -1,0 +1,42 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.video;
+
+/**
+ * Defines values for the role parameter of the {@link TokenOptions.Builder#role(Role role)} method.
+ */
+public enum Role {
+	/**
+	 * A subscriber can only subscribe to streams.
+	 */
+	SUBSCRIBER,
+	/**
+	 * A publisher can publish streams, subscribe to streams, and signal. (This is the default value if you do not set a
+	 * role by calling the {@link TokenOptions.Builder#role(Role role)} method.
+	 */
+	PUBLISHER,
+	/**
+	 * In addition to the privileges granted to a publisher, a moderator can perform moderation functions, such as
+	 * forcing clients to disconnect, to stop publishing streams, or to mute audio in published streams. See the
+	 * <a href="https://tokbox.com/developer/guides/moderation/">Moderation developer guide</a>.
+	 */
+	MODERATOR;
+
+	@Override
+	public String toString() {
+		return super.toString().toLowerCase();
+	}
+}

--- a/src/main/java/com/vonage/client/video/TokenOptions.java
+++ b/src/main/java/com/vonage/client/video/TokenOptions.java
@@ -1,0 +1,191 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.video;
+
+import com.vonage.jwt.Jwt;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Defines values for the <code>options</code> parameter of the
+ * {@link VideoClient#generateToken(String sessionId, TokenOptions tokenOptions)} method.
+ */
+public class TokenOptions {
+    private final Role role;
+    private final Duration ttl;
+    private final String data;
+    private final List<String> initialLayoutClassList;
+
+    private TokenOptions(Builder builder) {
+        role = Objects.requireNonNull(builder.role, "Role cannot be null.");
+
+        ttl = Objects.requireNonNull(builder.ttl, "Time-to-Live cannot be null.");
+        if (ttl.toMillis() > Duration.ofDays(30).toMillis()) {
+            throw new IllegalArgumentException("Time-to-Live cannot exceed 30 days.");
+        }
+
+        // default value of null means to omit the key "connection_data" from the token
+        if ((data = builder.data) != null && data.length() > 1000) {
+            throw new IllegalArgumentException("Connection data cannot exceed 1000 characters.");
+        }
+
+        // default value of null means to omit the key "initialLayoutClassList" from the token
+        initialLayoutClassList = builder.initialLayoutClassList;
+    }
+
+    protected void addClaims(Jwt.Builder jwt) {
+        jwt.expiresAt(ZonedDateTime.now().plus(ttl));
+        jwt.addClaim("role", role);
+        if (data != null) {
+            jwt.addClaim("connection_data", data);
+        }
+        if (initialLayoutClassList != null) {
+            jwt.addClaim("initial_layout_class_list", String.join(" ", initialLayoutClassList));
+        }
+    }
+
+    /**
+     * Returns the role assigned to the token.
+     *
+     * @return The role, as an enum.
+     * @see Builder#role(Role)
+    */
+    public Role getRole() {
+        return role;
+    }
+
+    /**
+     * Returns the time-to-live for the JWT.
+     *
+     * @return The TTL duration.
+     * @see Builder#expiryLength(Duration) 
+    */
+    public Duration getExpiryLength() {
+        return ttl;
+    }
+
+    /**
+     * Returns the connection metadata assigned to the token.
+     *
+     * @return The connection data, as a string.
+     * @see Builder#data(String) 
+     */
+    public String getData() {
+        return data;
+    }
+
+    /**
+     * Returns the initial layout class list for streams published by the client using this token.
+     *
+     * @return The initial layout classes, as a List of strings.
+     * @see Builder#initialLayoutClassList(List) 
+    */
+    public List<String> getInitialLayoutClassList() {
+        return initialLayoutClassList;
+    }
+
+    /**
+     * Entry point for constructing an instance of TokenOptions.
+     *
+     * @return A new Builder.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Use this class to create a TokenOptions object.
+     */
+    public static class Builder {
+        private Role role = Role.PUBLISHER;
+        private Duration ttl = Duration.ofHours(24);
+        private String data;
+        private List<String> initialLayoutClassList;
+
+        Builder() {}
+
+        /**
+         * Sets the role for the token. Each role defines a set of permissions granted to the token.
+         *
+         * @param role The role for the token. Valid values are defined in the Role class:
+         * <ul>
+         *   <li> <code>SUBSCRIBER</code> &mdash; A subscriber can only subscribe to streams.</li>
+         *
+         *   <li> <code>PUBLISHER</code> &mdash; A publisher can publish streams, subscribe to
+         *      streams, and signal. (This is the default value if you do not specify a role.)</li>
+         *
+         *   <li> <code>MODERATOR</code> &mdash; In addition to the privileges granted to a
+         *     publisher, a moderator can perform moderation functions, such as forcing clients to
+         *     disconnect, to stop publishing streams, or to mute audio in published streams. See the
+         *     <a href="https://tokbox.com/developer/guides/moderation/">Moderation developer guide</a>.
+         *     </li>
+         * </ul>
+         */
+        public Builder role(Role role) {
+            this.role = role;
+            return this;
+        }
+
+         /**
+         * Sets the expiration time for the token.
+         *
+         * @param ttl The expiration length (time-to-live) The maximum duration is 30 days. Default is 24 hours.
+         */
+        public Builder expiryLength(Duration ttl) {
+            this.ttl = ttl;
+            return this;
+        }
+
+         /**
+         * A string containing connection metadata describing the end-user. For example, you
+         * can pass the user ID, name, or other data describing the end-user. The length of the
+         * string is limited to 1000 characters. This data cannot be updated once it is set.
+         *
+         * @param data The connection metadata.
+         */
+        public Builder data(String data) throws IllegalArgumentException {
+            this.data = data;
+            return this;
+        }
+
+        /**
+        * A List of class names (strings) to be used as the initial layout classes
+        * for streams published by the client. Layout classes are used in customizing the layout
+        * of videos in
+        * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/">live streaming
+        * broadcasts</a> and
+        * <a href="https://tokbox.com/developer/guides/archiving/layout-control.html">composed
+        * archives</a>. 
+        *
+        * @param initialLayoutClassList The initial layout class list.
+        */
+        public Builder initialLayoutClassList (List<String> initialLayoutClassList) {
+            this.initialLayoutClassList = initialLayoutClassList;
+            return this;
+        }
+
+        /**
+         * Builds the TokenOptions object.
+         *
+         * @return A new TokenOptions instance with this builder's properties.
+         */
+        public TokenOptions build() {
+            return new TokenOptions(this);
+        }
+    }
+}

--- a/src/test/java/com/vonage/client/video/TokenOptionsTest.java
+++ b/src/test/java/com/vonage/client/video/TokenOptionsTest.java
@@ -1,0 +1,90 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.video;
+
+import com.vonage.jwt.Jwt;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.*;
+
+public class TokenOptionsTest {
+	final String applicationId = UUID.randomUUID().toString();
+	final String privateKeyContents = "blah";
+
+	Jwt buildJwtWithClaims(TokenOptions options) {
+		Jwt.Builder jwtBuilder = Jwt.builder().applicationId(applicationId).privateKeyContents(privateKeyContents);
+		options.addClaims(jwtBuilder);
+		return jwtBuilder.build();
+	}
+
+	@Test
+	public void testAllValidOptions() {
+		String data = String.join("", Collections.nCopies(100, "myConnData"));
+		assertEquals(1000, data.length());
+		Duration ttl = Duration.ofDays(30).minusMillis(1);
+		List<String> layoutClassList = Arrays.asList("fill", "min");
+		Role role = Role.MODERATOR;
+
+		TokenOptions options = TokenOptions.builder()
+			.initialLayoutClassList(layoutClassList)
+			.data(data).expiryLength(ttl).role(role).build();
+
+		Jwt jwt = buildJwtWithClaims(options);
+
+		ZonedDateTime expiresAt = jwt.getExpiresAt();
+		assertFalse(expiresAt.isAfter(ZonedDateTime.now().plus(ttl)));
+		assertTrue(expiresAt.minus(ttl).isBefore(ZonedDateTime.now().plusSeconds(1)));
+
+		Map<String, ?> claims = jwt.getClaims();
+		assertEquals(4, claims.size());
+		assertEquals(data, claims.get("connection_data"));
+		assertEquals(String.join(" ", layoutClassList), claims.get("initial_layout_class_list"));
+		assertEquals(role, claims.get("role"));
+	}
+
+	@Test
+	public void testMandatoryParameters() {
+		TokenOptions options = TokenOptions.builder().build();
+
+		assertEquals(Role.PUBLISHER, options.getRole());
+		assertEquals(Duration.ofDays(1), options.getExpiryLength());
+		assertNull(options.getInitialLayoutClassList());
+		assertNull(options.getData());
+
+		Jwt jwt = buildJwtWithClaims(options);
+
+		Map<String, ?> claims = jwt.getClaims();
+		assertEquals(2, claims.size());
+		assertEquals("publisher", claims.get("role").toString());
+		assertNull(claims.get("connection_data"));
+		assertNull(claims.get("initial_layout_class_list"));
+	}
+
+	@Test
+	public void testInvalidParameters() {
+		assertThrows(NullPointerException.class, () -> TokenOptions.builder().role(null).build());
+		assertThrows(NullPointerException.class, () -> TokenOptions.builder().expiryLength(null).build());
+
+		Duration longTtl = Duration.ofDays(30).plusMillis(1);
+		assertThrows(IllegalArgumentException.class, () -> TokenOptions.builder().expiryLength(longTtl).build());
+
+		String data1001 = new String(new char[1001]).replace("\0", "d");
+		assertEquals(1001, data1001.length());
+		assertThrows(IllegalArgumentException.class, () -> TokenOptions.builder().data(data1001).build());
+	}
+}

--- a/src/test/java/com/vonage/client/video/VideoClientTest.java
+++ b/src/test/java/com/vonage/client/video/VideoClientTest.java
@@ -332,4 +332,14 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 		stubArchiveJsonAndAssertEquals(() -> client.createArchive(request));
 		stubArchiveJsonAndAssertThrows(() -> client.createArchive(null));
 	}
+
+	@Test
+	public void testGenerateToken() throws Exception {
+		String token = client.generateToken(sessionId, null);
+		assertTrue(token.length() > 100);
+		TokenOptions options = TokenOptions.builder().build();
+		token = client.generateToken(sessionId, options);
+		assertTrue(token.length() > 100);
+		assertThrows(IllegalArgumentException.class, () -> client.generateToken(null, options));
+	}
 }


### PR DESCRIPTION
This PR adds the missing token generation capabilities to the SDK, which is required for the Video integration. Users call the `VideoClient#generateToken(String, TokenOptions)` method to get a new signed JWT for a given session with the desired options.
Implementation-wise, this piggybacks on the `JWTAuthMethod`, which uses the [`com.vonage:jwt` library](https://github.com/Vonage/vonage-jwt-jdk).
