### PR TITLE
refactor: Add /v1 to Meetings endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# [7.9.0] - 2023-??-??
+# [7.9.0] - 2023-09-28
 - Added `get-full-pricing` implementation of Pricing API in `AccountClient`
 - Added master API key default overloads for secret management in Account API
 - Deprecated public internal request classes in Account API
 - Internal refactoring of Verify v1 and Account API implementations
+- Added `/v1` to Meetings API endpoint URL paths
 
 # [7.8.0] - 2023-09-07
 - Added capability to configure request timeouts (default is 60 seconds)

--- a/src/main/java/com/vonage/client/meetings/CreateRoomEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/CreateRoomEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class CreateRoomEndpoint extends AbstractMethod<MeetingRoom, MeetingRoom> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/rooms";
+	private static final String PATH = "/v1/meetings/rooms";
 	private MeetingRoom cachedRoom;
 
 	CreateRoomEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/meetings/CreateThemeEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/CreateThemeEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class CreateThemeEndpoint extends AbstractMethod<Theme, Theme> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes";
+	private static final String PATH = "/v1/meetings/themes";
 	private Theme cachedTheme;
 
 	CreateThemeEndpoint(HttpWrapper httpWrapper) {

--- a/src/main/java/com/vonage/client/meetings/DeleteRecordingEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/DeleteRecordingEndpoint.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 class DeleteRecordingEndpoint extends AbstractMethod<UUID, Void> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/recordings/%s";
+	private static final String PATH = "/v1/meetings/recordings/%s";
 
 	DeleteRecordingEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/DeleteThemeEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/DeleteThemeEndpoint.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 class DeleteThemeEndpoint extends AbstractMethod<DeleteThemeRequest, Void> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/%s";
+	private static final String PATH = "/v1/meetings/themes/%s";
 
 	DeleteThemeEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/FinalizeLogosEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/FinalizeLogosEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class FinalizeLogosEndpoint extends AbstractMethod<FinalizeLogosRequest, Void> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/%s/finalizeLogos";
+	private static final String PATH = "/v1/meetings/themes/%s/finalizeLogos";
 
 	FinalizeLogosEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/GetLogoUploadUrlsEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/GetLogoUploadUrlsEndpoint.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 class GetLogoUploadUrlsEndpoint extends AbstractMethod<Void, List<LogoUploadsUrlResponse>> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/logos-upload-urls";
+	private static final String PATH = "/v1/meetings/themes/logos-upload-urls";
 
 	GetLogoUploadUrlsEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/GetRecordingEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/GetRecordingEndpoint.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 class GetRecordingEndpoint extends AbstractMethod<UUID, Recording> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/recordings/%s";
+	private static final String PATH = "/v1/meetings/recordings/%s";
 
 	GetRecordingEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/GetRoomEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/GetRoomEndpoint.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 class GetRoomEndpoint extends AbstractMethod<UUID, MeetingRoom> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/rooms/%s";
+	private static final String PATH = "/v1/meetings/rooms/%s";
 
 	GetRoomEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/GetThemeEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/GetThemeEndpoint.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 
 class GetThemeEndpoint extends AbstractMethod<UUID, Theme> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/%s";
+	private static final String PATH = "/v1/meetings/themes/%s";
 
 	GetThemeEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/ListDialNumbersEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/ListDialNumbersEndpoint.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 class ListDialNumbersEndpoint extends AbstractMethod<Void, List<DialInNumber>> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/dial-in-numbers";
+	private static final String PATH = "/v1/meetings/dial-in-numbers";
 
 	ListDialNumbersEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/ListRecordingsEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/ListRecordingsEndpoint.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 class ListRecordingsEndpoint extends AbstractMethod<String, ListRecordingsResponse> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/sessions/%s/recordings";
+	private static final String PATH = "/v1/meetings/sessions/%s/recordings";
 
 	ListRecordingsEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/ListRoomsEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/ListRoomsEndpoint.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 class ListRoomsEndpoint extends AbstractMethod<ListRoomsRequest, ListRoomsResponse> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/rooms";
+	private static final String PATH = "/v1/meetings/rooms";
 
 	ListRoomsEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/ListThemesEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/ListThemesEndpoint.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 class ListThemesEndpoint extends AbstractMethod<Void, List<Theme>> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes";
+	private static final String PATH = "/v1/meetings/themes";
 
 	ListThemesEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/MeetingsClient.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingsClient.java
@@ -32,23 +32,21 @@ import java.util.*;
 
 public class MeetingsClient {
 	HttpClient httpClient;
-	final ListRoomsEndpoint listRooms;
-	final GetRoomEndpoint getRoom;
-	final CreateRoomEndpoint createRoom;
-	final UpdateRoomEndpoint updateRoom;
-	final SearchThemeRoomsEndpoint searchThemeRooms;
-	final ListThemesEndpoint listThemes;
-	final GetThemeEndpoint getTheme;
-	final CreateThemeEndpoint createTheme;
-	final UpdateThemeEndpoint updateTheme;
-	final DeleteThemeEndpoint deleteTheme;
-	final ListRecordingsEndpoint listRecordings;
-	final GetRecordingEndpoint getRecording;
-	final DeleteRecordingEndpoint deleteRecording;
-	final ListDialNumbersEndpoint listDialNumbers;
-	final UpdateApplicationEndpoint updateApplication;
-	final FinalizeLogosEndpoint finalizeLogos;
-	final GetLogoUploadUrlsEndpoint getLogoUploadUrls;
+	final RestEndpoint<ListRoomsRequest, ListRoomsResponse> listRooms, searchThemeRooms;
+	final RestEndpoint<UUID, MeetingRoom> getRoom;
+	final RestEndpoint<MeetingRoom, MeetingRoom> createRoom;
+	final RestEndpoint<UpdateRoomRequest, MeetingRoom> updateRoom;
+	final RestEndpoint<Void, List<Theme>> listThemes;
+	final RestEndpoint<UUID, Theme> getTheme;
+	final RestEndpoint<Theme, Theme> createTheme, updateTheme;
+	final RestEndpoint<DeleteThemeRequest, Void> deleteTheme;
+	final RestEndpoint<String, ListRecordingsResponse> listRecordings;
+	final RestEndpoint<UUID, Recording> getRecording;
+	final RestEndpoint<UUID, Void> deleteRecording;
+	final RestEndpoint<Void, List<DialInNumber>> listDialNumbers;
+	final RestEndpoint<UpdateApplicationRequest, Application> updateApplication;
+	final RestEndpoint<FinalizeLogosRequest, Void> finalizeLogos;
+	final RestEndpoint<Void, List<LogoUploadsUrlResponse>> getLogoUploadUrls;
 
 	/**
 	 * Constructor.
@@ -105,7 +103,7 @@ public class MeetingsClient {
 	}
 
 	private List<MeetingRoom> getAllRoomsFromResponseRecursively(
-			AbstractMethod<ListRoomsRequest, ListRoomsResponse> endpoint, ListRoomsRequest initialRequest) {
+			RestEndpoint<ListRoomsRequest, ListRoomsResponse> endpoint, ListRoomsRequest initialRequest) {
 
 		final int initialPageSize = initialRequest.pageSize != null ? initialRequest.pageSize : 1000;
 		ListRoomsRequest request = new ListRoomsRequest(

--- a/src/main/java/com/vonage/client/meetings/SearchThemeRoomsEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/SearchThemeRoomsEndpoint.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 
 class SearchThemeRoomsEndpoint extends AbstractMethod<ListRoomsRequest, ListRoomsResponse> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/%s/rooms";
+	private static final String PATH = "/v1/meetings/themes/%s/rooms";
 
 	SearchThemeRoomsEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/UpdateApplicationEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/UpdateApplicationEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class UpdateApplicationEndpoint extends AbstractMethod<UpdateApplicationRequest, Application> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/applications";
+	private static final String PATH = "/v1/meetings/applications";
 
 	UpdateApplicationEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/UpdateRoomEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/UpdateRoomEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class UpdateRoomEndpoint extends AbstractMethod<UpdateRoomRequest, MeetingRoom> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/rooms/%s";
+	private static final String PATH = "/v1/meetings/rooms/%s";
 
 	UpdateRoomEndpoint(HttpWrapper httpWrapper) {
 		super(httpWrapper);

--- a/src/main/java/com/vonage/client/meetings/UpdateThemeEndpoint.java
+++ b/src/main/java/com/vonage/client/meetings/UpdateThemeEndpoint.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 
 class UpdateThemeEndpoint extends AbstractMethod<Theme, Theme> {
 	private static final Class<?>[] ALLOWED_AUTH_METHODS = {JWTAuthMethod.class};
-	private static final String PATH = "/meetings/themes/%s";
+	private static final String PATH = "/v1/meetings/themes/%s";
 	private Theme cachedTheme;
 
 	UpdateThemeEndpoint(HttpWrapper httpWrapper) {

--- a/src/test/java/com/vonage/client/meetings/CreateRoomEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/CreateRoomEndpointTest.java
@@ -67,7 +67,7 @@ public class CreateRoomEndpointTest {
 
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("POST", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/rooms";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/rooms";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
 
@@ -107,7 +107,7 @@ public class CreateRoomEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new CreateRoomEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/rooms";
+		String expectedUri = baseUri + "/v1/meetings/rooms";
 		String displayName = "My custom room";
 		MeetingRoom request = MeetingRoom.builder(displayName).build();
 		RequestBuilder builder = endpoint.makeRequest(request);

--- a/src/test/java/com/vonage/client/meetings/CreateThemeEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/CreateThemeEndpointTest.java
@@ -42,7 +42,7 @@ public class CreateThemeEndpointTest {
 
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("POST", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
@@ -66,7 +66,7 @@ public class CreateThemeEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new CreateThemeEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/themes";
+		String expectedUri = baseUri + "/v1/meetings/themes";
 		Theme request = Theme.builder().build();
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/meetings/DeleteRecordingEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/DeleteRecordingEndpointTest.java
@@ -39,7 +39,7 @@ public class DeleteRecordingEndpointTest {
 		UUID recordingId = UUID.randomUUID();
 		RequestBuilder builder = endpoint.makeRequest(recordingId);
 		assertEquals("DELETE", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/recordings/"+recordingId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/recordings/"+recordingId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertNull(endpoint.parseResponse(TestUtils.makeJsonHttpResponse(204, "")));
 	}
@@ -50,7 +50,7 @@ public class DeleteRecordingEndpointTest {
 		UUID recordingId = UUID.randomUUID();
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new DeleteRecordingEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/recordings/"+recordingId;
+		String expectedUri = baseUri + "/v1/meetings/recordings/"+recordingId;
 		RequestBuilder builder = endpoint.makeRequest(recordingId);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals("DELETE", builder.getMethod());

--- a/src/test/java/com/vonage/client/meetings/DeleteThemeEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/DeleteThemeEndpointTest.java
@@ -39,7 +39,7 @@ public class DeleteThemeEndpointTest {
 		UUID themeId = UUID.randomUUID();
 		RequestBuilder builder = endpoint.makeRequest(new DeleteThemeRequest(themeId, false));
 		assertEquals("DELETE", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/"+themeId+"?force=false";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/"+themeId+"?force=false";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertNull(endpoint.parseResponse(TestUtils.makeJsonHttpResponse(204, "")));
 	}
@@ -50,7 +50,7 @@ public class DeleteThemeEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new DeleteThemeEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/themes/"+themeId+"?force=true";
+		String expectedUri = baseUri + "/v1/meetings/themes/"+themeId+"?force=true";
 		RequestBuilder builder = endpoint.makeRequest(new DeleteThemeRequest(themeId, true));
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals("DELETE", builder.getMethod());

--- a/src/test/java/com/vonage/client/meetings/FinalizeLogosEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/FinalizeLogosEndpointTest.java
@@ -43,7 +43,7 @@ public class FinalizeLogosEndpointTest {
 		FinalizeLogosRequest request = new FinalizeLogosRequest(themeId, Arrays.asList("col", "fff"));
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("PUT", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/"+themeId+"/finalizeLogos";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/"+themeId+"/finalizeLogos";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertNull(endpoint.parseResponse(TestUtils.makeJsonHttpResponse(200, "")));
 	}
@@ -54,7 +54,7 @@ public class FinalizeLogosEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new FinalizeLogosEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/themes/"+themeId+"/finalizeLogos";
+		String expectedUri = baseUri + "/v1/meetings/themes/"+themeId+"/finalizeLogos";
 		FinalizeLogosRequest request = new FinalizeLogosRequest(themeId, Arrays.asList("lk1", "lk2"));
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/meetings/GetLogoUploadUrlsEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/GetLogoUploadUrlsEndpointTest.java
@@ -39,7 +39,7 @@ public class GetLogoUploadUrlsEndpointTest {
 	public void testDefaultUri() throws Exception {
 		RequestBuilder builder = endpoint.makeRequest(null);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/logos-upload-urls";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/logos-upload-urls";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 	}
 
@@ -48,7 +48,7 @@ public class GetLogoUploadUrlsEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new GetLogoUploadUrlsEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/themes/logos-upload-urls";
+		String expectedUri = baseUri + "/v1/meetings/themes/logos-upload-urls";
 		RequestBuilder builder = endpoint.makeRequest(null);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals("GET", builder.getMethod());

--- a/src/test/java/com/vonage/client/meetings/GetRecordingEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/GetRecordingEndpointTest.java
@@ -41,7 +41,7 @@ public class GetRecordingEndpointTest {
 		UUID recordingId = UUID.randomUUID();
 		RequestBuilder builder = endpoint.makeRequest(recordingId);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/recordings/"+recordingId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/recordings/"+recordingId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		String expectedResponse = "{\"nonsense\":0,\"_links\":{\"url\":{}}}";
@@ -62,7 +62,7 @@ public class GetRecordingEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new GetRecordingEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/recordings/"+recordingId;
+		String expectedUri = baseUri + "/v1/meetings/recordings/"+recordingId;
 		RequestBuilder builder = endpoint.makeRequest(recordingId);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());

--- a/src/test/java/com/vonage/client/meetings/GetRoomEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/GetRoomEndpointTest.java
@@ -40,7 +40,7 @@ public class GetRoomEndpointTest {
 		UUID roomId = UUID.randomUUID();
 		RequestBuilder builder = endpoint.makeRequest(roomId);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/rooms/"+roomId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/rooms/"+roomId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, MeetingsClientTest.SAMPLE_ROOM_RESPONSE);
@@ -54,7 +54,7 @@ public class GetRoomEndpointTest {
 		String baseUri = "https://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new GetRoomEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/rooms/"+roomId;
+		String expectedUri = baseUri + "/v1/meetings/rooms/"+roomId;
 		RequestBuilder builder = endpoint.makeRequest(roomId);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());

--- a/src/test/java/com/vonage/client/meetings/GetThemeEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/GetThemeEndpointTest.java
@@ -41,7 +41,7 @@ public class GetThemeEndpointTest {
 		UUID themeId = UUID.randomUUID();
 		RequestBuilder builder = endpoint.makeRequest(themeId);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/"+themeId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/"+themeId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		String expectedResponse = "{\"nonsense\":true}";
@@ -56,7 +56,7 @@ public class GetThemeEndpointTest {
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new GetThemeEndpoint(wrapper);
 		UUID themeId = UUID.randomUUID();
-		String expectedUri = baseUri + "/meetings/themes/"+themeId;
+		String expectedUri = baseUri + "/v1/meetings/themes/"+themeId;
 		RequestBuilder builder = endpoint.makeRequest(themeId);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());

--- a/src/test/java/com/vonage/client/meetings/ListDialNumbersEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/ListDialNumbersEndpointTest.java
@@ -39,7 +39,7 @@ public class ListDialNumbersEndpointTest {
 	public void testDefaultUri() throws Exception {
 		RequestBuilder builder = endpoint.makeRequest(null);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/dial-in-numbers";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/dial-in-numbers";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		String expectedPayload = "[\n" +
 				"{},   {\n" +
@@ -75,7 +75,7 @@ public class ListDialNumbersEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListDialNumbersEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/dial-in-numbers";
+		String expectedUri = baseUri + "/v1/meetings/dial-in-numbers";
 		RequestBuilder builder = endpoint.makeRequest(null);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals("GET", builder.getMethod());

--- a/src/test/java/com/vonage/client/meetings/ListRecordingsEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/ListRecordingsEndpointTest.java
@@ -40,7 +40,7 @@ public class ListRecordingsEndpointTest {
 		String sessionId = "2_MX40NjMwODczMn5-MTU3NTgyODEwNzQ2M...";
 		RequestBuilder builder = endpoint.makeRequest(sessionId);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/sessions/"+sessionId+"/recordings";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/sessions/"+sessionId+"/recordings";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
 		String expectedPayload = "{\"_embedded\":{\"recordings\":[{},{\"_links\":{},\"status\":\"uploaded\"}]}}";
@@ -65,7 +65,7 @@ public class ListRecordingsEndpointTest {
 		String sessionId = "2_MX40NjMwODczMn5-MTU3NTgyODEwNzQ2Jk.." , baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListRecordingsEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/sessions/"+sessionId+"/recordings";
+		String expectedUri = baseUri + "/v1/meetings/sessions/"+sessionId+"/recordings";
 		RequestBuilder builder = endpoint.makeRequest(sessionId);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());

--- a/src/test/java/com/vonage/client/meetings/ListRoomsEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/ListRoomsEndpointTest.java
@@ -41,7 +41,7 @@ public class ListRoomsEndpointTest {
 		ListRoomsRequest request = new ListRoomsRequest(null, null, null, null);
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/rooms";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/rooms";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
 		assertEquals(0, params.size());
@@ -62,7 +62,7 @@ public class ListRoomsEndpointTest {
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListRoomsEndpoint(wrapper);
 		ListRoomsRequest request = new ListRoomsRequest(51, 150, 25, null);
-		String expectedUri = baseUri + "/meetings/rooms?" +
+		String expectedUri = baseUri + "/v1/meetings/rooms?" +
 				"start_id="+request.startId+"&end_id="+request.endId+"&page_size="+request.pageSize;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/meetings/ListThemesEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/ListThemesEndpointTest.java
@@ -40,7 +40,7 @@ public class ListThemesEndpointTest {
 		Void request = null;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		HttpResponse mockResponse = TestUtils.makeJsonHttpResponse(200, "[{}]");
 		List<Theme> parsed = endpoint.parseResponse(mockResponse);
@@ -53,7 +53,7 @@ public class ListThemesEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new ListThemesEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/themes";
+		String expectedUri = baseUri + "/v1/meetings/themes";
 		RequestBuilder builder = endpoint.makeRequest(null);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals("GET", builder.getMethod());

--- a/src/test/java/com/vonage/client/meetings/SearchThemeRoomsEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/SearchThemeRoomsEndpointTest.java
@@ -42,7 +42,7 @@ public class SearchThemeRoomsEndpointTest {
 		ListRoomsRequest request = new ListRoomsRequest(21, 33, 50, UUID.randomUUID());
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("GET", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/"+request.themeId+
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/"+request.themeId+
 				"/rooms?start_id="+request.startId+"&end_id="+request.endId+"&page_size="+request.pageSize;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());
@@ -70,7 +70,7 @@ public class SearchThemeRoomsEndpointTest {
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new SearchThemeRoomsEndpoint(wrapper);
 		ListRoomsRequest request = new ListRoomsRequest(1, null, null, UUID.randomUUID());
-		String expectedUri = baseUri + "/meetings/themes/"+request.themeId+"/rooms?start_id="+request.startId;
+		String expectedUri = baseUri + "/v1/meetings/themes/"+request.themeId+"/rooms?start_id="+request.startId;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		Map<String, String> params = TestUtils.makeParameterMap(builder.getParameters());

--- a/src/test/java/com/vonage/client/meetings/UpdateApplicationEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/UpdateApplicationEndpointTest.java
@@ -43,7 +43,7 @@ public class UpdateApplicationEndpointTest {
 			.build();
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("PATCH", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/applications";
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/applications";
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Accept").getValue());
@@ -66,7 +66,7 @@ public class UpdateApplicationEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new UpdateApplicationEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/applications";
+		String expectedUri = baseUri + "/v1/meetings/applications";
 		UpdateApplicationRequest request = UpdateApplicationRequest.builder().defaultThemeId(UUID.randomUUID()).build();
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());

--- a/src/test/java/com/vonage/client/meetings/UpdateRoomEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/UpdateRoomEndpointTest.java
@@ -55,7 +55,7 @@ public class UpdateRoomEndpointTest {
 		request.roomId = roomId;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("PATCH", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/rooms/"+roomId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/rooms/"+roomId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
@@ -73,7 +73,7 @@ public class UpdateRoomEndpointTest {
 		String baseUri = "http://example.com";
 		HttpWrapper wrapper = new HttpWrapper(HttpConfig.builder().baseUri(baseUri).build());
 		endpoint = new UpdateRoomEndpoint(wrapper);
-		String expectedUri = baseUri + "/meetings/rooms/"+MeetingsClientTest.RANDOM_ID;
+		String expectedUri = baseUri + "/v1/meetings/rooms/"+MeetingsClientTest.RANDOM_ID;
 		UpdateRoomRequest request = UpdateRoomRequest.builder().build();
 		request.roomId = MeetingsClientTest.RANDOM_ID;
 		RequestBuilder builder = endpoint.makeRequest(request);

--- a/src/test/java/com/vonage/client/meetings/UpdateThemeEndpointTest.java
+++ b/src/test/java/com/vonage/client/meetings/UpdateThemeEndpointTest.java
@@ -45,7 +45,7 @@ public class UpdateThemeEndpointTest {
 		request.themeId = UUID.fromString(themeId);
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals("PATCH", builder.getMethod());
-		String expectedUri = "https://api-eu.vonage.com/meetings/themes/"+themeId;
+		String expectedUri = "https://api-eu.vonage.com/v1/meetings/themes/"+themeId;
 		assertEquals(expectedUri, builder.build().getURI().toString());
 
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());
@@ -67,7 +67,7 @@ public class UpdateThemeEndpointTest {
 		endpoint = new UpdateThemeEndpoint(wrapper);
 		Theme request = Theme.builder().build();
 		request.themeId = UUID.randomUUID();
-		String expectedUri = baseUri + "/meetings/themes/"+request.themeId;
+		String expectedUri = baseUri + "/v1/meetings/themes/"+request.themeId;
 		RequestBuilder builder = endpoint.makeRequest(request);
 		assertEquals(expectedUri, builder.build().getURI().toString());
 		assertEquals(ContentType.APPLICATION_JSON.getMimeType(), builder.getFirstHeader("Content-Type").getValue());


### PR DESCRIPTION
Adds the `/v1` part to the Meetings API endpoint paths to future-proof the SDK and ensure compatibility / consistency.
