### PR TITLE
refactor: Type inference hack for fromJson

### DIFF
--- a/src/main/java/com/vonage/client/VonageApiResponseException.java
+++ b/src/main/java/com/vonage/client/VonageApiResponseException.java
@@ -20,9 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
-import org.apache.http.HttpResponse;
-import org.apache.http.util.EntityUtils;
-import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
@@ -219,21 +216,6 @@ public class VonageApiResponseException extends VonageClientException implements
 				throw new VonageUnexpectedException(ex);
 			}
 		}
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			return mapper.readValue(json, clazz);
-		}
-		catch (IOException ex) {
-			throw new VonageResponseParseException("Failed to produce "+clazz.getSimpleName()+" from json.", ex);
-		}
-	}
-
-	protected static <E extends VonageApiResponseException> E fromHttpResponse(Class<E> clazz, HttpResponse response) throws IOException {
-		E crx = fromJson(clazz, EntityUtils.toString(response.getEntity()));
-		if (crx.title == null) {
-			crx.title = response.getStatusLine().getReasonPhrase();
-		}
-		crx.statusCode = response.getStatusLine().getStatusCode();
-		return crx;
+		else return Jsonable.fromJson(json, clazz);
 	}
 }

--- a/src/main/java/com/vonage/client/account/BalanceResponse.java
+++ b/src/main/java/com/vonage/client/account/BalanceResponse.java
@@ -43,6 +43,6 @@ public class BalanceResponse implements Jsonable {
     }
 
     public static BalanceResponse fromJson(String json) {
-        return Jsonable.fromJson(json, BalanceResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/account/ListSecretsResponse.java
+++ b/src/main/java/com/vonage/client/account/ListSecretsResponse.java
@@ -55,6 +55,6 @@ public class ListSecretsResponse implements Jsonable {
     }
 
     public static ListSecretsResponse fromJson(String json) {
-        return Jsonable.fromJson(json, ListSecretsResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/account/PrefixPricingResponse.java
+++ b/src/main/java/com/vonage/client/account/PrefixPricingResponse.java
@@ -36,6 +36,6 @@ public class PrefixPricingResponse implements Jsonable {
     }
 
     public static PrefixPricingResponse fromJson(String json) {
-        return Jsonable.fromJson(json, PrefixPricingResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/account/PricingResponse.java
+++ b/src/main/java/com/vonage/client/account/PricingResponse.java
@@ -51,6 +51,6 @@ public class PricingResponse implements Jsonable {
     }
 
     public static PricingResponse fromJson(String json) {
-        return Jsonable.fromJson(json, PricingResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/account/SecretResponse.java
+++ b/src/main/java/com/vonage/client/account/SecretResponse.java
@@ -64,6 +64,6 @@ public class SecretResponse implements Jsonable {
     }
 
     public static SecretResponse fromJson(String json) {
-        return Jsonable.fromJson(json, SecretResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/account/SettingsResponse.java
+++ b/src/main/java/com/vonage/client/account/SettingsResponse.java
@@ -69,6 +69,6 @@ public class SettingsResponse implements Jsonable {
     }
 
     public static SettingsResponse fromJson(String json) {
-        return Jsonable.fromJson(json, SettingsResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/application/Application.java
+++ b/src/main/java/com/vonage/client/application/Application.java
@@ -96,7 +96,7 @@ public class Application implements Jsonable {
     }
 
     public static Application fromJson(String json) {
-        return Jsonable.fromJson(json, Application.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/application/ApplicationList.java
+++ b/src/main/java/com/vonage/client/application/ApplicationList.java
@@ -45,6 +45,6 @@ public class ApplicationList extends HalPageResponse {
     }
 
     public static ApplicationList fromJson(String json) {
-        return Jsonable.fromJson(json, ApplicationList.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/incoming/CallEvent.java
+++ b/src/main/java/com/vonage/client/incoming/CallEvent.java
@@ -80,6 +80,6 @@ public class CallEvent implements Jsonable {
     }
 
     public static CallEvent fromJson(String json) {
-        return Jsonable.fromJson(json, CallEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/incoming/InputEvent.java
+++ b/src/main/java/com/vonage/client/incoming/InputEvent.java
@@ -85,6 +85,6 @@ public class InputEvent implements Jsonable {
     }
 
     public static InputEvent fromJson(String json) {
-        return Jsonable.fromJson(json, InputEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/incoming/MessageEvent.java
+++ b/src/main/java/com/vonage/client/incoming/MessageEvent.java
@@ -125,6 +125,6 @@ public class MessageEvent implements Jsonable {
     }
 
     public static MessageEvent fromJson(String json) {
-        return Jsonable.fromJson(json, MessageEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/incoming/NotifyEvent.java
+++ b/src/main/java/com/vonage/client/incoming/NotifyEvent.java
@@ -62,6 +62,6 @@ public class NotifyEvent implements Jsonable {
     }
 
     public static NotifyEvent fromJson(String json) {
-        return Jsonable.fromJson(json, NotifyEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/incoming/RecordEvent.java
+++ b/src/main/java/com/vonage/client/incoming/RecordEvent.java
@@ -62,6 +62,6 @@ public class RecordEvent implements Jsonable {
     }
 
     public static RecordEvent fromJson(String json) {
-        return Jsonable.fromJson(json, RecordEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
@@ -33,7 +33,7 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
     private String errorText;
 
     public static AdvancedInsightResponse fromJson(String json) {
-        return Jsonable.fromJson(json, AdvancedInsightResponse.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/insight/BasicInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/BasicInsightResponse.java
@@ -29,7 +29,7 @@ public class BasicInsightResponse implements Jsonable {
             countryCode, countryCodeIso3, countryName, countryPrefix;
 
     public static BasicInsightResponse fromJson(String json) {
-        return Jsonable.fromJson(json, BasicInsightResponse.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/insight/StandardInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/StandardInsightResponse.java
@@ -33,7 +33,7 @@ public class StandardInsightResponse extends BasicInsightResponse {
     private CallerType callerType;
 
     public static StandardInsightResponse fromJson(String json) {
-        return Jsonable.fromJson(json, StandardInsightResponse.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/meetings/Application.java
+++ b/src/main/java/com/vonage/client/meetings/Application.java
@@ -65,6 +65,6 @@ public class Application implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static Application fromJson(String json) {
-		return Jsonable.fromJson(json, Application.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/meetings/ListRecordingsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListRecordingsResponse.java
@@ -33,6 +33,6 @@ class ListRecordingsResponse implements Jsonable {
 	}
 
 	public static ListRecordingsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListRecordingsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/meetings/ListRoomsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListRoomsResponse.java
@@ -44,6 +44,6 @@ class ListRoomsResponse extends HalPageResponse {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListRoomsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListRoomsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/meetings/MeetingRoom.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingRoom.java
@@ -251,7 +251,7 @@ public class MeetingRoom implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static MeetingRoom fromJson(String json) {
-		return Jsonable.fromJson(json, MeetingRoom.class);
+		return Jsonable.fromJson(json);
 	}
 	
 	/**

--- a/src/main/java/com/vonage/client/meetings/MeetingsEventCallback.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingsEventCallback.java
@@ -197,6 +197,6 @@ public class MeetingsEventCallback implements Jsonable {
 	 * @throws VonageResponseParseException If the response could not be deserialized.
 	 */
 	public static MeetingsEventCallback fromJson(String json) {
-		return Jsonable.fromJson(json, MeetingsEventCallback.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/meetings/Recording.java
+++ b/src/main/java/com/vonage/client/meetings/Recording.java
@@ -101,6 +101,6 @@ public class Recording implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static Recording fromJson(String json) {
-		return Jsonable.fromJson(json, Recording.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/meetings/Theme.java
+++ b/src/main/java/com/vonage/client/meetings/Theme.java
@@ -235,7 +235,7 @@ public class Theme implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static Theme fromJson(String json) {
-		return Jsonable.fromJson(json, Theme.class);
+		return Jsonable.fromJson(json);
 	}
 	
 	/**

--- a/src/main/java/com/vonage/client/messages/InboundMessage.java
+++ b/src/main/java/com/vonage/client/messages/InboundMessage.java
@@ -300,6 +300,6 @@ public class InboundMessage implements Jsonable {
 	 * @throws com.vonage.client.VonageResponseParseException If the response could not be deserialized.
 	 */
 	public static InboundMessage fromJson(String json) {
-		return Jsonable.fromJson(json, InboundMessage.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/messages/MessageResponse.java
+++ b/src/main/java/com/vonage/client/messages/MessageResponse.java
@@ -56,6 +56,6 @@ public class MessageResponse implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static MessageResponse fromJson(String json) {
-		return Jsonable.fromJson(json, MessageResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/messages/MessageStatus.java
+++ b/src/main/java/com/vonage/client/messages/MessageStatus.java
@@ -16,11 +16,7 @@
 package com.vonage.client.messages;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.vonage.client.Jsonable;
-import com.vonage.client.VonageUnexpectedException;
-import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Currency;
@@ -304,14 +300,7 @@ public class MessageStatus implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static MessageStatus fromJson(String json) {
-		try {
-			ObjectMapper mapper = new ObjectMapper();
-			mapper.registerModule(new JavaTimeModule());
-			return mapper.readValue(json, MessageStatus.class);
-		}
-		catch (IOException ex) {
-			throw new VonageUnexpectedException("Failed to produce MessageStatus from json.", ex);
-		}
+		return Jsonable.fromJson(json);
 	}
 
 	@Override

--- a/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
@@ -35,6 +35,6 @@ public class ListNumbersResponse implements Jsonable {
     }
 
     public static ListNumbersResponse fromJson(String json) {
-        return Jsonable.fromJson(json, ListNumbersResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersResponse.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersResponse.java
@@ -42,7 +42,7 @@ public class SearchNumbersResponse implements Jsonable {
     }
 
     public static SearchNumbersResponse fromJson(String json) {
-        return Jsonable.fromJson(json, SearchNumbersResponse.class);
+        return Jsonable.fromJson(json);
     }
 
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ContactsList.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ContactsList.java
@@ -171,7 +171,7 @@ public class ContactsList implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ContactsList fromJson(String json) {
-		return Jsonable.fromJson(json, ContactsList.class);
+		return Jsonable.fromJson(json);
 	}
 	
 	/**

--- a/src/main/java/com/vonage/client/proactiveconnect/Event.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/Event.java
@@ -156,6 +156,6 @@ public class Event implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static Event fromJson(String json) {
-		return Jsonable.fromJson(json, Event.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
@@ -59,6 +59,6 @@ final class ListEventsResponse extends HalPageResponse {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListEventsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListEventsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItem.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItem.java
@@ -93,6 +93,6 @@ public class ListItem implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListItem fromJson(String json) {
-		return Jsonable.fromJson(json, ListItem.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
@@ -60,6 +60,6 @@ public final class ListItemsResponse extends HalPageResponse {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListItemsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListItemsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
@@ -58,6 +58,6 @@ public final class ListListsResponse extends HalPageResponse {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListListsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListListsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/SyncStatus.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SyncStatus.java
@@ -90,6 +90,6 @@ public class SyncStatus implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static SyncStatus fromJson(String json) {
-		return Jsonable.fromJson(json, SyncStatus.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsResponse.java
@@ -68,6 +68,6 @@ public class UploadListItemsResponse implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static UploadListItemsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, UploadListItemsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
+++ b/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
@@ -26,7 +26,7 @@ public class SmsSubmissionResponse implements Jsonable {
     private List<SmsSubmissionResponseMessage> messages;
 
     public static SmsSubmissionResponse fromJson(String json) {
-        return Jsonable.fromJson(json, SmsSubmissionResponse.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/subaccounts/Account.java
+++ b/src/main/java/com/vonage/client/subaccounts/Account.java
@@ -131,6 +131,6 @@ public class Account implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static Account fromJson(String json) {
-		return Jsonable.fromJson(json, Account.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/subaccounts/ListSubaccountsResponse.java
+++ b/src/main/java/com/vonage/client/subaccounts/ListSubaccountsResponse.java
@@ -64,6 +64,6 @@ public class ListSubaccountsResponse implements Jsonable {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static ListSubaccountsResponse fromJson(String json) {
-		return Jsonable.fromJson(json, ListSubaccountsResponse.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/subaccounts/MoneyTransfer.java
+++ b/src/main/java/com/vonage/client/subaccounts/MoneyTransfer.java
@@ -91,7 +91,7 @@ public class MoneyTransfer extends AbstractTransfer {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static MoneyTransfer fromJson(String json) {
-		return Jsonable.fromJson(json, MoneyTransfer.class);
+		return Jsonable.fromJson(json);
 	}
 
 	/**

--- a/src/main/java/com/vonage/client/subaccounts/NumberTransfer.java
+++ b/src/main/java/com/vonage/client/subaccounts/NumberTransfer.java
@@ -64,7 +64,7 @@ public class NumberTransfer extends AbstractTransfer {
 	 * @return An instance of this class with the fields populated, if present.
 	 */
 	public static NumberTransfer fromJson(String json) {
-		return Jsonable.fromJson(json, NumberTransfer.class);
+		return Jsonable.fromJson(json);
 	}
 	
 	/**

--- a/src/main/java/com/vonage/client/users/User.java
+++ b/src/main/java/com/vonage/client/users/User.java
@@ -121,7 +121,7 @@ public class User extends BaseUser {
      */
     @JsonCreator
     public static User fromJson(String json) {
-        return Jsonable.fromJson(json, User.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/verify/ControlResponse.java
+++ b/src/main/java/com/vonage/client/verify/ControlResponse.java
@@ -54,6 +54,6 @@ public class ControlResponse implements Jsonable {
     }
 
     public static ControlResponse fromJson(String json) {
-        return Jsonable.fromJson(json, ControlResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
@@ -84,6 +84,6 @@ public class SearchVerifyResponse implements Jsonable {
     }
 
     public static SearchVerifyResponse fromJson(String json) {
-        return Jsonable.fromJson(json, SearchVerifyResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/verify2/VerificationCallback.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationCallback.java
@@ -179,6 +179,6 @@ public class VerificationCallback implements Jsonable {
 	 * @throws VonageResponseParseException If the response could not be deserialized.
 	 */
 	public static VerificationCallback fromJson(String json) {
-		return Jsonable.fromJson(json, VerificationCallback.class);
+		return Jsonable.fromJson(json);
 	}
 }

--- a/src/main/java/com/vonage/client/voice/Call.java
+++ b/src/main/java/com/vonage/client/voice/Call.java
@@ -250,7 +250,7 @@ public class Call implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static Call fromJson(String json) {
-        return Jsonable.fromJson(json, Call.class);
+        return Jsonable.fromJson(json);
     }
 
     /**

--- a/src/main/java/com/vonage/client/voice/CallEvent.java
+++ b/src/main/java/com/vonage/client/voice/CallEvent.java
@@ -75,6 +75,6 @@ public class CallEvent implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static CallEvent fromJson(String json) {
-        return Jsonable.fromJson(json, CallEvent.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/CallInfo.java
+++ b/src/main/java/com/vonage/client/voice/CallInfo.java
@@ -186,6 +186,6 @@ public class CallInfo implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static CallInfo fromJson(String json) {
-        return Jsonable.fromJson(json, CallInfo.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/CallInfoPage.java
+++ b/src/main/java/com/vonage/client/voice/CallInfoPage.java
@@ -65,6 +65,6 @@ public class CallInfoPage implements Iterable<CallInfo>, Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static CallInfoPage fromJson(String json) {
-        return Jsonable.fromJson(json, CallInfoPage.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/DtmfResponse.java
+++ b/src/main/java/com/vonage/client/voice/DtmfResponse.java
@@ -48,6 +48,6 @@ public class DtmfResponse implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static DtmfResponse fromJson(String json) {
-        return Jsonable.fromJson(json, DtmfResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/ModifyCallResponse.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallResponse.java
@@ -46,6 +46,6 @@ public class ModifyCallResponse implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static ModifyCallResponse fromJson(String json) {
-        return Jsonable.fromJson(json, ModifyCallResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/StreamResponse.java
+++ b/src/main/java/com/vonage/client/voice/StreamResponse.java
@@ -48,6 +48,6 @@ public class StreamResponse implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static StreamResponse fromJson(String json) {
-        return Jsonable.fromJson(json, StreamResponse.class);
+        return Jsonable.fromJson(json);
     }
 }

--- a/src/main/java/com/vonage/client/voice/TalkResponse.java
+++ b/src/main/java/com/vonage/client/voice/TalkResponse.java
@@ -48,6 +48,6 @@ public class TalkResponse implements Jsonable {
      * @return An instance of this class with the fields populated, if present.
      */
     public static TalkResponse fromJson(String json) {
-        return Jsonable.fromJson(json, TalkResponse.class);
+        return Jsonable.fromJson(json);
     }
 }


### PR DESCRIPTION
This PR adds documentation to the `Jsonable` class, as well as an overload to infer the type using the varargs trick. It also removes the unused `VonageApiResponseException.fromHttpResponse` method, and standardises `MessageStatus.fromJson`.
