### PR TITLE
Basic auth in header for Numbers API

### DIFF
--- a/src/main/java/com/vonage/client/auth/RequestSigning.java
+++ b/src/main/java/com/vonage/client/auth/RequestSigning.java
@@ -27,6 +27,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -55,7 +56,7 @@ public class RequestSigning {
      *
      */
     public static void constructSignatureForRequestParameters(List<NameValuePair> params, String secretKey) {
-        constructSignatureForRequestParameters(params, secretKey, System.currentTimeMillis() / 1000);
+        constructSignatureForRequestParameters(params, secretKey, Instant.now().getEpochSecond());
     }
 
     /**
@@ -69,7 +70,7 @@ public class RequestSigning {
      * @param hashType The type of hash that is to be used in construction
      */
     public static void constructSignatureForRequestParameters(List<NameValuePair> params, String secretKey, HashUtil.HashType hashType) {
-        constructSignatureForRequestParameters(params, secretKey, System.currentTimeMillis() / 1000, hashType);
+        constructSignatureForRequestParameters(params, secretKey, Instant.now().getEpochSecond(), hashType);
     }
 
     /**
@@ -208,7 +209,7 @@ public class RequestSigning {
             ObjectMapper mapper = new ObjectMapper();
             try{
                 Map<String,String> params = mapper.readValue(request.getInputStream(), new TypeReference<Map<String,String>>(){});
-                for (Map.Entry<String, String> entry: params.entrySet()) {
+                for (Map.Entry<String, String> entry : params.entrySet()) {
                     String name = entry.getKey();
                     String value = entry.getValue();
                     log.info("" + name + " = " + value);
@@ -236,8 +237,7 @@ public class RequestSigning {
 
         // identify the signature supplied in the request ...
         String suppliedSignature = sortedParams.get(PARAM_SIGNATURE);
-        if (suppliedSignature == null)
-            return false;
+        if (suppliedSignature == null) return false;
 
         // Extract the timestamp parameter and verify that it is within 5 minutes of 'current time'
         String timeString = sortedParams.get(PARAM_TIMESTAMP);
@@ -258,9 +258,8 @@ public class RequestSigning {
 
         // walk this sorted list of parameters and construct a string
         StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> param: sortedParams.entrySet()) {
-            if (param.getKey().equals(PARAM_SIGNATURE))
-                continue;
+        for (Map.Entry<String, String> param : sortedParams.entrySet()) {
+            if (param.getKey().equals(PARAM_SIGNATURE)) continue;
             String name = param.getKey();
             String value = param.getValue();
             sb.append("&").append(clean(name)).append("=").append(clean(value));

--- a/src/main/java/com/vonage/client/auth/SignatureAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/SignatureAuthMethod.java
@@ -41,11 +41,8 @@ public class SignatureAuthMethod implements AuthMethod {
         request.addParameter("api_key", apiKey);
         List<NameValuePair> params = request.getParameters();
         RequestSigning.constructSignatureForRequestParameters(params, apiSecret, hashType);
-
-        // TODO: This is ugly:
-        request.addParameter(params.get(params.size()-1))
-                .addParameter(params.get(params.size()-2));
-
+        int last = params.size() - 1;
+        request.addParameters(params.get(last), params.get(last - 1));
         return request;
     }
 

--- a/src/main/java/com/vonage/client/numbers/BuyNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/BuyNumberEndpoint.java
@@ -53,7 +53,11 @@ class BuyNumberEndpoint extends AbstractMethod<BuyNumberRequest, Void> {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
-
         return null;
+    }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/CancelNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/CancelNumberEndpoint.java
@@ -18,6 +18,7 @@ package com.vonage.client.numbers;
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.VonageBadRequestException;
+import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -52,7 +53,11 @@ class CancelNumberEndpoint extends AbstractMethod<CancelNumberRequest, Void> {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new VonageBadRequestException(EntityUtils.toString(response.getEntity()));
         }
-
         return null;
+    }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersEndpoint.java
@@ -17,6 +17,7 @@ package com.vonage.client.numbers;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,5 +49,10 @@ class ListNumbersEndpoint extends AbstractMethod<ListNumbersFilter, ListNumbersR
     @Override
     public ListNumbersResponse parseResponse(HttpResponse response) throws IOException {
         return ListNumbersResponse.fromJson(basicResponseHandler.handleResponse(response));
+    }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersEndpoint.java
@@ -17,6 +17,7 @@ package com.vonage.client.numbers;
 
 import com.vonage.client.AbstractMethod;
 import com.vonage.client.HttpWrapper;
+import com.vonage.client.VonageClientException;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
@@ -48,5 +49,10 @@ class SearchNumbersEndpoint extends AbstractMethod<SearchNumbersFilter, SearchNu
     @Override
     public SearchNumbersResponse parseResponse(HttpResponse response) throws IOException {
         return SearchNumbersResponse.fromJson(basicResponseHandler.handleResponse(response));
+    }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/UpdateNumberEndpoint.java
+++ b/src/main/java/com/vonage/client/numbers/UpdateNumberEndpoint.java
@@ -57,4 +57,9 @@ class UpdateNumberEndpoint extends AbstractMethod<UpdateNumberRequest, Void> {
         }
         return null;
     }
+
+    @Override
+    protected RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
+        return getAuthMethod(getAcceptableAuthMethods()).applyAsBasicAuth(request);
+    }
 }

--- a/src/main/java/com/vonage/client/sns/SnsClient.java
+++ b/src/main/java/com/vonage/client/sns/SnsClient.java
@@ -22,7 +22,7 @@ import com.vonage.client.sns.response.SnsPublishResponse;
 import com.vonage.client.sns.response.SnsSubscribeResponse;
 
 /**
- * A client for talking to the Vonage Voice API. The standard way to obtain an instance of this class is to use {@link
+ * A client for talking to the Vonage SNS API. The standard way to obtain an instance of this class is to use {@link
  * VonageClient#getSnsClient()}.
  */
 public class SnsClient {

--- a/src/test/java/com/vonage/client/numbers/BuyNumberEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/BuyNumberEndpointTest.java
@@ -19,28 +19,32 @@ import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.TestUtils;
 import com.vonage.client.VonageBadRequestException;
+import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
 
 public class BuyNumberEndpointTest {
     private BuyNumberEndpoint endpoint;
 
     @Before
     public void setUp() throws Exception {
-        endpoint = new BuyNumberEndpoint(new HttpWrapper());
+        endpoint = new BuyNumberEndpoint(new HttpWrapper(
+                new TokenAuthMethod("abc123", "a2cd5f789")
+        ));
     }
 
     @Test
@@ -51,6 +55,15 @@ public class BuyNumberEndpointTest {
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
         assertEquals("AA", params.get("country"));
         assertEquals("447700900000", params.get("msisdn"));
+    }
+
+    @Test
+    public void applyAuth() throws Exception {
+        RequestBuilder builder = endpoint.applyAuth(endpoint.makeRequest(
+                new BuyNumberRequest("UK", "447700900001")
+        ));
+        List<NameValuePair> params = builder.getParameters();
+        assertEquals(2, params.size());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/numbers/CancelNumberEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/CancelNumberEndpointTest.java
@@ -19,20 +19,24 @@ import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.TestUtils;
 import com.vonage.client.VonageBadRequestException;
+import com.vonage.client.auth.TokenAuthMethod;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Test;
+import java.util.List;
 import java.util.Map;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertEquals;
-
 
 public class CancelNumberEndpointTest {
     CancelNumberEndpoint endpoint;
 
     @Before
     public void setUp() throws Exception {
-        endpoint = new CancelNumberEndpoint(new HttpWrapper());
+        endpoint = new CancelNumberEndpoint(new HttpWrapper(
+                new TokenAuthMethod("abc123", "a2cd5f789")
+        ));
     }
 
     @Test
@@ -43,6 +47,15 @@ public class CancelNumberEndpointTest {
         Map<String, String> params = TestUtils.makeParameterMap(request.getParameters());
         assertEquals("AA", params.get("country"));
         assertEquals("447700900000", params.get("msisdn"));
+    }
+
+    @Test
+    public void applyAuth() throws Exception {
+        RequestBuilder builder = endpoint.applyAuth(endpoint.makeRequest(
+                new CancelNumberRequest("GB", "447700900001")
+        ));
+        List<NameValuePair> params = builder.getParameters();
+        assertEquals(2, params.size());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/numbers/ListNumbersEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/ListNumbersEndpointTest.java
@@ -18,21 +18,24 @@ package com.vonage.client.numbers;
 import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.TestUtils;
+import static com.vonage.client.TestUtils.test429;
+import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
-import static com.vonage.client.TestUtils.test429;
-import static org.junit.Assert.assertEquals;
 
 
 public class ListNumbersEndpointTest {
@@ -40,7 +43,9 @@ public class ListNumbersEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        endpoint = new ListNumbersEndpoint(new HttpWrapper());
+        endpoint = new ListNumbersEndpoint(new HttpWrapper(
+                new TokenAuthMethod("abc123", "a2cd5f789")
+        ));
     }
 
     @Test
@@ -59,6 +64,13 @@ public class ListNumbersEndpointTest {
         assertEquals("10", params.get("index"));
         assertEquals("20", params.get("size"));
         assertEquals(ContentType.APPLICATION_JSON.getMimeType(), request.getFirstHeader("Accept").getValue());
+    }
+
+    @Test
+    public void applyAuth() throws Exception {
+        RequestBuilder builder = endpoint.applyAuth(endpoint.makeRequest(new ListNumbersFilter()));
+        List<NameValuePair> params = builder.getParameters();
+        assertEquals(0, params.size());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/numbers/SearchNumbersEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/SearchNumbersEndpointTest.java
@@ -18,22 +18,25 @@ package com.vonage.client.numbers;
 import com.vonage.client.HttpConfig;
 import com.vonage.client.HttpWrapper;
 import com.vonage.client.TestUtils;
+import static com.vonage.client.TestUtils.test429;
+import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import org.junit.Before;
 import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Map;
-import static com.vonage.client.TestUtils.test429;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 
 public class SearchNumbersEndpointTest {
@@ -41,7 +44,9 @@ public class SearchNumbersEndpointTest {
 
     @Before
     public void setUp() throws Exception {
-        endpoint = new SearchNumbersEndpoint(new HttpWrapper());
+        endpoint = new SearchNumbersEndpoint(new HttpWrapper(
+                new TokenAuthMethod("abc123", "a2cd5f789")
+        ));
     }
 
     @Test
@@ -66,6 +71,13 @@ public class SearchNumbersEndpointTest {
         assertEquals("10", params.get("index"));
         assertEquals("20", params.get("size"));
         assertEquals("landline-toll-free", params.get("type"));
+    }
+
+    @Test
+    public void applyAuth() throws Exception {
+        RequestBuilder builder = endpoint.applyAuth(endpoint.makeRequest(new SearchNumbersFilter("GB")));
+        List<NameValuePair> params = builder.getParameters();
+        assertEquals(1, params.size());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/numbers/UpdateNumberEndpointTest.java
+++ b/src/test/java/com/vonage/client/numbers/UpdateNumberEndpointTest.java
@@ -20,19 +20,23 @@ import com.vonage.client.HttpWrapper;
 import com.vonage.client.TestUtils;
 import com.vonage.client.auth.TokenAuthMethod;
 import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.entity.ContentType;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+import java.util.List;
 import java.util.Map;
-import static org.junit.Assert.*;
 
 public class UpdateNumberEndpointTest {
     private UpdateNumberEndpoint endpoint;
 
     @Before
     public void setUp() throws Exception {
-        endpoint = new UpdateNumberEndpoint(new HttpWrapper());
+        endpoint = new UpdateNumberEndpoint(new HttpWrapper(
+                new TokenAuthMethod("abc123", "a2cd5f789")
+        ));
     }
 
     @Test
@@ -80,6 +84,15 @@ public class UpdateNumberEndpointTest {
         assertEquals("https://api.example.com/callback", params.get("voiceStatusCallback"));
         assertEquals("MESSAGES-APPLICATION-ID", params.get("messagesCallbackValue"));
         assertEquals(UpdateNumberRequest.CallbackType.APP.paramValue(), params.get("messagesCallbackType"));
+    }
+
+    @Test
+    public void testApplyAuth() throws Exception {
+        RequestBuilder builder = endpoint.applyAuth(endpoint.makeRequest(
+                new UpdateNumberRequest("447700900015", "UK")
+        ));
+        List<NameValuePair> params = builder.getParameters();
+        assertEquals(2, params.size());
     }
 
     @Test


### PR DESCRIPTION
Currently the Numbers API appends the API key and secret in the query body. This PR moves it to the header instead as `Basic`, which is inline with the spec.