### PR TITLE
Add missing query parameters for ListEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# [7.6.0] - 2023-06-29
+# [7.6.0] - 2023-06-30
 - Added Proactive Connect API implementation
 - Added Meetings API implementation
 - Updated Subaccounts name & secret validation logic

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     compileOnly 'jakarta.servlet:jakarta.servlet-api:4.0.4'
 
-    implementation 'commons-codec:commons-codec:1.15'
+    implementation 'commons-codec:commons-codec:1.16.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.httpcomponents:httpmime:4.5.14'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.2'
@@ -36,7 +36,6 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:4.11.0'
-    testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'org.springframework:spring-test:5.3.28'
     testImplementation 'org.springframework:spring-web:5.3.28'
     testImplementation 'jakarta.servlet:jakarta.servlet-api:4.0.4'

--- a/src/main/java/com/vonage/client/meetings/package-info.java
+++ b/src/main/java/com/vonage/client/meetings/package-info.java
@@ -16,10 +16,9 @@
 
 /**
  * This package contains classes and sub-packages to support usage of the
- * <a href=https://developer.vonage.com/api/meetings>Meetings API</a>.
- * <br>
- * Please refer to <a href=https://developer.vonage.com/en/meetings/overview>
- * the developer documentation</a> for an overview of the concepts.
+ * <a href=https://developer.vonage.com/api/meetings>Meetings API</a>. Please refer to
+ * <a href=https://developer.vonage.com/en/meetings/overview>the developer documentation</a>
+ * for an overview of the concepts.
  *
  * @since 7.6.0
  */

--- a/src/main/java/com/vonage/client/proactiveconnect/Event.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/Event.java
@@ -121,7 +121,7 @@ public class Event {
 	}
 
 	/**
-	 * {@code src_ctx} field.
+	 * The name of the segment or matcher.
 	 *
 	 * @return The source context or {@code null} if unknown.
 	 */

