### PR TITLE
[VIDEO] Fix token generation & endpoints

### DIFF
--- a/src/main/java/com/vonage/client/video/DeleteArchiveEndpoint.java
+++ b/src/main/java/com/vonage/client/video/DeleteArchiveEndpoint.java
@@ -17,9 +17,11 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class DeleteArchiveEndpoint extends AbstractMethod<String, Void> {
@@ -44,7 +46,9 @@ class DeleteArchiveEndpoint extends AbstractMethod<String, Void> {
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 204) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/ForceDisconnectEndpoint.java
+++ b/src/main/java/com/vonage/client/video/ForceDisconnectEndpoint.java
@@ -46,7 +46,7 @@ class ForceDisconnectEndpoint extends AbstractMethod<ForceDisconnectRequestWrapp
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		if (response.getStatusLine().getStatusCode() != 200) {
+		if (response.getStatusLine().getStatusCode() != 204) {
 			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
 		}
 		return null;

--- a/src/main/java/com/vonage/client/video/ForceDisconnectEndpoint.java
+++ b/src/main/java/com/vonage/client/video/ForceDisconnectEndpoint.java
@@ -17,9 +17,11 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class ForceDisconnectEndpoint extends AbstractMethod<ForceDisconnectRequestWrapper, Void> {
@@ -44,7 +46,9 @@ class ForceDisconnectEndpoint extends AbstractMethod<ForceDisconnectRequestWrapp
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/MuteSessionEndpoint.java
+++ b/src/main/java/com/vonage/client/video/MuteSessionEndpoint.java
@@ -17,14 +17,16 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
-class MuteSessionEndpoint extends AbstractMethod<MuteSessionRequest, ProjectDetails> {
+class MuteSessionEndpoint extends AbstractMethod<MuteSessionRequest, Void> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 	private static final String PATH = "/v2/project/%s/session/%s/mute";
 
@@ -48,7 +50,10 @@ class MuteSessionEndpoint extends AbstractMethod<MuteSessionRequest, ProjectDeta
 	}
 
 	@Override
-	public ProjectDetails parseResponse(HttpResponse response) throws IOException {
-		return ProjectDetails.fromJson(basicResponseHandler.handleResponse(response));
+	public Void parseResponse(HttpResponse response) throws IOException {
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/MuteStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/video/MuteStreamEndpoint.java
@@ -17,12 +17,14 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
-class MuteStreamEndpoint extends AbstractMethod<MuteStreamRequestWrapper, ProjectDetails> {
+class MuteStreamEndpoint extends AbstractMethod<MuteStreamRequestWrapper, Void> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 	private static final String PATH = "/v2/project/%s/session/%s/stream/%s/mute";
 
@@ -44,7 +46,10 @@ class MuteStreamEndpoint extends AbstractMethod<MuteStreamRequestWrapper, Projec
 	}
 
 	@Override
-	public ProjectDetails parseResponse(HttpResponse response) throws IOException {
-		return ProjectDetails.fromJson(basicResponseHandler.handleResponse(response));
+	public Void parseResponse(HttpResponse response) throws IOException {
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/PatchArchiveStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/video/PatchArchiveStreamEndpoint.java
@@ -17,11 +17,13 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class PatchArchiveStreamEndpoint extends AbstractMethod<PatchArchiveStreamRequest, Void> {
@@ -48,7 +50,9 @@ class PatchArchiveStreamEndpoint extends AbstractMethod<PatchArchiveStreamReques
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/PatchArchiveStreamEndpoint.java
+++ b/src/main/java/com/vonage/client/video/PatchArchiveStreamEndpoint.java
@@ -50,7 +50,7 @@ class PatchArchiveStreamEndpoint extends AbstractMethod<PatchArchiveStreamReques
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		if (response.getStatusLine().getStatusCode() != 200) {
+		if (response.getStatusLine().getStatusCode() != 204) {
 			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
 		}
 		return null;

--- a/src/main/java/com/vonage/client/video/ProjectDetails.java
+++ b/src/main/java/com/vonage/client/video/ProjectDetails.java
@@ -21,8 +21,7 @@ import com.vonage.client.VonageUnexpectedException;
 import java.io.IOException;
 
 /**
- * Represents properties of a video project,
- * typically returned as a response for muting sessions or streams.
+ * Represents properties of a video project.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ProjectDetails {
@@ -76,6 +75,9 @@ public class ProjectDetails {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ProjectDetails fromJson(String json) {
+		if (json == null || json.trim().isEmpty()) {
+			return new ProjectDetails();
+		}
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			return mapper.readValue(json, ProjectDetails.class);

--- a/src/main/java/com/vonage/client/video/Role.java
+++ b/src/main/java/com/vonage/client/video/Role.java
@@ -37,6 +37,6 @@ public enum Role {
 
 	@Override
 	public String toString() {
-		return super.toString().toLowerCase();
+		return name().toLowerCase();
 	}
 }

--- a/src/main/java/com/vonage/client/video/SetArchiveLayoutEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SetArchiveLayoutEndpoint.java
@@ -17,11 +17,13 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class SetArchiveLayoutEndpoint extends AbstractMethod<SetArchiveLayoutRequestWrapper, Void> {
@@ -48,7 +50,9 @@ class SetArchiveLayoutEndpoint extends AbstractMethod<SetArchiveLayoutRequestWra
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/SetStreamLayoutEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SetStreamLayoutEndpoint.java
@@ -17,11 +17,13 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class SetStreamLayoutEndpoint extends AbstractMethod<SetStreamLayoutRequest, Void> {
@@ -48,7 +50,9 @@ class SetStreamLayoutEndpoint extends AbstractMethod<SetStreamLayoutRequest, Voi
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/SignalAllEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SignalAllEndpoint.java
@@ -17,11 +17,13 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
-import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class SignalAllEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
@@ -48,7 +50,9 @@ class SignalAllEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/SignalAllEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SignalAllEndpoint.java
@@ -50,7 +50,7 @@ class SignalAllEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		if (response.getStatusLine().getStatusCode() != 200) {
+		if (response.getStatusLine().getStatusCode() != 204) {
 			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
 		}
 		return null;

--- a/src/main/java/com/vonage/client/video/SignalEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SignalEndpoint.java
@@ -50,7 +50,7 @@ class SignalEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		if (response.getStatusLine().getStatusCode() != 200) {
+		if (response.getStatusLine().getStatusCode() != 204) {
 			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
 		}
 		return null;

--- a/src/main/java/com/vonage/client/video/SignalEndpoint.java
+++ b/src/main/java/com/vonage/client/video/SignalEndpoint.java
@@ -17,11 +17,13 @@ package com.vonage.client.video;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.JWTAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 
 class SignalEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
@@ -48,7 +50,9 @@ class SignalEndpoint extends AbstractMethod<SignalRequestWrapper, Void> {
 
 	@Override
 	public Void parseResponse(HttpResponse response) throws IOException {
-		basicResponseHandler.handleResponse(response);
+		if (response.getStatusLine().getStatusCode() != 200) {
+			throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
+		}
 		return null;
 	}
 }

--- a/src/main/java/com/vonage/client/video/SignalRequest.java
+++ b/src/main/java/com/vonage/client/video/SignalRequest.java
@@ -69,8 +69,7 @@ public class SignalRequest {
 	}
 	
 	public static class Builder {
-		private String type;
-		private String data;
+		private String type, data;
 	
 		Builder() {}
 	

--- a/src/main/java/com/vonage/client/video/TokenOptions.java
+++ b/src/main/java/com/vonage/client/video/TokenOptions.java
@@ -50,7 +50,7 @@ public class TokenOptions {
 
     protected void addClaims(Jwt.Builder jwt) {
         jwt.expiresAt(ZonedDateTime.now().plus(ttl));
-        jwt.addClaim("role", role);
+        jwt.addClaim("role", role.toString());
         if (data != null) {
             jwt.addClaim("connection_data", data);
         }

--- a/src/main/java/com/vonage/client/video/VideoClient.java
+++ b/src/main/java/com/vonage/client/video/VideoClient.java
@@ -224,10 +224,9 @@ public class VideoClient {
 	 *
 	 * @param sessionId The session ID.
 	 * @param streamId ID of the stream to mute.
-	 * @return The project details.
 	 */
-	public ProjectDetails muteStream(String sessionId, String streamId) {
-		return muteStream.execute(new MuteStreamRequestWrapper(
+	public void muteStream(String sessionId, String streamId) {
+		muteStream.execute(new MuteStreamRequestWrapper(
 				validateSessionId(sessionId),
 				validateStreamId(streamId)
 		));
@@ -248,11 +247,9 @@ public class VideoClient {
 	 * @param excludedStreamIds (OPTIONAL) The stream IDs for streams that should not be muted.
 	 * If you omit this, all streams in the session will be muted. This only applies when the "active" property is set
 	 * {@code true}. When the "active" property is set to {@code false}, it is ignored.
-	 *
-	 * @return Metadata about the video project.
 	 */
-	public ProjectDetails muteSession(String sessionId, boolean active, Collection<String> excludedStreamIds) {
-		return muteSession.execute(new MuteSessionRequest(
+	public void muteSession(String sessionId, boolean active, Collection<String> excludedStreamIds) {
+		muteSession.execute(new MuteSessionRequest(
 				validateSessionId(sessionId),
 				active,
 				excludedStreamIds
@@ -275,11 +272,10 @@ public class VideoClient {
 	 * If you omit this, all streams in the session will be muted. This only applies when the "active" property is set
 	 * {@code true}. When the "active" property is set to {@code false}, it is ignored.
 	 *
-	 * @return Metadata about the video project.
 	 * @see #muteSession(String, boolean, Collection)
 	 */
-	public ProjectDetails muteSession(String sessionId, boolean active, String... excludedStreamIds) {
-		return muteSession(sessionId, active,
+	public void muteSession(String sessionId, boolean active, String... excludedStreamIds) {
+		muteSession(sessionId, active,
 				excludedStreamIds != null && excludedStreamIds.length > 0 ?
 					Arrays.asList(excludedStreamIds) : null
 		);
@@ -424,7 +420,7 @@ public class VideoClient {
 		options.addClaims(jwtBuilder);
 		return jwtBuilder
 				.addClaim("session_id", validateSessionId(sessionId))
-				.addClaim("nonce", new Random().nextInt())
+			    .addClaim("nonce", new Random().nextInt())
 				.issuedAt(ZonedDateTime.now())
 				.build().generate();
 	}

--- a/src/main/java/com/vonage/client/video/VideoClient.java
+++ b/src/main/java/com/vonage/client/video/VideoClient.java
@@ -23,7 +23,6 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
 import java.util.function.Supplier;
 
 /**
@@ -420,7 +419,7 @@ public class VideoClient {
 		options.addClaims(jwtBuilder);
 		return jwtBuilder
 				.addClaim("session_id", validateSessionId(sessionId))
-			    .addClaim("nonce", new Random().nextInt())
+			    .addClaim("scope", "session.connect")
 				.issuedAt(ZonedDateTime.now())
 				.build().generate();
 	}

--- a/src/test/java/com/vonage/client/ClientTest.java
+++ b/src/test/java/com/vonage/client/ClientTest.java
@@ -21,12 +21,14 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
+import org.apache.http.client.HttpResponseException;
 import org.apache.http.client.methods.HttpUriRequest;
 import static org.junit.Assert.assertThrows;
 import org.junit.function.ThrowingRunnable;
 import static org.mockito.Mockito.*;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.function.Supplier;
 
 public abstract class ClientTest<T> {
     protected HttpWrapper wrapper;
@@ -78,6 +80,16 @@ public abstract class ClientTest<T> {
         invocation.run();
     }
 
+    protected <R> R stubResponseWithResult(int statusCode, String response, Supplier<? extends R> invocation) throws Exception {
+        stubResponse(statusCode, response);
+        return invocation.get();
+    }
+
+    protected <R> R stubResponseWithResult(String response, Supplier<? extends R> invocation) throws Exception {
+        stubResponse(response);
+        return invocation.get();
+    }
+
     protected void stubResponseAndAssertThrows(int statusCode, ThrowingRunnable invocation,
                                                Class<? extends Exception> exceptionClass) throws Exception {
         stubResponse(statusCode);
@@ -94,5 +106,36 @@ public abstract class ClientTest<T> {
                                                Class<? extends Exception> exceptionClass) throws Exception {
         stubResponse(statusCode, response);
         assertThrows(exceptionClass, invocation);
+    }
+
+    protected void stubResponseAndAssertThrowsHttpResponseException(int statusCode, String response,
+                                                                    ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(statusCode, response, invocation, HttpResponseException.class);
+    }
+
+    protected void stubResponseAndAssertThrowsIAX(int statusCode, ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(statusCode, invocation, IllegalArgumentException.class);
+    }
+
+    protected void stubResponseAndAssertThrowsIAX(ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrowsIAX(200, invocation);
+    }
+
+    protected void stubResponseAndAssertThrowsIAX(String response, ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(response, invocation, IllegalArgumentException.class);
+    }
+
+    protected void stubResponseAndAssertThrowsNPE(ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(200, invocation, NullPointerException.class);
+    }
+
+    protected void stubResponseAndAssertThrowsBadRequestException(int statusCode, String response,
+                                                                  ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(statusCode, response, invocation, VonageBadRequestException.class);
+    }
+
+    protected void stubResponseAndAssertThrowsResponseParseException(int statusCode, String response,
+                                                                  ThrowingRunnable invocation) throws Exception {
+        stubResponseAndAssertThrows(statusCode, response, invocation, VonageResponseParseException.class);
     }
 }

--- a/src/test/java/com/vonage/client/TestUtils.java
+++ b/src/test/java/com/vonage/client/TestUtils.java
@@ -15,6 +15,9 @@
  */
 package com.vonage.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.logging.LoggingUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
@@ -23,18 +26,15 @@ import org.apache.http.client.HttpResponseException;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import static org.junit.Assert.fail;
 import org.mockito.MockedStatic;
+import static org.mockito.Mockito.mockStatic;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mockStatic;
+import java.util.*;
 
 public class TestUtils {
 
@@ -102,6 +102,20 @@ public class TestUtils {
             fail("A 429 response should raise a HttpResponseException");
         } catch (HttpResponseException e) {
             // This is expected
+        }
+    }
+
+    public static Map<String, String> decodeTokenBody(String jwt) {
+        String[] parts = jwt.split("\\.");
+        if (parts.length < 2 || parts.length > 3) {
+            throw new IllegalArgumentException("Invalid JWT: "+jwt);
+        }
+        String claims = new String(Base64.getDecoder().decode(parts[1]));
+        try {
+            return new ObjectMapper().readValue(claims, new TypeReference<LinkedHashMap<String, String>>(){});
+        }
+        catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Could not decode "+claims, ex);
         }
     }
 }

--- a/src/test/java/com/vonage/client/video/TokenOptionsTest.java
+++ b/src/test/java/com/vonage/client/video/TokenOptionsTest.java
@@ -54,7 +54,7 @@ public class TokenOptionsTest {
 		assertEquals(4, claims.size());
 		assertEquals(data, claims.get("connection_data"));
 		assertEquals(String.join(" ", layoutClassList), claims.get("initial_layout_class_list"));
-		assertEquals(role, claims.get("role"));
+		assertEquals(role.toString(), claims.get("role"));
 	}
 
 	@Test

--- a/src/test/java/com/vonage/client/video/VideoClientTest.java
+++ b/src/test/java/com/vonage/client/video/VideoClientTest.java
@@ -88,23 +88,6 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 		assertArchiveEqualsExpectedJson(archives.get(0));
 	}
 
-	void stubMuteResponseAndAssertEquals(Supplier<ProjectDetails> invocation) throws Exception {
-		String responseJson = "{\n" +
-				"  \"applicationId\": \"78d335fa-323d-0114-9c3d-d6f0d48968cf\",\n" +
-				"  \"status\": \"ACTIVE\",\n" +
-				"  \"name\": \"Joe Montana\",\n" +
-				"  \"environment\": \"standard\",\n" +
-				"  \"createdAt\": 1414642898000\n" +
-				"}";
-		stubResponse(responseJson);
-		ProjectDetails response = invocation.get();
-		assertEquals("78d335fa-323d-0114-9c3d-d6f0d48968cf", response.getApplicationId());
-		assertEquals(ProjectStatus.ACTIVE, response.getStatus());
-		assertEquals("Joe Montana", response.getName());
-		assertEquals(ProjectEnvironment.STANDARD, response.getEnvironment());
-		assertEquals(1414642898000L, response.getCreatedAt().longValue());
-	}
-
 	void stubResponseAndAssertThrowsIAX(int statusCode, ThrowingRunnable invocation) throws Exception {
 		stubResponseAndAssertThrows(statusCode, invocation, IllegalArgumentException.class);
 	}
@@ -250,7 +233,7 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 
 	@Test
 	public void testMuteStream() throws Exception {
-		stubMuteResponseAndAssertEquals(() -> client.muteStream(sessionId, streamId));
+		stubResponseAndRun(() -> client.muteStream(sessionId, streamId));
 		stubResponseAndAssertThrowsIAX(() -> client.muteStream(null, streamId));
 		stubResponseAndAssertThrowsIAX(() -> client.muteStream(sessionId, null));
 	}
@@ -266,13 +249,13 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 				emptyStreamIdsArr = {},
 				singleStreamIdArr = {streamId};
 
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, true));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, false, nullStreamIdsCol));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, true, nullStreamIdsArr));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, true, emptyStreamIdsCol));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, false, emptyStreamIdsArr));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, true, singleStreamIdCol));
-		stubMuteResponseAndAssertEquals(() -> client.muteSession(sessionId, false, singleStreamIdArr));
+		stubResponseAndRun(() -> client.muteSession(sessionId, true));
+		stubResponseAndRun(() -> client.muteSession(sessionId, false, nullStreamIdsCol));
+		stubResponseAndRun(() -> client.muteSession(sessionId, true, nullStreamIdsArr));
+		stubResponseAndRun(() -> client.muteSession(sessionId, true, emptyStreamIdsCol));
+		stubResponseAndRun(() -> client.muteSession(sessionId, false, emptyStreamIdsArr));
+		stubResponseAndRun(() -> client.muteSession(sessionId, true, singleStreamIdCol));
+		stubResponseAndRun(() -> client.muteSession(sessionId, false, singleStreamIdArr));
 		stubResponseAndAssertThrowsIAX(() -> client.muteSession(null, false));
 	}
 

--- a/src/test/java/com/vonage/client/video/VideoClientTest.java
+++ b/src/test/java/com/vonage/client/video/VideoClientTest.java
@@ -210,7 +210,7 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 	@Test
 	public void testSignal() throws Exception {
 		SignalRequest signalRequest = SignalRequest.builder().data("d").type("t").build();
-		stubResponseAndRun(() -> client.signal(sessionId, connectionId, signalRequest));
+		stubResponseAndRun(204, () -> client.signal(sessionId, connectionId, signalRequest));
 		stubResponseAndAssertThrowsIAX(() -> client.signal(sessionId, connectionId, null));
 		stubResponseAndAssertThrowsIAX(() -> client.signal(sessionId, null, signalRequest));
 		stubResponseAndAssertThrowsIAX(() -> client.signal(null, connectionId, signalRequest));
@@ -219,14 +219,14 @@ public class VideoClientTest extends ClientTest<VideoClient> {
 	@Test
 	public void testSignalAll() throws Exception {
 		SignalRequest signalRequest = SignalRequest.builder().data("d").type("t").build();
-		stubResponseAndRun(() -> client.signalAll(sessionId, signalRequest));
+		stubResponseAndRun(204, () -> client.signalAll(sessionId, signalRequest));
 		stubResponseAndAssertThrowsIAX(() -> client.signalAll(sessionId, null));
 		stubResponseAndAssertThrowsIAX(() -> client.signalAll(null, signalRequest));
 	}
 
 	@Test
 	public void testForceDisconnect() throws Exception {
-		stubResponseAndRun(() -> client.forceDisconnect(sessionId, connectionId));
+		stubResponseAndRun(204, () -> client.forceDisconnect(sessionId, connectionId));
 		stubResponseAndAssertThrowsIAX(() -> client.forceDisconnect(null, connectionId));
 		stubResponseAndAssertThrowsIAX(() -> client.forceDisconnect(sessionId, null));
 	}


### PR DESCRIPTION
- Adds the required `scope` claim to the JWT
- Improves testing of `VideoClient#generateToken`
- Fixes mishandling of empty 2xx responses
- MuteSession and MuteStream return nothing (API spec was mis-specified)
- Note: API specs are wrong about `signal`, `signallAll` and `forceDisconnect`: they return 204 not 200.