### PR TITLE
Fix Silent Auth URL deserialisation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = v7.4.0
+current_version = v7.5.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [7.5.0] - 2023-06
+- Added custom PIN functionality to Verify v1
+- Fixed Silent Auth action URL webhook deserialization issue
+
 # [7.4.0] - 2023-05-18
 - Added Verify v2 API implementation
 - Added Advanced Machine Detection to Voice API

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For Gradle 3.4 or Higher:
 
 ```groovy
 dependencies {
-    implementation 'com.vonage:client:7.4.0'
+    implementation 'com.vonage:client:7.5.0'
 }
 ```
 
@@ -42,7 +42,7 @@ For older versions:
 
 ```groovy
 dependencies {
-    compile 'com.vonage:client:7.4.0'
+    compile 'com.vonage:client:7.5.0'
 }
 ```
 
@@ -54,7 +54,7 @@ Add the following to the correct place in your project's POM file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>client</artifactId>
-    <version>7.4.0</version>
+    <version>7.5.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ dependencies {
 
     implementation 'commons-codec:commons-codec:1.15'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.0'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.0'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2'
     implementation 'io.openapitools.jackson.dataformat:jackson-dataformat-hal:1.0.9'
     implementation 'com.vonage:jwt:1.0.2'
 
@@ -38,7 +38,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.springframework:spring-test:5.3.27'
     testImplementation 'org.springframework:spring-web:5.3.27'
-    testImplementation 'com.sparkjava:spark-core:2.9.4'
+    testImplementation 'jakarta.servlet:jakarta.servlet-api:4.0.4'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = "com.vonage"
 archivesBaseName = "client"
-version = "7.4.0"
+version = "7.5.0"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class HttpWrapper {
     private static final String CLIENT_NAME = "vonage-java-sdk";
-    private static final String CLIENT_VERSION = "7.4.0";
+    private static final String CLIENT_VERSION = "7.5.0";
     private static final String JAVA_VERSION = System.getProperty("java.version");
     private static final String USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/messages/Channel.java
+++ b/src/main/java/com/vonage/client/messages/Channel.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import static com.vonage.client.messages.MessageType.*;
 import java.util.EnumSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Represents the services available for sending messages.
@@ -38,13 +39,25 @@ public enum Channel {
 	}
 
 	/**
-	 * This method is useful for determining which message types are supported
-	 * by this messaging service.
+	 * This method is useful for determining which message types are applicable to this messaging service.
 	 *
 	 * @return The Set of message types that this service can handle.
 	 */
 	public Set<MessageType> getSupportedMessageTypes() {
 		return supportedTypes;
+	}
+
+	/**
+	 * Similar to {@link #getSupportedMessageTypes()} but excludes message types used only for inbound / webhooks.
+	 *
+	 * @return The Set of message types that this service can send.
+	 * @since 7.5.0
+	 */
+	public Set<MessageType> getSupportedOutboundMessageTypes() {
+		return getSupportedMessageTypes().stream().filter(mt -> mt != MessageType.UNSUPPORTED &&
+				mt != MessageType.REPLY && mt != MessageType.ORDER &&
+				(this != Channel.MMS || mt != MessageType.TEXT)
+		).collect(Collectors.toSet());
 	}
 
 	@JsonCreator

--- a/src/main/java/com/vonage/client/messages/MessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/MessageRequest.java
@@ -53,7 +53,7 @@ public abstract class MessageRequest {
 	protected MessageRequest(Builder<?, ?> builder, Channel channel, MessageType messageType) {
 		this.messageType = Objects.requireNonNull(messageType, "Message type cannot be null");
 		this.channel = Objects.requireNonNull(channel, "Channel cannot be null");
-		if (!this.channel.getSupportedMessageTypes().contains(this.messageType)) {
+		if (!this.channel.getSupportedOutboundMessageTypes().contains(this.messageType)) {
 			throw new IllegalArgumentException(this.messageType +" cannot be sent via "+ this.channel);
 		}
 		clientRef = validateClientReference(builder.clientRef);

--- a/src/main/java/com/vonage/client/verify2/VerificationCallback.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationCallback.java
@@ -41,7 +41,7 @@ public class VerificationCallback {
 	protected String clientRef;
 	protected Integer channelTimeout;
 	protected List<WorkflowStatus> workflows;
-	@JsonProperty("action") List<Action> actions;
+	@JsonProperty("action") Action action;
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	static class Action {
@@ -166,10 +166,10 @@ public class VerificationCallback {
 	 */
 	@JsonIgnore
 	public URI getSilentAuthUrl() {
-		if (actions == null || actions.isEmpty() || channel != Channel.SILENT_AUTH) {
+		if (action == null || channel != Channel.SILENT_AUTH) {
 			return null;
 		}
-		return actions.get(0).checkUrl;
+		return action.checkUrl;
 	}
 
 	/**

--- a/src/test/java/com/vonage/client/verify2/VerificationCallbackTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationCallbackTest.java
@@ -132,12 +132,10 @@ public class VerificationCallbackTest {
 				"   \"type\": \"event\",\n" +
 				"   \"channel\": \"silent_auth\",\n" +
 				"   \"status\": \"action_pending\",\n" +
-				"   \"action\": [\n" +
-				"      {\n" +
-				"         \"type\": \"check\",\n" +
-				"         \"check_url\": \"https://eu.api.silent.auth/phone_check/v0.1/checks/request_id/redirect\"\n" +
-				"      }\n" +
-				"   ]\n" +
+				"   \"action\": {\n" +
+				"       \"type\": \"check\",\n" +
+				"       \"check_url\": \"https://eu.api.silent.auth/phone_check/v0.1/checks/request_id/redirect\"\n" +
+				"    }\n" +
 				"}"
 		);
 		assertEquals(UUID.fromString("c15236f4-00bf-4b89-84ba-88b25df97315"), webhook.getRequestId());
@@ -145,9 +143,8 @@ public class VerificationCallbackTest {
 		assertEquals(CallbackType.EVENT, webhook.getType());
 		assertEquals(Channel.SILENT_AUTH, webhook.getChannel());
 		assertEquals(VerificationStatus.ACTION_PENDING, webhook.getStatus());
-		assertNotNull(webhook.actions);
-		assertEquals(1, webhook.actions.size());
-		assertEquals("check", webhook.actions.get(0).type);
+		assertNotNull(webhook.action);
+		assertEquals("check", webhook.action.type);
 		assertEquals(
 				URI.create("https://eu.api.silent.auth/phone_check/v0.1/checks/request_id/redirect"),
 				webhook.getSilentAuthUrl()


### PR DESCRIPTION
This PR remediates the currently broken `VerificationCallback#getSilentAuthUrl()` method due to an inaccuracy in the [Verify v2 webhook spec](https://developer.vonage.com/en/api/verify.v2#silent-auth-update).