### PR TITLE
feat: Add getAllSessions endpoint to Meetings API

### DIFF
--- a/src/main/java/com/vonage/client/meetings/ListSessionsRequest.java
+++ b/src/main/java/com/vonage/client/meetings/ListSessionsRequest.java
@@ -1,0 +1,204 @@
+/*
+ *   Copyright 2023 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.meetings;
+
+import com.vonage.client.QueryParamsRequest;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Filter parameters for listing all sessions with {@link MeetingsClient#listSessions(ListSessionsRequest)}.
+ *
+ * @since 7.10.0
+ */
+public class ListSessionsRequest implements QueryParamsRequest {
+	private final Instant from, to;
+	private final Boolean recorded;
+	private final Integer offset, pageSize;
+
+	ListSessionsRequest(Builder builder) {
+		if ((from = builder.from) != null && from.isAfter(Instant.now())) {
+			throw new IllegalArgumentException("'from' date cannot be in the future.");
+		}
+		if ((to = builder.to) != null) {
+			if (to.isAfter(Instant.now())) {
+				throw new IllegalArgumentException("'to' date cannot be in the future.");
+			}
+			else if (from != null && to.isBefore(from)) {
+				throw new IllegalStateException("'to' date must be after 'from'.");
+			}
+		}
+		recorded = builder.recorded;
+		offset = builder.offset;
+		pageSize = builder.pageSize;
+	}
+	
+	@Override
+	public Map<String, String> makeParams() {
+		Map<String, String> params = new LinkedHashMap<>(8);
+		if (from != null) {
+            params.put("from", from.toString());
+        }
+		if (to != null) {
+            params.put("to", to.toString());
+        }
+		if (recorded != null) {
+            params.put("recorded", recorded.toString());
+        }
+		if (offset != null) {
+            params.put("offset", offset.toString());
+        }
+		if (pageSize != null) {
+            params.put("page_size", pageSize.toString());
+        }
+		return params;
+	}
+
+	/**
+	 * Earliest date to return results from, in ISO-8601 format.
+	 * 
+	 * @return Start timestamp for the results, or {@code null} if absent.
+	 */
+	public Instant getFrom() {
+		return from;
+	}
+
+	/**
+	 * Latest date to return results from, in ISO-8601 format. Default is today's date.
+	 * 
+	 * @return End timestamp for the results, or {@code null} if absent.
+	 */
+	public Instant getTo() {
+		return to;
+	}
+
+	/**
+	 * If the value is set to true, only recorded sessions will be returned. If set to false, non-recorded sessions will be returned. If the value is not set, all sessions will be returned.
+	 * 
+	 * @return Whether to include only recorded or non-recorded sessions, or {@code null} to include all sessions.
+	 */
+	public Boolean getRecorded() {
+		return recorded;
+	}
+
+	/**
+	 * Specify how many records to skip before fetching.
+	 * 
+	 * @return The results offset, or {@code null} if unspecified.
+	 */
+	public Integer getOffset() {
+		return offset;
+	}
+
+	/**
+	 * Maximum number of items to fetch.
+	 * 
+	 * @return The results page size, or {@code null} if unspecified.
+	 */
+	public Integer getPageSize() {
+		return pageSize;
+	}
+
+	/**
+	 * Entry point for constructing an instance of this class.
+	 * 
+	 * @return A new Builder.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+	
+	public static class Builder {
+		private Instant from, to;
+		private Boolean recorded;
+		private Integer offset, pageSize;
+	
+		Builder() {}
+	
+		/**
+		 * Earliest date to return results from, in ISO-8601 format.
+		 *
+		 * @param from Start timestamp for the results, or {@code null} if absent.
+		 *
+		 * @return This builder.
+		 */
+		public Builder from(Instant from) {
+			this.from = from;
+			return this;
+		}
+
+		/**
+		 * Latest date to return results from, in ISO-8601 format. Default is today's date.
+		 *
+		 * @param to End timestamp for the results, or {@code null} if absent.
+		 *
+		 * @return This builder.
+		 */
+		public Builder to(Instant to) {
+			this.to = to;
+			return this;
+		}
+
+		/**
+		 * If the value is set to true, only recorded sessions will be returned. If set to false, non-recorded
+		 * sessions will be returned. If the value is not set, all sessions will be returned.
+		 *
+		 * @param recorded Whether to include only recorded or non-recorded sessions.
+		 *
+		 * @return This builder.
+		 */
+		public Builder recorded(boolean recorded) {
+			this.recorded = recorded;
+			return this;
+		}
+
+		/**
+		 * Specify how many records to skip before fetching.
+		 *
+		 * @param offset The results offset, or {@code null} if unspecified.
+		 *
+		 * @return This builder.
+		 */
+		public Builder offset(int offset) {
+			this.offset = offset;
+			return this;
+		}
+
+		/**
+		 * Maximum number of items to fetch.
+		 *
+		 * @param pageSize The results page size (maximum 1000).
+		 *
+		 * @return This builder.
+		 */
+		public Builder pageSize(int pageSize) {
+			this.pageSize = pageSize;
+			return this;
+		}
+
+	
+		/**
+		 * Builds the {@linkplain ListSessionsRequest}.
+		 *
+		 * @return An instance of ListSessionsRequest, populated with all fields from this builder.
+		 */
+		public ListSessionsRequest build() {
+			return new ListSessionsRequest(this);
+		}
+	}
+
+}

