### PR TITLE
Added BYOP to Verify v1

### DIFF
--- a/src/main/java/com/vonage/client/verify/BaseRequest.java
+++ b/src/main/java/com/vonage/client/verify/BaseRequest.java
@@ -34,14 +34,16 @@ public abstract class BaseRequest {
 
     protected BaseRequest(String number, Integer length, Locale locale, String country, Integer pinExpiry, Integer nextEventWait) {
         this.number = number;
-        this.length = length;
         this.locale = locale;
         this.country = country;
+        if ((this.length = length) != null && (length != 4 && length != 6)) {
+            throw new IllegalArgumentException("code_length must be 4 or 6.");
+        }
         if ((this.pinExpiry = pinExpiry) != null && (pinExpiry < 60 || pinExpiry > 3600)) {
-            throw new IllegalArgumentException("pin_expiry '"+pinExpiry+"' is out of bounds");
+            throw new IllegalArgumentException("pin_expiry '"+pinExpiry+"' is out of bounds.");
         }
         if ((this.nextEventWait = nextEventWait) != null && (nextEventWait < 60 || nextEventWait > 900)) {
-            throw new IllegalArgumentException("next_event_wait '"+nextEventWait+"' is out of bounds");
+            throw new IllegalArgumentException("next_event_wait '"+nextEventWait+"' is out of bounds.");
         }
     }
 

--- a/src/main/java/com/vonage/client/verify/CheckResponse.java
+++ b/src/main/java/com/vonage/client/verify/CheckResponse.java
@@ -18,10 +18,8 @@ package com.vonage.client.verify;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.VonageResponseParseException;
-import com.vonage.client.VonageUnexpectedException;
 import java.io.IOException;
 import java.math.BigDecimal;
 
@@ -101,10 +99,8 @@ public class CheckResponse {
         try {
             ObjectMapper mapper = new ObjectMapper();
             return mapper.readValue(json, CheckResponse.class);
-        } catch (JsonMappingException jme) {
+        } catch (IOException jme) {
             throw new VonageResponseParseException("Failed to produce CheckResponse from json.", jme);
-        } catch (IOException jpe) {
-            throw new VonageUnexpectedException("Failed to produce CheckResponse from json.", jpe);
         }
     }
 }

--- a/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
@@ -18,11 +18,9 @@ package com.vonage.client.verify;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.vonage.client.VonageResponseParseException;
-import com.vonage.client.VonageUnexpectedException;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.List;
@@ -74,10 +72,9 @@ public class SearchVerifyResponse {
             mapper.registerModule(module);
 
             return mapper.readValue(json, SearchVerifyResponse.class);
-        } catch (JsonMappingException jme) {
+        }
+        catch (IOException jme) {
             throw new VonageResponseParseException("Failed to produce SearchVerifyResponse from json.", jme);
-        } catch (IOException jpe) {
-            throw new VonageUnexpectedException("Failed to produce SearchVerifyResponse from json.", jpe);
         }
     }
 }

