### PR TITLE
Added Inbound Message webhook object

### DIFF
--- a/src/main/java/com/vonage/client/messages/Channel.java
+++ b/src/main/java/com/vonage/client/messages/Channel.java
@@ -17,9 +17,9 @@ package com.vonage.client.messages;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Set;
-import java.util.EnumSet;
 import static com.vonage.client.messages.MessageType.*;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Represents the services available for sending messages.
@@ -27,8 +27,8 @@ import static com.vonage.client.messages.MessageType.*;
 public enum Channel {
 	SMS (TEXT),
 	MMS (IMAGE, VCARD, AUDIO, VIDEO),
-	WHATSAPP (TEXT, IMAGE, AUDIO, VIDEO, FILE, TEMPLATE, CUSTOM),
-	MESSENGER (TEXT, IMAGE, AUDIO, VIDEO, FILE),
+	WHATSAPP (TEXT, IMAGE, AUDIO, VIDEO, FILE, TEMPLATE, CUSTOM, LOCATION, ORDER, REPLY, UNSUPPORTED),
+	MESSENGER (TEXT, IMAGE, AUDIO, VIDEO, FILE, UNSUPPORTED),
 	VIBER (TEXT, IMAGE);
 
 	private final Set<MessageType> supportedTypes;

--- a/src/main/java/com/vonage/client/messages/InboundMessage.java
+++ b/src/main/java/com/vonage/client/messages/InboundMessage.java
@@ -1,0 +1,246 @@
+/*
+ *   Copyright 2023 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vonage.client.VonageUnexpectedException;
+import java.io.IOException;
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Convenience class representing an inbound message webhook.
+ * <p>
+ * Refer to the
+ * <a href=https://developer.vonage.com/api/messages-olympus#webhooks>Messages API Webhook reference</a>
+ * for more details on the response object structure.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InboundMessage {
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	protected static class UrlWrapper {
+		@JsonProperty("url") protected URI url;
+	}
+
+	protected InboundMessage() {}
+
+	@JsonAnySetter protected Map<String, Object> unknownProperties;
+
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = MessageStatus.ISO_8601_PATTERN)
+	@JsonProperty("timestamp") protected ZonedDateTime timestamp;
+	@JsonProperty("channel") protected Channel channel;
+	@JsonProperty("message_type") protected MessageType messageType;
+	@JsonProperty("message_uuid") protected UUID messageUuid;
+	@JsonProperty("to") protected String to;
+	@JsonProperty("from") protected String from;
+	@JsonProperty("client_ref") protected String clientRef;
+
+	@JsonProperty("text") protected String text;
+	@JsonProperty("image") protected UrlWrapper image;
+	@JsonProperty("audio") protected UrlWrapper audio;
+	@JsonProperty("video") protected UrlWrapper video;
+	@JsonProperty("file") protected UrlWrapper file;
+	@JsonProperty("vcard") protected UrlWrapper vcard;
+
+	/**
+	 * This is a catch-all method which encapsulates all fields in the response JSON
+	 * that are not already a field in this class. Channel-specific response objects
+	 * are deserialized into this Map. For example, an SMS message may have the following
+	 * response object which is not deserialized into a field by this class:<br>
+	 * {@code
+	 *     "sms": {
+	 *     "num_messages": "2",
+	 *     "keyword": "HELLO"
+	 *   }
+	 * } <br><br>
+	 *
+	 * To obtain the "num_messages" from the map, you could do the following:<br>
+	 *
+	 * {@code
+	 *      Map<String, ?> additionalProps = inboundMessage.getAdditionalProperties();
+	 *      Map<String, String> smsObj = (Map<String, String>) additionalProps.get("sms");
+	 *      int numMessages = Integer.parseInt(smsObj.get("num_messages"));
+	 * }
+	 *
+	 * @return The Map of unknown properties to their values.
+	 */
+	@JsonAnyGetter
+	public Map<String, ?> getAdditionalProperties() {
+		return unknownProperties;
+	}
+
+	/**
+	 * The media type of the message.
+	 *
+	 * @return The message type, as an enum.
+	 */
+	public MessageType getMessageType() {
+		return messageType;
+	}
+
+	/**
+	 * The service used to send the message.
+	 *
+	 * @return The channel, as an enum.
+	 */
+	public Channel getChannel() {
+		return channel;
+	}
+
+	/**
+	 * Unique identifier of the message that was sent.
+	 *
+	 * @return The UUID of the message.
+	 */
+	public UUID getMessageUuid() {
+		return messageUuid;
+	}
+
+	/**
+	 * The number this message was sent to.
+	 *
+	 * @return The recipient number or ID.
+	 */
+	public String getTo() {
+		return to;
+	}
+
+	/**
+	 * The number this message was sent from.
+	 *
+	 * @return The sender number or ID.
+	 */
+	public String getFrom() {
+		return from;
+	}
+
+	protected void setTimestamp(String timestamp) {
+		this.timestamp = MessageStatus.ISO_8601.parse(timestamp, ZonedDateTime::from);
+	}
+
+	/**
+	 * The datetime of when the event occurred.
+	 *
+	 * @return The timestamp as a ZonedDateTime.
+	 */
+	public ZonedDateTime getTimestamp() {
+		return timestamp;
+	}
+
+	/**
+	 * The client reference will be present if set in the original outbound message.
+	 *
+	 * @return The client reference, or {@code null} if unset.
+	 */
+	public String getClientRef() {
+		return clientRef;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#TEXT}, returns the message text.
+	 *
+	 * @return The message text, or {@code null} if not applicable.
+	 */
+	public String getText() {
+		return text;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#IMAGE}, returns the URL of the image.
+	 *
+	 * @return The image URL, or {@code null} if not applicable.
+	 */
+	public URI getImageUrl() {
+		return image != null ? image.url : null;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#AUDIO}, returns the URL of the audio.
+	 *
+	 * @return The audio URL, or {@code null} if not applicable.
+	 */
+	public URI getAudioUrl() {
+		return audio != null ? audio.url : null;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#VIDEO}, returns the URL of the video.
+	 *
+	 * @return The video URL, or {@code null} if not applicable.
+	 */
+	public URI getVideoUrl() {
+		return video != null ? video.url : null;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#FILE}, returns the URL of the file.
+	 *
+	 * @return The file URL, or {@code null} if not applicable.
+	 */
+	public URI getFileUrl() {
+		return file != null ? file.url : null;
+	}
+
+	/**
+	 * If {@linkplain #getMessageType()} is {@linkplain MessageType#VCARD}, returns the URL of the vCard.
+	 *
+	 * @return The vCard URL, or {@code null} if not applicable.
+	 */
+	public URI getVcardUrl() {
+		return vcard != null ? vcard.url : null;
+	}
+
+	/**
+	 * Convenience method for obtaining the credit usage of an SMS message.
+	 *
+	 * @return The deserialized usage object, or <code>null</code> if absent or not applicable.
+	 * @throws IllegalStateException If the channel is not {@linkplain Channel#SMS}.
+	 */
+	@SuppressWarnings("unchecked")
+	public MessageStatus.Usage getSmsUsage() {
+		if (channel != Channel.SMS) {
+			throw new IllegalStateException("Usage only applies to SMS messages");
+		}
+		Map<String, String> usageMap = (Map<String, String>) unknownProperties.get("usage");
+		if (usageMap == null) return null;
+		MessageStatus.Usage usageObj = new MessageStatus.Usage();
+		usageObj.setCurrency(usageMap.get("currency"));
+		usageObj.setPrice(usageMap.get("price"));
+		return usageObj;
+	}
+
+	/**
+	 * Constructs an instance of this class from a JSON payload. Known fields will be mapped, whilst
+	 * unknown fields can be manually obtained through the {@linkplain #getAdditionalProperties()} method.
+	 *
+	 * @param json The webhook response JSON string.
+	 *
+	 * @return The deserialized webhook response object.
+	 * @throws VonageUnexpectedException If the response could not be deserialized.
+	 */
+	public static InboundMessage fromJson(String json) {
+		try {
+			ObjectMapper mapper = new ObjectMapper();
+			return mapper.readValue(json, InboundMessage.class);
+		}
+		catch (IOException ex) {
+			throw new VonageUnexpectedException("Failed to produce InboundMessage from json.", ex);
+		}
+	}
+}

--- a/src/main/java/com/vonage/client/messages/MessageStatus.java
+++ b/src/main/java/com/vonage/client/messages/MessageStatus.java
@@ -198,9 +198,8 @@ public class MessageStatus {
 	protected MessageStatus() {
 	}
 
-	@JsonProperty("timestamp")
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = ISO_8601_PATTERN)
-	protected ZonedDateTime timestamp;
+	@JsonProperty("timestamp") protected ZonedDateTime timestamp;
 	@JsonProperty("message_uuid") protected UUID messageUuid;
 	@JsonProperty("to") protected String to;
 	@JsonProperty("from") protected String from;

--- a/src/main/java/com/vonage/client/messages/MessageType.java
+++ b/src/main/java/com/vonage/client/messages/MessageType.java
@@ -22,14 +22,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Represents the media type of the message.
  */
 public enum MessageType {
-	TEXT,
-	IMAGE,
-	AUDIO,
-	VIDEO,
-	FILE,
-	VCARD,
-	TEMPLATE,
-	CUSTOM;
+	TEXT, IMAGE, AUDIO, VIDEO, FILE, VCARD, TEMPLATE, CUSTOM, LOCATION, UNSUPPORTED, REPLY, ORDER;
 
 	@JsonCreator
 	public static MessageType fromString(String value) {

--- a/src/test/java/com/vonage/client/messages/InboundMessageTest.java
+++ b/src/test/java/com/vonage/client/messages/InboundMessageTest.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2022 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+import static org.junit.Assert.*;
+import org.junit.Test;
+import java.util.Map;
+import java.util.UUID;
+
+public class InboundMessageTest {
+	UUID messageUuid = UUID.randomUUID();
+	String to = "447700900000", from = "447700900001";
+	String timestamp = "2020-01-01 15:43:21 +0200";
+	String clientRef = UUID.randomUUID().toString();
+	String text = "Hello, world!";
+	String price = "0.0333";
+	String currency = "EUR";
+
+	String getCommonPartialJsonStub(Channel channel, MessageType messageType) {
+		return "{\n" +
+			  "  \"message_uuid\": \""+messageUuid+"\",\n" +
+			  "  \"to\": \""+to+"\",\n" +
+			  "  \"from\": \""+from+"\",\n" +
+			  "  \"timestamp\": \""+timestamp+"\",\n" +
+			  "  \"channel\": \""+channel+"\",\n" +
+			  "  \"message_type\": \""+messageType+"\",\n" +
+			  "  \"client_ref\": \""+clientRef+"\"";
+	}
+
+	String getSmsPartialJsonStub() {
+		return getCommonPartialJsonStub(Channel.SMS, MessageType.TEXT) +
+			  ",\n  \"text\": \""+text+"\"";
+	}
+
+	String getSmsPartialStubWithUsage() {
+		return getSmsPartialJsonStub() + ",\n  \"usage\": {\n" +
+			  "    \"currency\": \""+currency+"\",\n" +
+			  "    \"price\": \""+price+"\"\n"+
+			  "  }";
+	}
+
+	void assertEqualsCommon(InboundMessage im) {
+		assertEquals(messageUuid, im.getMessageUuid());
+		assertEquals(to, im.getTo());
+		assertEquals(from, im.getFrom());
+		assertEquals(timestamp, MessageStatus.ISO_8601.format(im.getTimestamp()));
+		assertEquals(clientRef, im.getClientRef());
+	}
+
+	void assertEqualsSms(InboundMessage im) {
+		assertEqualsCommon(im);
+		assertEquals(Channel.SMS, im.getChannel());
+		assertEquals(MessageType.TEXT, im.getMessageType());
+		assertEquals(text, im.getText());
+	}
+
+	void assertEqualsSmsWithUsage(InboundMessage im) {
+		assertEqualsSms(im);
+		MessageStatus.Usage usage = im.getSmsUsage();
+		assertNotNull(usage);
+		assertEquals(currency, usage.getCurrency().getCurrencyCode());
+		assertEquals(price, ""+usage.getPrice());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testUnknownProperty() {
+		String fullJson = getSmsPartialStubWithUsage() + ",\n  \"sms\": {\n" +
+			  "  \"num_messages\": \"2\",\n" +
+			  "  \"keyword\": \"HELLO\"\n" +
+			  "}\n}";
+
+		InboundMessage im = InboundMessage.fromJson(fullJson);
+		assertEqualsSmsWithUsage(im);
+
+		assertNull(im.getAudioUrl());
+		assertNull(im.getVcardUrl());
+		assertNull(im.getVideoUrl());
+		assertNull(im.getFileUrl());
+		assertNull(im.getImageUrl());
+
+		Map<String, String> smsMap = (Map<String, String>) im.getAdditionalProperties().get("sms");
+		assertNotNull(smsMap);
+		assertEquals("2", smsMap.get("num_messages"));
+		assertEquals("HELLO", smsMap.get("keyword"));
+	}
+
+	@Test
+	public void testMessengerUnsupportedType() throws Exception {
+		String fullJson = getCommonPartialJsonStub(Channel.MESSENGER, MessageType.UNSUPPORTED) + "\n}";
+		InboundMessage im = InboundMessage.fromJson(fullJson);
+
+		assertEqualsCommon(im);
+		assertEquals(Channel.MESSENGER, im.getChannel());
+		assertEquals(MessageType.UNSUPPORTED, im.getMessageType());
+		assertNull(im.getAdditionalProperties());
+		assertNull(im.getText());
+		assertNull(im.getAudioUrl());
+		assertNull(im.getVcardUrl());
+		assertNull(im.getVideoUrl());
+		assertNull(im.getFileUrl());
+		assertNull(im.getImageUrl());
+		assertThrows(IllegalStateException.class, im::getSmsUsage);
+	}
+}


### PR DESCRIPTION
Adds a class for deserializing webhook responses in the Messages API [see spec](https://developer.vonage.com/api/messages-olympus#webhooks). For simplicity and maintainability, this is provided as a single class with commonly known fields mapped using Jackson. This approach makes it easy to use and easy to maintain, whilst also being extensible should the user wish to explicitly support additional unmapped fields. Since the spec for WhatsApp webhooks is much more complex, the additional fields are not explicitly mapped in the object.