--- a/src/main/java/com/vonage/client/meetings/ListSessionsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListSessionsResponse.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright 2023 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.meetings;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.Jsonable;
+import com.vonage.client.common.HalPageResponse;
+import java.util.List;
+
+/**
+ * HAL response for {@link MeetingsClient#listSessions(ListSessionsRequest)}.
+ *
+ * @since 7.11.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ListSessionsResponse extends HalPageResponse {
+	@JsonProperty("_embedded") private Embedded _embedded;
+
+	ListSessionsResponse() {
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	private static final class Embedded {
+		@JsonProperty("sessions") private List<Session> sessions;
+	}
+
+	/**
+	 * Gets the sessions contained in the {@code _embedded} response.
+	 *
+	 * @return The sessions for this page.
+	 */
+	@JsonIgnore
+	public List<Session> getSessions() {
+		return _embedded != null ? _embedded.sessions : null;
+	}
+	
+	/**
+	 * Creates an instance of this class from a JSON payload.
+	 *
+	 * @param json The JSON string to parse.
+	 * @return An instance of this class with the fields populated, if present.
+	 */
+	public static ListSessionsResponse fromJson(String json) {
+		return Jsonable.fromJson(json, ListSessionsResponse.class);
+	}
+}

--- a/src/main/java/com/vonage/client/meetings/Session.java
+++ b/src/main/java/com/vonage/client/meetings/Session.java
@@ -1,0 +1,128 @@
+/*
+ *   Copyright 2023 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.meetings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a session for a Meeting.
+ *
+ * @since 7.11.0
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Session {
+	private UUID roomId;
+	private String id, roomDisplayName;
+	private Instant startTime, endTime;
+	private Boolean isRecorded;
+	private Integer participantsNumber;
+	private Double billedTime, recordingsTime;
+
+	protected Session() {}
+
+	/**
+	 * ID of the session.
+	 *
+	 * @return The session ID, or {@code null} if absent.
+	 */
+	@JsonProperty("id")
+	public String getId() {
+		return id;
+	}
+
+	/**
+	 * Room ID for the session.
+	 *
+	 * @return The room ID, or {@code null} if absent.
+	 */
+	@JsonProperty("room_id")
+	public UUID getRoomId() {
+		return roomId;
+	}
+
+	/**
+	 * Name of the meeting room.
+	 *
+	 * @return The room name, or {@code null} if absent.
+	 */
+	@JsonProperty("room_display_name")
+	public String getRoomDisplayName() {
+		return roomDisplayName;
+	}
+
+	/**
+	 * Recording start date in ISO-8601 format.
+	 *
+	 * @return Timestamp of the recording's start, or {@code null} if absent.
+	 */
+	@JsonProperty("start_time")
+	public Instant getStartTime() {
+		return startTime;
+	}
+
+	/**
+	 * Recording end date in ISO-8601 format.
+	 *
+	 * @return Timestamp of the recording's end, or {@code null} if absent.
+	 */
+	@JsonProperty("end_time")
+	public Instant getEndTime() {
+		return endTime;
+	}
+
+	/**
+	 * Whether the session is recorded.
+	 *
+	 * @return {@code true} if the session is recorded, {@code false} if not and {@code null} if unknown.
+	 */
+	@JsonProperty("is_recorded")
+	public Boolean getIsRecorded() {
+		return isRecorded;
+	}
+
+	/**
+	 * Number of participants in the meeting.
+	 *
+	 * @return The total number of participants, or {@code null} if unknown.
+	 */
+	@JsonProperty("participants_number")
+	public Integer getParticipantsNumber() {
+		return participantsNumber;
+	}
+
+	/**
+	 * Duration of the recording that was billed, in minutes.
+	 *
+	 * @return The number of minutes billed for this meeting, or {@code null} if unknown / not applicable.
+	 */
+	@JsonProperty("billed_time")
+	public Double getBilledTime() {
+		return billedTime;
+	}
+
+	/**
+	 * Aggregated recording time of the session in minutes.
+	 *
+	 * @return The total number of minutes this meeting was recorded for, or {@code null} if not applicable.
+	 */
+	@JsonProperty("recordings_time")
+	public Double getRecordingsTime() {
+		return recordingsTime;
+	}
+}

--- a/src/test/java/com/vonage/client/BugRepro.java
+++ b/src/test/java/com/vonage/client/BugRepro.java
@@ -29,7 +29,7 @@ public class BugRepro {
 		String TO_NUMBER = System.getenv("TO_NUMBER");
 
 		VonageClient client = VonageClient.builder()
-				.httpConfig(HttpConfig.builder().timeoutMillis(12_000).build())
+				.httpConfig(HttpConfig.builder().timeoutMillis(45_000).build())
 				.apiKey(System.getenv("VONAGE_API_KEY"))
 				.apiSecret(System.getenv("VONAGE_API_SECRET"))
 				.applicationId(System.getenv("VONAGE_APPLICATION_ID"))

--- a/src/test/java/com/vonage/client/ClientTest.java
+++ b/src/test/java/com/vonage/client/ClientTest.java
@@ -72,6 +72,10 @@ public abstract class ClientTest<T> {
         return result;
     }
 
+    protected void stubResponse(int code, String firstResponse, String... additionalReturns) throws Exception {
+        wrapper.setHttpClient(stubHttpClient(code, firstResponse, additionalReturns));
+    }
+
     protected void stubResponse(int code, String response) throws Exception {
         wrapper.setHttpClient(stubHttpClient(code, response));
     }


### PR DESCRIPTION
Implements the [getAllSessions](https://developer.vonage.com/en/api/meetings#getAllSessions) endpoint in the Meetings API.