--- a/src/main/java/com/vonage/client/proactiveconnect/EventType.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/EventType.java
@@ -22,15 +22,54 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Represents values for {@link Event#getType()}.
  */
 public enum EventType {
+	/**
+	 * Action call succeeded
+	 */
 	ACTION_CALL_SUCCEEDED,
+
+	/**
+	 * Action call failed
+	 */
 	ACTION_CALL_FAILED,
+
+	/**
+	 * Action call info
+	 */
 	ACTION_CALL_INFO,
+
+	/**
+	 * Recipient response
+	 */
 	RECIPIENT_RESPONSE,
+
+	/**
+	 * Run item skipped
+	 */
 	RUN_ITEM_SKIPPED,
+
+	/**
+	 * Run item failed
+	 */
 	RUN_ITEM_FAILED,
+
+	/**
+	 * Run item submitted
+	 */
 	RUN_ITEM_SUBMITTED,
+
+	/**
+	 * Run items total
+	 */
 	RUN_ITEMS_TOTAL,
+
+	/**
+	 * Run items ready
+	 */
 	RUN_ITEMS_READY,
+
+	/**
+	 * Run items excluded
+	 */
 	RUN_ITEMS_EXCLUDED;
 
 	@JsonCreator

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsEndpoint.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsEndpoint.java
@@ -22,7 +22,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import java.io.IOException;
 
-class ListEventsEndpoint extends AbstractMethod<HalRequestWrapper, ListEventsResponse> {
+class ListEventsEndpoint extends AbstractMethod<ListEventsFilter, ListEventsResponse> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 	private static final String PATH = "/v0.1/bulk/events";
 
@@ -36,10 +36,9 @@ class ListEventsEndpoint extends AbstractMethod<HalRequestWrapper, ListEventsRes
 	}
 
 	@Override
-	public RequestBuilder makeRequest(HalRequestWrapper request) {
+	public RequestBuilder makeRequest(ListEventsFilter request) {
 		String uri = httpWrapper.getHttpConfig().getApiEuBaseUri() + PATH;
-		return request.addParams(RequestBuilder.get(uri))
-				.setHeader("Accept", "application/json");
+		return request.addParams(RequestBuilder.get(uri)).setHeader("Accept", "application/json");
 	}
 
 	@Override

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsFilter.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsFilter.java
@@ -1,0 +1,347 @@
+/*
+ *   Copyright 2023 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.proactiveconnect;
+
+import org.apache.http.client.methods.RequestBuilder;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+/**
+ * Filter options for finding events using {@link ProactiveConnectClient#listEvents(ListEventsFilter)}.
+ */
+public class ListEventsFilter {
+	private final SortOrder order;
+	private final UUID runId, runItemId, invocationId, actionId, traceId;
+	private final String recipientId, sourceContext;
+	private final SourceType sourceType;
+	private final Instant startDate, endDate;
+
+	ListEventsFilter(Builder builder) {
+		order = builder.order;
+		runId = builder.runId != null ? UUID.fromString(builder.runId) : null;
+		runItemId = builder.runItemId != null ? UUID.fromString(builder.runItemId) : null;
+		invocationId = builder.invocationId != null ? UUID.fromString(builder.invocationId) : null;
+		actionId = builder.actionId != null ? UUID.fromString(builder.actionId) : null;
+		traceId = builder.traceId != null ? UUID.fromString(builder.traceId) : null;
+		recipientId = builder.recipientId;
+		sourceContext = builder.sourceContext;
+		sourceType = builder.sourceType;
+		startDate = builder.startDate;
+		if ((endDate = builder.endDate) != null && startDate != null && startDate.isAfter(endDate)) {
+			throw new IllegalStateException("Start date cannot be later than end date.");
+		}
+	}
+
+	RequestBuilder addParams(RequestBuilder request) {
+		request.addParameter("page", "1").addParameter("page_size", "1000");
+		if (order != null) {
+			request.addParameter("order", order.toString());
+		}
+		if (runId != null) {
+			request.addParameter("run_id", runId.toString());
+		}
+		if (runItemId != null) {
+			request.addParameter("run_item_id", runItemId.toString());
+		}
+		if (invocationId != null) {
+			request.addParameter("invocation_id", invocationId.toString());
+		}
+		if (actionId != null) {
+			request.addParameter("action_id", actionId.toString());
+		}
+		if (traceId != null) {
+			request.addParameter("trace_id", traceId.toString());
+		}
+		if (recipientId != null) {
+			request.addParameter("recipient_id", recipientId);
+		}
+		if (sourceContext != null) {
+			request.addParameter("src_ctx", sourceContext);
+		}
+		if (sourceType != null) {
+			request.addParameter("src_type", sourceType.toString());
+		}
+		if (startDate != null) {
+			request.addParameter("date_start", startDate.truncatedTo(ChronoUnit.SECONDS).toString());
+		}
+		if (endDate != null) {
+			request.addParameter("date_end", endDate.truncatedTo(ChronoUnit.SECONDS).toString());
+		}
+		return request;
+	}
+
+	/**
+	 * Sort in either ascending or descending order.
+	 *
+	 * @return The sort order as an enum, or {@code null} if unspecified.
+	 */
+	public SortOrder getOrder() {
+		return order;
+	}
+
+	/**
+	 * Run ID to filter by.
+	 *
+	 * @return The run ID, or {@code null} if unspecified.
+	 */
+	public UUID getRunId() {
+		return runId;
+	}
+
+	/**
+	 * Run item ID to filter by.
+	 *
+	 * @return The run item ID, or {@code null} if unspecified.
+	 */
+	public UUID getRunItemId() {
+		return runItemId;
+	}
+
+	/**
+	 * Invocation ID to filter by.
+	 *
+	 * @return The invocation ID, or {@code null} if unspecified.
+	 */
+	public UUID getInvocationId() {
+		return invocationId;
+	}
+
+	/**
+	 * Action ID to filter by.
+	 *
+	 * @return The action ID, or {@code null} if unspecified.
+	 */
+	public UUID getActionId() {
+		return actionId;
+	}
+
+	/**
+	 * Trace ID to filter by.
+	 *
+	 * @return The trace ID, or {@code null} if unspecified.
+	 */
+	public UUID getTraceId() {
+		return traceId;
+	}
+
+	/**
+	 * Recipient ID to filter by.
+	 *
+	 * @return The recipient ID, or {@code null} if unspecified.
+	 */
+	public String getRecipientId() {
+		return recipientId;
+	}
+
+	/**
+	 * The name of the segment / matcher the item / event to filter by (exact string).
+	 *
+	 * @return The source context string, or {@code null} if unspecified.
+	 */
+	public String getSourceContext() {
+		return sourceContext;
+	}
+
+	/**
+	 * Source type to filter by.
+	 *
+	 * @return The source type as an enum, or {@code null} if unspecified.
+	 */
+	public SourceType getSourceType() {
+		return sourceType;
+	}
+
+	/**
+	 * ISO-8601 formatted date for when to begin events filter.
+	 *
+	 * @return The start date for events as an Instant, or {@code null} if unspecified.
+	 */
+	public Instant getStartDate() {
+		return startDate;
+	}
+
+	/**
+	 * ISO-8601 formatted date for when to end events filter.
+	 *
+	 * @return The end date for events as an Instant, or {@code null} if unspecified.
+	 */
+	public Instant getEndDate() {
+		return endDate;
+	}
+
+	/**
+	 * Entry point for constructing an instance of this class.
+	 *
+	 * @return A new Builder.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for specifying options to filter events by. All fields are optional.
+	 */
+	public static class Builder {
+		private SortOrder order;
+		private String runId, runItemId, invocationId, actionId, traceId, recipientId, sourceContext;
+		private SourceType sourceType;
+		private Instant startDate, endDate;
+
+		Builder() {}
+
+		/**
+		 * Sort in either ascending or descending order.
+		 *
+		 * @param order The sort order as an enum.
+		 *
+		 * @return This builder.
+		 */
+		public Builder order(SortOrder order) {
+			this.order = order;
+			return this;
+		}
+
+		/**
+		 * Run ID to filter by.
+		 *
+		 * @param runId The run ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder runId(String runId) {
+			this.runId = runId;
+			return this;
+		}
+
+		/**
+		 * Run item ID to filter by.
+		 *
+		 * @param runItemId The run item ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder runItemId(String runItemId) {
+			this.runItemId = runItemId;
+			return this;
+		}
+
+		/**
+		 * Invocation ID to filter by.
+		 *
+		 * @param invocationId The invocation ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder invocationId(String invocationId) {
+			this.invocationId = invocationId;
+			return this;
+		}
+
+		/**
+		 * Action ID to filter by.
+		 *
+		 * @param actionId The action ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder actionId(String actionId) {
+			this.actionId = actionId;
+			return this;
+		}
+
+		/**
+		 * Trace ID to filter by.
+		 *
+		 * @param traceId The trace ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder traceId(String traceId) {
+			this.traceId = traceId;
+			return this;
+		}
+
+		/**
+		 * Recipient ID to filter by.
+		 *
+		 * @param recipientId The recipient ID.
+		 *
+		 * @return This builder.
+		 */
+		public Builder recipientId(String recipientId) {
+			this.recipientId = recipientId;
+			return this;
+		}
+
+		/**
+		 * The name of the segment / matcher the item / event to filter by (exact string).
+		 *
+		 * @param sourceContext The source context string.
+		 *
+		 * @return This builder.
+		 */
+		public Builder sourceContext(String sourceContext) {
+			this.sourceContext = sourceContext;
+			return this;
+		}
+
+		/**
+		 * Source type to filter by.
+		 *
+		 * @param sourceType The source type as an enum.
+		 *
+		 * @return This builder.
+		 */
+		public Builder sourceType(SourceType sourceType) {
+			this.sourceType = sourceType;
+			return this;
+		}
+
+		/**
+		 * ISO-8601 formatted date for when to begin events filter.
+		 *
+		 * @param startDate The start date for events as an Instant.
+		 *
+		 * @return This builder.
+		 */
+		public Builder startDate(Instant startDate) {
+			this.startDate = startDate;
+			return this;
+		}
+
+		/**
+		 * ISO-8601 formatted date for when to end events filter.
+		 *
+		 * @param endDate The end date for events as an Instant.
+		 *
+		 * @return This builder.
+		 */
+		public Builder endDate(Instant endDate) {
+			this.endDate = endDate;
+			return this;
+		}
+
+		/**
+		 * Builds the {@linkplain ListEventsFilter}.
+		 *
+		 * @return An instance of ListEventsFilter, populated with all fields from this builder.
+		 */
+		public ListEventsFilter build() {
+			return new ListEventsFilter(this);
+		}
+	}
+}

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
@@ -26,10 +26,10 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * HAL response for {@link ProactiveConnectClient#listEvents(int, int)}.
+ * HAL response for {@link ProactiveConnectClient#listEvents(ListEventsFilter)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class ListEventsResponse extends HalPageResponse {
+final class ListEventsResponse extends HalPageResponse {
 	@JsonProperty("_embedded") private Embedded _embedded;
 
 	ListEventsResponse() {

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * HAL response for {@link ProactiveConnectClient#listItems(UUID, int, int)}.
+ * HAL response for {@link ProactiveConnectClient#listItems(UUID, int, int, SortOrder)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class ListItemsResponse extends HalPageResponse {

--- a/src/main/java/com/vonage/client/proactiveconnect/ListListsEndpoint.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListListsEndpoint.java
@@ -22,7 +22,7 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import java.io.IOException;
 
-class ListListsEndpoint extends AbstractMethod<HalRequestWrapper, ListsResponse> {
+class ListListsEndpoint extends AbstractMethod<HalRequestWrapper, ListListsResponse> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
 	private static final String PATH = "/v0.1/bulk/lists";
 
@@ -43,10 +43,10 @@ class ListListsEndpoint extends AbstractMethod<HalRequestWrapper, ListsResponse>
 	}
 
 	@Override
-	public ListsResponse parseResponse(HttpResponse response) throws IOException {
+	public ListListsResponse parseResponse(HttpResponse response) throws IOException {
 		int statusCode = response.getStatusLine().getStatusCode();
 		if (statusCode >= 200 && statusCode < 300) {
-			return ListsResponse.fromJson(basicResponseHandler.handleResponse(response));
+			return ListListsResponse.fromJson(basicResponseHandler.handleResponse(response));
 		}
 		else {
 			throw ProactiveConnectResponseException.fromHttpResponse(response);

--- a/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
@@ -29,10 +29,10 @@ import java.util.List;
  * HAL response for {@link ProactiveConnectClient#listLists(int, int, SortOrder)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class ListsResponse extends HalPageResponse {
+public final class ListListsResponse extends HalPageResponse {
 	@JsonProperty("_embedded") private Embedded _embedded;
 
-	ListsResponse() {}
+	ListListsResponse() {}
 
 	@JsonIgnoreProperties(ignoreUnknown = true)
 	static final class Embedded {
@@ -60,14 +60,14 @@ public final class ListsResponse extends HalPageResponse {
 	 * @param json The JSON string to parse.
 	 * @return An instance of this class with the fields populated, if present.
 	 */
-	public static ListsResponse fromJson(String json) {
+	public static ListListsResponse fromJson(String json) {
 		try {
 			ObjectMapper mapper = new ObjectMapper();
 			mapper.registerModule(new JavaTimeModule());
-			return mapper.readValue(json, ListsResponse.class);
+			return mapper.readValue(json, ListListsResponse.class);
 		}
 		catch (IOException ex) {
-			throw new VonageResponseParseException("Failed to produce ListsResponse from json.", ex);
+			throw new VonageResponseParseException("Failed to produce ListListsResponse from json.", ex);
 		}
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ListsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListsResponse.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * HAL response for {@link ProactiveConnectClient#listLists(int, int)}.
+ * HAL response for {@link ProactiveConnectClient#listLists(int, int, SortOrder)}.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class ListsResponse extends HalPageResponse {

--- a/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
@@ -197,7 +197,7 @@ public class ProactiveConnectClient {
 	 *
 	 * @throws ProactiveConnectResponseException If there was an error in retrieving the lists.
 	 */
-	public ListsResponse listLists(int page, int pageSize, SortOrder order) {
+	public ListListsResponse listLists(int page, int pageSize, SortOrder order) {
 		return halRequest(listLists, null, page, pageSize, order);
 	}
 

--- a/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
@@ -76,14 +76,15 @@ public class ProactiveConnectClient {
 		return Objects.requireNonNull(uuid, name+" is required.").toString();
 	}
 
-	private <R extends HalPageResponse> R halRequest(AbstractMethod<HalRequestWrapper, R> endpoint, String id, Integer page, Integer pageSize) {
+	private <R extends HalPageResponse> R halRequest(AbstractMethod<HalRequestWrapper, R> endpoint,
+			String id, Integer page, Integer pageSize, SortOrder order) {
 		if (page != null && page < 1) {
 			throw new IllegalArgumentException("Page number must be positive.");
 		}
 		if (pageSize != null && pageSize < 1) {
 			throw new IllegalArgumentException("Page size must be positive.");
 		}
-		return endpoint.execute(new HalRequestWrapper(page, pageSize, id));
+		return endpoint.execute(new HalRequestWrapper(page, pageSize, order, id));
 	}
 
 	/**
@@ -182,21 +183,7 @@ public class ProactiveConnectClient {
 	 * @throws ProactiveConnectResponseException If there was an error in retrieving the lists.
 	 */
 	public List<ContactsList> listLists() {
-		return halRequest(listLists, null, 1, 1000).getLists();
-	}
-
-	/**
-	 * Get all lists on a particular page (with the default number of lists per page).
-	 *
-	 * @param page The page number of the HAL response to parse results.
-	 *
-	 * @return The lists page.
-	 * @see #listLists(int, int)
-	 *
-	 * @throws ProactiveConnectResponseException If there was an error in retrieving the lists.
-	 */
-	public ListsResponse listLists(int page) {
-		return halRequest(listLists, null,page, null);
+		return halRequest(listLists, null, 1, 1000, null).getLists();
 	}
 
 	/**
@@ -204,13 +191,14 @@ public class ProactiveConnectClient {
 	 *
 	 * @param page The page number of the HAL response to parse results.
 	 * @param pageSize Number of results per page in the HAL response.
+	 * @param order The order to sort results by (ascending or descending).
 	 *
 	 * @return The lists page.
 	 *
 	 * @throws ProactiveConnectResponseException If there was an error in retrieving the lists.
 	 */
-	public ListsResponse listLists(int page, int pageSize) {
-		return halRequest(listLists, null, page, pageSize);
+	public ListsResponse listLists(int page, int pageSize, SortOrder order) {
+		return halRequest(listLists, null, page, pageSize, order);
 	}
 
 	/**
@@ -360,22 +348,7 @@ public class ProactiveConnectClient {
 	 * @throws ProactiveConnectResponseException If the list does not exist or the items couldn't be retrieved.
 	 */
 	public List<ListItem> listItems(UUID listId) {
-		return halRequest(listItems, validateUuid("List ID", listId), 1, 1000).getItems();
-	}
-
-	/**
-	 * Get all items on a particular page (with the default number of items per page).
-	 *
-	 * @param listId Unique ID of the list to retrieve items from.
-	 * @param page The page number of the HAL response to parse results.
-	 *
-	 * @return The items page.
-	 * @see #listItems(UUID, int, int)
-	 *
-	 * @throws ProactiveConnectResponseException If the list does not exist or the items couldn't be retrieved.
-	 */
-	public ListItemsResponse listItems(UUID listId, int page) {
-		return halRequest(listItems, validateUuid("List ID", listId), page, null);
+		return halRequest(listItems, validateUuid("List ID", listId), 1, 1000, null).getItems();
 	}
 
 	/**
@@ -384,51 +357,26 @@ public class ProactiveConnectClient {
 	 * @param listId Unique ID of the list to retrieve items from.
 	 * @param page The page number of the HAL response to parse results.
 	 * @param pageSize Number of results per page in the HAL response.
+	 * @param order The order to sort results by (ascending or descending).
 	 *
 	 * @return The items page.
 	 *
 	 * @throws ProactiveConnectResponseException If the list does not exist or the items couldn't be retrieved.
 	 */
-	public ListItemsResponse listItems(UUID listId, int page, int pageSize) {
-		return halRequest(listItems, validateUuid("List ID", listId), page, pageSize);
+	public ListItemsResponse listItems(UUID listId, int page, int pageSize, SortOrder order) {
+		return halRequest(listItems, validateUuid("List ID", listId), page, pageSize, order);
 	}
 
 	/**
-	 * Gets the first 1000 events in the application.
+	 * Gets all events in the application matching the criteria.
 	 *
-	 * @return The events in order of creation.
+	 * @param filter Optional attributes to narrow down the results.
 	 *
-	 * @throws ProactiveConnectResponseException If the events couldn't be retrieved.
-	 */
-	public List<Event> listEvents() {
-		return halRequest(listEvents, null, 1, 1000).getEvents();
-	}
-
-	/**
-	 * Get all events on a particular page (with the default number of events per page).
-	 *
-	 * @param page The page number of the HAL response to parse results.
-	 *
-	 * @return The events page.
-	 * @see #listEvents(int, int)
+	 * @return The list of events applicable to the request criteria, in order of creation.
 	 *
 	 * @throws ProactiveConnectResponseException If the events couldn't be retrieved.
 	 */
-	public ListEventsResponse listEvents(int page) {
-		return halRequest(listEvents, null, page, null);
-	}
-
-	/**
-	 * Get all events on a particular page.
-	 *
-	 * @param page The page number of the HAL response to parse results.
-	 * @param pageSize Number of results per page in the HAL response.
-	 *
-	 * @return The events page.
-	 *
-	 * @throws ProactiveConnectResponseException If the events couldn't be retrieved.
-	 */
-	public ListEventsResponse listEvents(int page, int pageSize) {
-		return halRequest(listEvents, null, page, pageSize);
+	public List<Event> listEvents(ListEventsFilter filter) {
+		return listEvents.execute(filter != null ? filter : ListEventsFilter.builder().build()).getEvents();
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/SortOrder.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SortOrder.java
@@ -15,30 +15,25 @@
  */
 package com.vonage.client.proactiveconnect;
 
-import org.apache.http.client.methods.RequestBuilder;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-class HalRequestWrapper {
-	final Integer page, pageSize;
-	final SortOrder order;
-	final String id;
+/**
+ * Represents the sort order for events.
+ */
+public enum SortOrder {
+	/**
+	 * Ascending
+	 */
+	ASC,
 
-	HalRequestWrapper(Integer page, Integer pageSize, SortOrder order, String id) {
-		this.page = page;
-		this.pageSize = pageSize;
-		this.order = order;
-		this.id = id;
-	}
+	/**
+	 * Descending
+	 */
+	DESC;
 
-	RequestBuilder addParams(RequestBuilder builder) {
-		if (page != null) {
-			builder.addParameter("page", page.toString());
-		}
-		if (pageSize != null) {
-			builder.addParameter("page_size", pageSize.toString());
-		}
-		if (order != null) {
-			builder.addParameter("order", order.toString());
-		}
-		return builder;
-	}
+	@JsonValue
+	@Override
+	public String toString() {
+		return name().toLowerCase();
+	}	
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/SourceType.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SourceType.java
@@ -15,30 +15,25 @@
  */
 package com.vonage.client.proactiveconnect;
 
-import org.apache.http.client.methods.RequestBuilder;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-class HalRequestWrapper {
-	final Integer page, pageSize;
-	final SortOrder order;
-	final String id;
+/**
+ * Represents source types for events.
+ */
+public enum SourceType {
+	/**
+	 * Segmentation
+	 */
+	SEGMENTATION,
 
-	HalRequestWrapper(Integer page, Integer pageSize, SortOrder order, String id) {
-		this.page = page;
-		this.pageSize = pageSize;
-		this.order = order;
-		this.id = id;
-	}
+	/**
+	 * Event handler
+	 */
+	EVENT_HANDLER;
 
-	RequestBuilder addParams(RequestBuilder builder) {
-		if (page != null) {
-			builder.addParameter("page", page.toString());
-		}
-		if (pageSize != null) {
-			builder.addParameter("page_size", pageSize.toString());
-		}
-		if (order != null) {
-			builder.addParameter("order", order.toString());
-		}
-		return builder;
-	}
+	@JsonValue
+	@Override
+	public String toString() {
+		return name().toLowerCase().replace('_', '-');
+	}	
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/package-info.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/package-info.java
@@ -16,8 +16,9 @@
 
 /**
  * This package contains classes and sub-packages to support usage of the
- * <a href=https://developer.vonage.com/en/proactive-connect/overview>Vonage Proactive Connect API</a>.
- * <br>
+ * <a href=https://developer.vonage.com/en/api/proactive-connect>Vonage Proactive Connect API</a>. Please
+ * refer to <a href=https://developer.vonage.com/en/proactive-connect/overview> the developer documentation</a>
+ * for an overview of the concepts.
  *
  * @since 7.6.0
  */

--- a/src/test/java/com/vonage/client/BugRepro.java
+++ b/src/test/java/com/vonage/client/BugRepro.java
@@ -35,7 +35,7 @@ public class BugRepro {
 
 		try {
 			// Debug code here
-
+			
 			System.out.println("Success");
 		}
 		catch (Exception ex) {

--- a/src/test/java/com/vonage/client/proactiveconnect/ListEventsEndpointTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ListEventsEndpointTest.java
@@ -28,6 +28,7 @@ import org.junit.Assert;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
@@ -47,24 +48,54 @@ public class ListEventsEndpointTest {
 	}
 	
 	@Test
-	public void testMakeRequestAllParams() throws Exception {
-		HalRequestWrapper request = new HalRequestWrapper(6, 50, null);
+	public void testDefaultUriAllParams() throws Exception {
+		ListEventsFilter request = ListEventsFilter.builder()
+				.order(SortOrder.ASC)
+				.runId("51aca838-2cf6-4100-b0d2-e74ac0e95c88")
+				.runItemId("d6f1d012-227e-4025-a388-3d1aaa05bc29")
+				.invocationId("29bab76c-156e-42e4-ab38-f6a465f0048e")
+				.actionId("99ea10e0-1f14-4f55-b976-3c88ea8ec4cd")
+				.traceId("a3c7472d-495a-4f6f-b29a-1646ffe70643")
+				.recipientId("15551584817")
+				.sourceContext("uk-customers")
+				.sourceType(SourceType.EVENT_HANDLER)
+				.startDate(Instant.EPOCH)
+				.endDate(Instant.parse("2023-06-29T12:39:34.319723Z"))
+				.build();
+
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/events" +
-				"?page=" + request.page + "&page_size=" + request.pageSize;
-		assertEquals(expectedUri, builder.build().getURI().toString());
+		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/events?";
+		assertTrue(builder.build().getURI().toString().startsWith(expectedUri));
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
-		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
-		assertEquals(2, params.size());
-	}
 
-	@Test
-	public void testDefaultUri() throws Exception {
-		RequestBuilder builder = endpoint.makeRequest(new HalRequestWrapper(null, null, null));
-		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/events";
-		assertEquals(expectedUri, builder.build().getURI().toString());
+		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
+		assertEquals(13, params.size());
+		assertEquals("1", params.get("page"));
+		assertEquals("1000", params.get("page_size"));
+		assertEquals("asc", params.get("order"));
+		assertEquals("51aca838-2cf6-4100-b0d2-e74ac0e95c88", params.get("run_id"));
+		assertEquals("d6f1d012-227e-4025-a388-3d1aaa05bc29", params.get("run_item_id"));
+		assertEquals("29bab76c-156e-42e4-ab38-f6a465f0048e", params.get("invocation_id"));
+		assertEquals("99ea10e0-1f14-4f55-b976-3c88ea8ec4cd", params.get("action_id"));
+		assertEquals("a3c7472d-495a-4f6f-b29a-1646ffe70643", params.get("trace_id"));
+		assertEquals("15551584817", params.get("recipient_id"));
+		assertEquals("uk-customers", params.get("src_ctx"));
+		assertEquals("event-handler", params.get("src_type"));
+		assertEquals("1970-01-01T00:00:00Z", params.get("date_start"));
+		assertEquals("2023-06-29T12:39:34Z", params.get("date_end"));
+
+		assertNotNull(request.getOrder());
+		assertNotNull(request.getActionId());
+		assertNotNull(request.getInvocationId());
+		assertNotNull(request.getRecipientId());
+		assertNotNull(request.getRunItemId());
+		assertNotNull(request.getRunId());
+		assertNotNull(request.getTraceId());
+		assertNotNull(request.getSourceContext());
+		assertNotNull(request.getSourceType());
+		assertNotNull(request.getStartDate());
+		assertNotNull(request.getEndDate());
 	}
 
 	@Test
@@ -72,9 +103,8 @@ public class ListEventsEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListEventsEndpoint(wrapper);
-		HalRequestWrapper request = new HalRequestWrapper(3, null, null);
-		String expectedUri = baseUri + "/v0.1/bulk/events?page="+ request.page;
-		RequestBuilder builder = endpoint.makeRequest(request);
+		String expectedUri = baseUri + "/v0.1/bulk/events?page=1&page_size=1000";
+		RequestBuilder builder = endpoint.makeRequest(ListEventsFilter.builder().build());
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		assertEquals("GET", builder.getMethod());

--- a/src/test/java/com/vonage/client/proactiveconnect/ListItemsEndpointTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ListItemsEndpointTest.java
@@ -50,24 +50,24 @@ public class ListItemsEndpointTest {
 	
 	@Test
 	public void testMakeRequestAllParams() throws Exception {
-		HalRequestWrapper request = new HalRequestWrapper(7, 30, listId);
+		HalRequestWrapper request = new HalRequestWrapper(7, 30, SortOrder.DESC, listId);
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
 		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/lists/"+request.id+"/items" +
-				"?page=" + request.page + "&page_size=" +request.pageSize;
+				"?page="+request.page+"&page_size="+request.pageSize+"&order="+request.order;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
-		assertEquals(2, params.size());
-		String expectedResponse = "{}";
-		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, expectedResponse);
+		assertEquals(3, params.size());
+		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, "{}");
 		ListItemsResponse parsed = endpoint.parseResponse(mockResponse);
 		assertNotNull(parsed);
 	}
 
 	@Test
 	public void testDefaultUri() throws Exception {
-		RequestBuilder builder = endpoint.makeRequest(new HalRequestWrapper(null, null, listId));
+		HalRequestWrapper request = new HalRequestWrapper(null, null, null, listId);
+		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
 		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/lists/"+listId+"/items";
 		assertEquals(expectedUri, builder.build().getURI().toString());
@@ -78,7 +78,7 @@ public class ListItemsEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListItemsEndpoint(wrapper);
-		HalRequestWrapper request = new HalRequestWrapper(2, null, listId);
+		HalRequestWrapper request = new HalRequestWrapper(2, null, null, listId);
 		String expectedUri = baseUri + "/v0.1/bulk/lists/"+request.id+"/items?page="+request.page;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/proactiveconnect/ListListsEndpointTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ListListsEndpointTest.java
@@ -48,20 +48,21 @@ public class ListListsEndpointTest {
 	
 	@Test
 	public void testMakeRequestAllParams() throws Exception {
-		HalRequestWrapper request = new HalRequestWrapper(3, 12, null);
+		HalRequestWrapper request = new HalRequestWrapper(3, 12, SortOrder.DESC, null);
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
 		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/lists" +
-				"?page=" + request.page + "&page_size=" + request.pageSize;
+				"?page=" + request.page + "&page_size=" + request.pageSize + "&order=" + request.order;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
-		assertEquals(2, params.size());
+		assertEquals(3, params.size());
 	}
 
 	@Test
 	public void testDefaultUri() throws Exception {
-		RequestBuilder builder = endpoint.makeRequest(new HalRequestWrapper(null, null, null));
+		HalRequestWrapper request = new HalRequestWrapper(null, null, null, null);
+		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
 		String expectedUri = "https://api-eu.vonage.com/v0.1/bulk/lists";
 		assertEquals(expectedUri, builder.build().getURI().toString());
@@ -72,7 +73,7 @@ public class ListListsEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListListsEndpoint(wrapper);
-		HalRequestWrapper request = new HalRequestWrapper(5, null, null);
+		HalRequestWrapper request = new HalRequestWrapper(5, null, null, null);
 		String expectedUri = baseUri + "/v0.1/bulk/lists?page=" + request.page;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/proactiveconnect/ListListsEndpointTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ListListsEndpointTest.java
@@ -84,7 +84,7 @@ public class ListListsEndpointTest {
 	@Test
 	public void testEmptyResponse() throws Exception {
 		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, "{}");
-		ListsResponse parsed = endpoint.parseResponse(mockResponse);
+		ListListsResponse parsed = endpoint.parseResponse(mockResponse);
 		assertNotNull(parsed);
 		assertNull(parsed.getLists());
 		assertNull(parsed.getLinks());
@@ -122,7 +122,7 @@ public class ListListsEndpointTest {
 				"   }\n" +
 				"}";
 		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, expectedResponse);
-		ListsResponse parsed = endpoint.parseResponse(mockResponse);
+		ListListsResponse parsed = endpoint.parseResponse(mockResponse);
 		assertNotNull(parsed);
 		HalLinks links = parsed.getLinks();
 		assertNotNull(links);
@@ -142,7 +142,7 @@ public class ListListsEndpointTest {
 
 	@Test(expected = VonageResponseParseException.class)
 	public void testInvalidResponse() {
-		ListsResponse.fromJson("{malformed]");
+		ListListsResponse.fromJson("{malformed]");
 	}
 
 	@Test(expected = ProactiveConnectResponseException.class)

--- a/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
@@ -361,7 +361,7 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testListLists() throws Exception {
 		stubResponse(HAL_TEMPLATE_RESPONSE + "  \"lists\": [{},"+SAMPLE_LIST_RESPONSE+",{}]\n}  \n}");
-		ListsResponse parsed = client.listLists(2, 10, SortOrder.ASC);
+		ListListsResponse parsed = client.listLists(2, 10, SortOrder.ASC);
 		assertEqualsSampleHal(parsed);
 		List<ContactsList> lists = parsed.getLists();
 		assertNotNull(lists);

--- a/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
@@ -27,6 +27,7 @@ import org.junit.function.ThrowingRunnable;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 
@@ -287,19 +288,10 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testCreateList() throws Exception {
 		ContactsList request = ContactsList.builder("my list").build();
-		assertNull(request.getDatasource());
-		assertNull(request.getCreatedAt());
-		assertNull(request.getUpdatedAt());
-		assertNull(request.getTags());
-		assertNull(request.getAttributes());
-		assertNull(request.getDescription());
-		assertNull(request.getId());
-		assertNull(request.getSyncStatus());
-		assertNull(request.getItemsCount());
-		assertNotNull(request.getName());
 		assert409ResponseException(() -> client.createList(request));
-		stubResponseAndRun(SAMPLE_LIST_RESPONSE, () -> client.createList(request));
-		assertEqualsSampleList(request);
+		ContactsList response = stubResponseAndGet(SAMPLE_LIST_RESPONSE, () -> client.createList(request));
+		assertEquals(request, response);
+		assertEqualsSampleList(response);
 		stubResponseAndAssertThrows(201, () -> client.createList(null), NullPointerException.class);
 		stubResponseAndAssertThrows(201, () ->
 				client.createList(ContactsList.builder(null).build()),
@@ -369,7 +361,7 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testListLists() throws Exception {
 		stubResponse(HAL_TEMPLATE_RESPONSE + "  \"lists\": [{},"+SAMPLE_LIST_RESPONSE+",{}]\n}  \n}");
-		ListsResponse parsed = client.listLists(2, 10);
+		ListsResponse parsed = client.listLists(2, 10, SortOrder.ASC);
 		assertEqualsSampleHal(parsed);
 		List<ContactsList> lists = parsed.getLists();
 		assertNotNull(lists);
@@ -377,12 +369,12 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 		assertNullList(lists.get(0));
 		assertEqualsSampleList(lists.get(1));
 		assertNullList(lists.get(2));
-		assertNull(stubResponseAndGet("{}", () -> client.listLists(1, 1)).getLists());
+		assertNull(stubResponseAndGet("{}", () -> client.listLists(1, 1, null)).getLists());
 		stubResponseAndAssertThrows("{}", () ->
-				client.listLists(0), IllegalArgumentException.class
+				client.listLists(1, 0, SortOrder.ASC), IllegalArgumentException.class
 		);
 		stubResponseAndAssertThrows("{}", () ->
-				client.listLists(1, 0), IllegalArgumentException.class
+				client.listLists(0, 25, SortOrder.DESC), IllegalArgumentException.class
 		);
 		assertNull(stubResponseAndGet("{}", client::listLists));
 		String emptyListsResponse = "{\"_embedded\":{\"lists\":[]}}";
@@ -393,9 +385,9 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testCreateListItem() throws Exception {
 		Map<String, ?> data = Collections.emptyMap();
-		stubResponseAndRun(SAMPLE_LIST_ITEM_RESPONSE, () ->
+		assertEqualsSampleListItem(stubResponseAndGet(SAMPLE_LIST_ITEM_RESPONSE, () ->
 				client.createListItem(SAMPLE_LIST_ID, data)
-		);
+		));
 		stubResponseAndAssertThrows(200, () ->
 				client.createListItem(null, data), NullPointerException.class
 		);
@@ -504,7 +496,7 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testListItems() throws Exception {
 		stubResponse(HAL_TEMPLATE_RESPONSE + "  \"items\": [{},"+ SAMPLE_LIST_ITEM_RESPONSE +",{}]\n}  \n}");
-		ListItemsResponse parsed = client.listItems(SAMPLE_LIST_ID, 2, 10);
+		ListItemsResponse parsed = client.listItems(SAMPLE_LIST_ID, 2, 10, SortOrder.ASC);
 		assertEqualsSampleHal(parsed);
 		List<ListItem> items = parsed.getItems();
 		assertNotNull(items);
@@ -512,21 +504,20 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 		assertNullListItem(items.get(0));
 		assertEqualsSampleListItem(items.get(1));
 		assertNullListItem(items.get(2));
-		assertNull(stubResponseAndGet("{}", () -> client.listItems(SAMPLE_LIST_ID, 1, 1).getItems()));
+		assertNull(stubResponseAndGet("{}", () ->
+				client.listItems(SAMPLE_LIST_ID, 1, 1, null).getItems()
+		));
 		stubResponseAndAssertThrows("{}", () ->
-				client.listItems(SAMPLE_LIST_ID, 1, 0), IllegalArgumentException.class
+				client.listItems(SAMPLE_LIST_ID, 1, 0, SortOrder.DESC), IllegalArgumentException.class
 		);
 		stubResponseAndAssertThrows("{}", () ->
-				client.listItems(SAMPLE_LIST_ID, 0), IllegalArgumentException.class
+				client.listItems(SAMPLE_LIST_ID, 0, 25, SortOrder.DESC), IllegalArgumentException.class
 		);
 		stubResponseAndAssertThrows("{}", () ->
 				client.listItems(null), NullPointerException.class
 		);
 		stubResponseAndAssertThrows("{}", () ->
-				client.listItems(null, 3, 25), NullPointerException.class
-		);
-		stubResponseAndAssertThrows("{}", () ->
-				client.listItems(null, 2), NullPointerException.class
+				client.listItems(null, 3, 25, SortOrder.ASC), NullPointerException.class
 		);
 		assertNull(stubResponseAndGet("{}", () -> client.listItems(SAMPLE_LIST_ID)));
 		String emptyListsResponse = "{\"_embedded\":{\"items\":[]}}";
@@ -537,22 +528,23 @@ public class ProactiveConnectClientTest extends ClientTest<ProactiveConnectClien
 	@Test
 	public void testListEvents() throws Exception {
 		stubResponse(HAL_TEMPLATE_RESPONSE + "  \"events\": [{},"+ SAMPLE_EVENT_RESPONSE +",{}]\n}  \n}");
-		ListEventsResponse parsed = client.listEvents(2, 10);
-		assertEqualsSampleHal(parsed);
-		List<Event> events = parsed.getEvents();
+		List<Event> events = client.listEvents(null);
 		assertNotNull(events);
 		assertEquals(3, events.size());
 		assertNullEvent(events.get(0));
 		assertEqualsSampleEvent(events.get(1));
 		assertNullEvent(events.get(2));
-		assertNull(stubResponseAndGet("{}", () -> client.listEvents(1, 1)).getEvents());
+		assertNull(stubResponseAndGet("{}", () -> client.listEvents(null)));
 		stubResponseAndAssertThrows("{}", () ->
-				client.listEvents(1, 0), IllegalArgumentException.class
+				client.listEvents(ListEventsFilter.builder()
+						.startDate(Instant.now())
+						.endDate(Instant.now().minus(Duration.ofHours(3)))
+						.build()
+				),
+				IllegalStateException.class
 		);
-		stubResponseAndAssertThrows("{}", () -> client.listEvents(0), IllegalArgumentException.class);
-		assertNull(stubResponseAndGet("{}", client::listEvents));
 		String emptyListsResponse = "{\"_embedded\":{\"events\":[]}}";
-		assertEquals(0, stubResponseAndGet(emptyListsResponse, client::listEvents).size());
-		assert409ResponseException(client::listEvents);
+		assertEquals(0, stubResponseAndGet(emptyListsResponse, () -> client.listEvents(null)).size());
+		assert409ResponseException(() -> client.listEvents(ListEventsFilter.builder().build()));
 	}
 }


### PR DESCRIPTION
The additional query parameters for [finding all events](https://developer.vonage.com/en/api/proactive-connect#eventsFindAll) was missed in #452. Same with the `order` query parameter in `listLists` and `listItems`.