### PR TITLE
Add duration and file_size to Viber Video message

### DIFF
--- a/src/main/java/com/vonage/client/messages/sms/SmsInboundMetadata.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsInboundMetadata.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SmsInboundMetadata {
-	private Integer numMessages;
+	private Integer numMessages, totalCount;
 	private String keyword;
 
 	SmsInboundMetadata() {}
@@ -40,6 +40,18 @@ public final class SmsInboundMetadata {
 	@JsonProperty("num_messages")
 	public Integer getNumMessages() {
 		return numMessages;
+	}
+
+	/**
+	 * The number of inbound SMS messages concatenated together to comprise this message. SMS messages are 160
+	 * characters, if an inbound message exceeds that size they are concatenated together to form a single message.
+	 * This number indicates how many messages formed this webhook.
+	 *
+	 * @return The total number of SMS messages used to create the text message.
+	 */
+	@JsonProperty("total_count")
+	public Integer getTotalCount() {
+		return totalCount;
 	}
 
 	/**

--- a/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
@@ -29,10 +29,9 @@ public abstract class ViberRequest extends MessageRequest {
 	protected ViberRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.VIBER, messageType);
 		viberService = ViberService.construct(
-				builder.category,
-				builder.ttl,
-				builder.viberType,
-				Action.construct(builder.actionUrl, builder.actionText)
+				builder.category, builder.ttl, builder.viberType,
+				Action.construct(builder.actionUrl, builder.actionText),
+				builder.duration, builder.fileSize
 		);
 	}
 
@@ -55,7 +54,7 @@ public abstract class ViberRequest extends MessageRequest {
 	@SuppressWarnings("unchecked")
 	protected abstract static class Builder<M extends ViberRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
 		protected Category category;
-		protected Integer ttl;
+		protected Integer ttl, duration, fileSize;
 		protected String viberType, actionUrl, actionText;
 
 		/**

--- a/src/main/java/com/vonage/client/messages/viber/ViberService.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberService.java
@@ -21,25 +21,33 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class ViberService {
 	private final Category category;
-	private final Integer ttl;
+	private final Integer ttl, duration, fileSize;
 	private final String type;
 	private final Action action;
 
-	private ViberService(Category category, Integer ttl, String type, Action action) {
+	private ViberService(Category category, Integer ttl, String type, Action action, Integer duration, Integer fileSize) {
 		this.category = category;
 		this.ttl = ttl;
 		this.type = type;
 		this.action = action;
+		this.duration = duration;
+		this.fileSize = fileSize;
 	}
 
-	static ViberService construct(Category category, Integer ttl, String type, Action action) {
-		if (category == null && ttl == null && type == null && action == null) {
+	static ViberService construct(Category category, Integer ttl, String type, Action action,  Integer duration, Integer fileSize) {
+		if (category == null && ttl == null && type == null && action == null && duration == null && fileSize == null) {
 			return null;
 		}
 		if (ttl != null && (ttl < 30 || ttl > 259200)) {
 			throw new IllegalArgumentException("Time-to-live (ttl) must be between 30 and 259200 seconds");
 		}
-		return new ViberService(category, ttl, type, action);
+		if (duration != null && (duration < 1 || duration > 600)) {
+			throw new IllegalArgumentException("Duration must be between 1 and 600 seconds.");
+		}
+		if (fileSize != null && (fileSize < 1 || fileSize > 200)) {
+			throw new IllegalArgumentException("File size must be between 1 and 200 MB.");
+		}
+		return new ViberService(category, ttl, type, action, duration, fileSize);
 	}
 
 	@JsonProperty("category")
@@ -60,5 +68,15 @@ public final class ViberService {
 	@JsonProperty("action")
 	public Action getAction() {
 		return action;
+	}
+
+	@JsonProperty("duration")
+	public Integer getDuration() {
+		return duration;
+	}
+
+	@JsonProperty("file_size")
+	public Integer getFileSize() {
+		return fileSize;
 	}
 }

--- a/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
@@ -18,6 +18,7 @@ package com.vonage.client.messages.viber;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.MessageType;
+import java.util.Objects;
 
 /**
  * @since 7.2.0
@@ -28,6 +29,8 @@ public final class ViberVideoRequest extends ViberRequest {
 
 	ViberVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);
+		Objects.requireNonNull(builder.duration, "Duration is required.");
+		Objects.requireNonNull(builder.fileSize, "File size is required.");
 		video = new Video(builder.url, builder.thumbUrl, builder.caption);
 	}
 
@@ -67,6 +70,30 @@ public final class ViberVideoRequest extends ViberRequest {
 		 */
 		public Builder thumbUrl(String thumbUrl) {
 			this.thumbUrl = thumbUrl;
+			return this;
+		}
+
+		/**
+		 * (REQUIRED)
+		 * Length of the video in seconds. Must be between 1 and 600.
+		 *
+		 * @param duration The video duration as an integer.
+		 * @return This builder.
+		 */
+		public Builder duration(int duration) {
+			this.duration = duration;
+			return this;
+		}
+
+		/**
+		 * (REQUIRED)
+		 * The video file size in megabytes. Must be between 1 and 200.
+		 *
+		 * @param fileSize The file size as an integer.
+		 * @return This builder.
+		 */
+		public Builder fileSize(int fileSize) {
+			this.fileSize = fileSize;
 			return this;
 		}
 

--- a/src/test/java/com/vonage/client/messages/InboundMessageTest.java
+++ b/src/test/java/com/vonage/client/messages/InboundMessageTest.java
@@ -58,6 +58,7 @@ public class InboundMessageTest {
 			  "    \"price\": \""+price+"\"\n"+
 			  "  },\n  \"sms\": {\n" +
 				"  \"num_messages\": \"2\",\n" +
+				"  \"total_count\": \"3\",\n" +
 				"  \"keyword\": \"HELLO\"\n  }";
 	}
 
@@ -85,6 +86,7 @@ public class InboundMessageTest {
 		SmsInboundMetadata metadata = im.getSmsMetadata();
 		assertNotNull(metadata);
 		assertEquals(2, metadata.getNumMessages().intValue());
+		assertEquals(3, metadata.getTotalCount().intValue());
 		assertEquals("HELLO", metadata.getKeyword());
 	}
 

--- a/src/test/java/com/vonage/client/messages/MessagesClientTest.java
+++ b/src/test/java/com/vonage/client/messages/MessagesClientTest.java
@@ -115,7 +115,7 @@ public class MessagesClientTest extends ClientTest<MessagesClient> {
 	public void testSendViberSuccess() throws Exception {
 		assertResponse(ViberTextRequest.builder().text(TEXT));
 		assertResponse(ViberImageRequest.builder().url(IMAGE));
-		assertResponse(ViberVideoRequest.builder().url(VIDEO).thumbUrl(IMAGE));
+		assertResponse(ViberVideoRequest.builder().url(VIDEO).thumbUrl(IMAGE).duration(15).fileSize(8));
 		assertResponse(ViberFileRequest.builder().url(FILE));
 	}
 


### PR DESCRIPTION
Duration and file size are required fields according to [the API spec](https://developer.vonage.com/en/api/messages-olympus).