--- a/src/main/java/com/vonage/client/verify/VerifyClient.java
+++ b/src/main/java/com/vonage/client/verify/VerifyClient.java
@@ -83,10 +83,7 @@ public class VerifyClient {
      */
     public VerifyResponse verify(final String number, final String brand, VerifyRequest.Workflow workflow)
             throws VonageResponseParseException, VonageClientException {
-        return verify(new VerifyRequest.Builder(number, brand)
-                .workflow(workflow)
-                .build()
-        );
+        return verify(new VerifyRequest.Builder(number, brand).workflow(workflow).build());
     }
 
     /**

--- a/src/main/java/com/vonage/client/verify/VerifyRequest.java
+++ b/src/main/java/com/vonage/client/verify/VerifyRequest.java
@@ -25,13 +25,16 @@ import java.util.Locale;
  */
 public class VerifyRequest extends BaseRequest {
     private final LineType type;
-    private final String brand, from;
+    private final String brand, from, pinCode;
     private final Workflow workflow;
 
     public VerifyRequest(Builder builder) {
         super(builder.number, builder.length, builder.locale, builder.country, builder.pinExpiry, builder.nextEventWait);
         if ((brand = builder.brand) != null && brand.length() > 18) {
-            throw new IllegalArgumentException("Brand '"+brand+"' is longer than 18 characters");
+            throw new IllegalArgumentException("Brand '"+brand+"' is longer than 18 characters.");
+        }
+        if ((pinCode = builder.pinCode) != null && (pinCode.length() < 4 || pinCode.length() > 10)) {
+            throw new IllegalArgumentException("Pin code must be between 4 and 10 characters.");
         }
         from = builder.senderId;
         type = builder.type;
@@ -39,7 +42,7 @@ public class VerifyRequest extends BaseRequest {
     }
 
     /**
-     * @return the name of the company or app to be verified for.
+     * @return The name of the company or app to be verified for.
      */
     public String getBrand() {
         return this.brand;
@@ -82,6 +85,18 @@ public class VerifyRequest extends BaseRequest {
         return workflow;
     }
 
+    /**
+     * A custom PIN to send to the user. If a PIN is not provided, Verify will generate a random PIN for you.
+     * This feature is not enabled by default - please discuss with your Account Manager if you would like it enabled.
+     *
+     * @return The custom pin code as a string, or {@code null} if not set.
+     *
+     * @since 7.5.0
+     */
+    public String getPinCode() {
+        return pinCode;
+    }
+
     protected void addParams(RequestBuilder result) {
         result.addParameter("number", getNumber()).addParameter("brand", getBrand());
 
@@ -99,6 +114,9 @@ public class VerifyRequest extends BaseRequest {
         }
         if (getPinExpiry() != null) {
             result.addParameter("pin_expiry", getPinExpiry().toString());
+        }
+        if (getPinCode() != null) {
+            result.addParameter("pin_code", getPinCode());
         }
         if (getNextEventWait() != null) {
             result.addParameter("next_event_wait", getNextEventWait().toString());
@@ -163,7 +181,7 @@ public class VerifyRequest extends BaseRequest {
      * @since 5.5.0
      */
     public static class Builder {
-        private String brand, senderId, number, country;
+        private String brand, senderId, number, country, pinCode;
         private Integer length, pinExpiry, nextEventWait;
         private LineType type;
         private Workflow workflow;
@@ -182,8 +200,8 @@ public class VerifyRequest extends BaseRequest {
 
         /**
          * @param senderId the short alphanumeric string to specify the SenderID for SMS sent by Verify.
-         * @return {@link Builder}
          *
+         * @return This builder.
          */
         public Builder senderId(String senderId) {
             this.senderId = senderId;
@@ -196,7 +214,7 @@ public class VerifyRequest extends BaseRequest {
          *
          * @deprecated This is no longer used and will be removed in the next major release.
          *
-         * @return {@link Builder}
+         * @return This builder.
          **/
         @Deprecated
         public Builder type(LineType type) {
@@ -209,7 +227,7 @@ public class VerifyRequest extends BaseRequest {
          * user. See <a href="https://developer.vonage.com/verify/guides/workflows-and-events">https://developer.vonage.com/verify/guides/workflows-and-events</a>
          *
          * @param workflow The workflow to use for conveying the PIN to your user.
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder workflow(Workflow workflow) {
             this.workflow = workflow;
@@ -219,7 +237,7 @@ public class VerifyRequest extends BaseRequest {
         /**
          * @param locale (optional) Override the default locale used for verification. By default the locale is determined
          *        from the country code included in {@code number}
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder locale(Locale locale) {
             this.locale = locale;
@@ -229,7 +247,7 @@ public class VerifyRequest extends BaseRequest {
         /**
          * @param length (optional) The length of the verification code to be sent to the user. Must be either 4 or 6. Use
          *               -1 to use the default value.
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder length(Integer length) {
             this.length = length;
@@ -238,7 +256,7 @@ public class VerifyRequest extends BaseRequest {
 
         /**
          * @param pinExpiry (optional) the PIN validity time from generation, in seconds. Default is 300 seconds
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder pinExpiry(Integer pinExpiry) {
             this.pinExpiry = pinExpiry;
@@ -247,7 +265,7 @@ public class VerifyRequest extends BaseRequest {
 
         /**
          * @param nextEventWait (optional) the wait time between attempts to deliver the PIN. A number between 600-900.
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder nextEventWait(Integer nextEventWait) {
             this.nextEventWait = nextEventWait;
@@ -262,13 +280,32 @@ public class VerifyRequest extends BaseRequest {
          * </p>
          *
          * @param country  a String containing a 2-character country code
-         * @return {@link Builder}
+         * @return This builder.
          */
         public Builder country(String country) {
             this.country = country;
             return this;
         }
 
+        /**
+         * A custom PIN to send to the user. If a PIN is not provided, Verify will generate a random PIN for you. This
+         * feature is not enabled by default - please discuss with your Account Manager if you would like it enabled.
+         *
+         * @param pinCode The custom code as a string.
+         *
+         * @return This builder.
+         * @since 7.5.0
+         */
+        public Builder pinCode(String pinCode) {
+            this.pinCode = pinCode;
+            return this;
+        }
+
+        /**
+         * Builds the VerifyRequest.
+         *
+         * @return A new VerifyRequest with this builder's properties.
+         */
         public VerifyRequest build() {
             return new VerifyRequest(this);
         }

--- a/src/main/java/com/vonage/client/verify/VerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/VerifyResponse.java
@@ -18,10 +18,8 @@ package com.vonage.client.verify;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vonage.client.VonageResponseParseException;
-import com.vonage.client.VonageUnexpectedException;
 import java.io.IOException;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -60,6 +58,7 @@ public class VerifyResponse {
 
     /**
      * @return The network ID, if {@link #getStatus()} returns {@link VerifyStatus#NUMBER_BARRED}.
+     *
      * @since 7.1.0
      */
     @JsonProperty("network")
@@ -71,10 +70,9 @@ public class VerifyResponse {
         try {
             ObjectMapper mapper = new ObjectMapper();
             return mapper.readValue(json, VerifyResponse.class);
-        } catch (JsonMappingException jme) {
+        }
+        catch (IOException jme) {
             throw new VonageResponseParseException("Failed to produce VerifyResponse from json.", jme);
-        } catch (IOException jpe) {
-            throw new VonageUnexpectedException("Failed to produce VerifyResponse from json.", jpe);
         }
     }
 }

--- a/src/main/java/com/vonage/client/verify2/VerificationRequest.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationRequest.java
@@ -275,7 +275,7 @@ public class VerificationRequest {
 		}
 
 		/**
-		 * (REQUIRED)
+		 * (OPTIONAL)
 		 * Length of the code to send to the user, must be between 4 and 10 (inclusive).
 		 * This is not used for Silent Auth or Whatsapp Interactive.
 		 *

--- a/src/test/java/com/vonage/client/verify/VerifyClientCheckEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientCheckEndpointTest.java
@@ -17,8 +17,7 @@ package com.vonage.client.verify;
 
 import com.vonage.client.ClientTest;
 import com.vonage.client.VonageResponseParseException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 import java.math.BigDecimal;
@@ -49,6 +48,7 @@ public class VerifyClientCheckEndpointTest extends ClientTest<VerifyClient> {
         for (CheckResponse response : responses) {
             assertEquals("a-request-id", response.getRequestId());
             assertEquals(VerifyStatus.OK, response.getStatus());
+            assertFalse(response.getStatus().isTemporaryError());
             assertEquals("an-event-id", response.getEventId());
             assertEquals(new BigDecimal("0.10000000"), response.getPrice());
             assertEquals("EUR", response.getCurrency());

--- a/src/test/java/com/vonage/client/verify/VerifyClientSearchEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientSearchEndpointTest.java
@@ -44,7 +44,8 @@ public class VerifyClientSearchEndpointTest extends ClientTest<VerifyClient> {
                 + "      \"status\": \"VALID\",\n" + "      \"ip_address\": \"\"\n" + "    }\n" + "  ],\n"
                 + "  \"first_event_date\": \"2012-01-02 03:04:05\",\n"
                 + "  \"last_event_date\": \"2012-01-02 03:04:06\",\n" + "  \"price\": \"0.03000000\",\n"
-                + "  \"currency\": \"EUR\",\n" + "  \"status\": \"SUCCESS\"\n" + "}";
+                + "  \"currency\": \"EUR\",\n" + "  \"status\": \"SUCCESS\",\n"
+                + "  \"estimated_price_messages_sent\": \"0.03330000\"\n}";
         wrapper.setHttpClient(stubHttpClient(200, json));
 
         SearchVerifyResponse response = client.search("not-a-search-request-id");
@@ -75,6 +76,7 @@ public class VerifyClientSearchEndpointTest extends ClientTest<VerifyClient> {
         assertEquals("not-a-search-request-id", details.getRequestId());
         assertEquals("447700900991", details.getSenderId());
         assertEquals(VerifyDetails.Status.SUCCESS, details.getStatus());
+        assertEquals(0.03330000, details.getEstimatedPriceMessagesSent().doubleValue(), 0.001);
 
         List<VerifyCheck> checks = details.getChecks();
 

--- a/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
@@ -137,4 +137,17 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
         assertEquals("error", response.getErrorText());
         assertEquals("not-really-a-request-id", response.getRequestId());
     }
+
+    @Test
+    public void testVerifyWithWorkflow() throws Exception {
+        wrapper.setHttpClient(stubHttpClient(200,
+                "{\n" + "  \"request_id\": \"not-really-a-request-id\",\n" + "  \"status\": \"test\",\n"
+                        + "  \"error_text\": \"error\"\n" + "}"
+        ));
+
+        VerifyResponse response = client.verify("447900000000", "testBrand", VerifyRequest.Workflow.SMS);
+        assertEquals(VerifyStatus.INTERNAL_ERROR, response.getStatus());
+        assertEquals("error", response.getErrorText());
+        assertEquals("not-really-a-request-id", response.getRequestId());
+    }
 }


### PR DESCRIPTION
Adds the missing `pin_code` parameter to the classic Verify API. Also improves test coverage. and validation for pin length.
