### PR TITLE
docs: Deprecate SNS and publish relocation information

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = v7.11.0
+current_version = v7.11.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [7.11.1] - 2023-11-06
+- Deprecated SNS client, `legacyutils` and `LoggingUtils`
+- Un-deprecated Redact client
+- Published relocation information in artifact metadata
+
 # [8.0.0-rc1] - 2023-11-02
 - Includes Video API from `8.0.0-beta4`
 - Removed deprecations:

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ See all of our SDKs and integrations on the [Vonage Developer portal](https://de
 
 ## Installation
 
-Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/client/7.11.0/snippets).
+Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/client/7.11.1/snippets).
 Instructions for your build system can be found in the snippets section.
-They're also available from [here](https://mvnrepository.com/artifact/com.vonage/client/7.11.0).
+They're also available from [here](https://mvnrepository.com/artifact/com.vonage/client/7.11.1).
 Release notes can be found in the [changelog](CHANGELOG.md).
 
 ### Build It Yourself

--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,12 @@ publishing {
                     system = "GitHub"
                     url = "https://github.com/$githubPath/issues"
                 }
+                distributionManagement {
+                    relocation {
+                        artifactId = "server-sdk"
+                        message = "Moved to avoid confusion with Client SDKs"
+                    }
+                }
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = "com.vonage"
 archivesBaseName = "client"
-version = "7.11.0"
+version = "7.11.1"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class HttpWrapper {
     private static final String CLIENT_NAME = "vonage-java-sdk";
-    private static final String CLIENT_VERSION = "7.11.0";
+    private static final String CLIENT_VERSION = "7.11.1";
     private static final String JAVA_VERSION = System.getProperty("java.version");
     private static final String USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -110,6 +110,12 @@ public class VonageClient {
         return sms;
     }
 
+    /**
+     * @deprecated SNS will be removed in the next major release.
+     *
+     * @return The SNS client.
+     */
+    @Deprecated
     public SnsClient getSnsClient() {
         return sns;
     }
@@ -126,12 +132,6 @@ public class VonageClient {
         return conversion;
     }
 
-    /**
-     *
-     * @return The Redact API client.
-     * @deprecated This API will be removed in the next major release.
-     */
-    @Deprecated
     public RedactClient getRedactClient() {
         return redact;
     }

--- a/src/main/java/com/vonage/client/legacyutils/XmlParser.java
+++ b/src/main/java/com/vonage/client/legacyutils/XmlParser.java
@@ -23,6 +23,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+/**
+ * @deprecated This will be removed in the next major release.
+ */
+@Deprecated
 public class XmlParser {
     /**
      * A lock associated with {@link #documentBuilder}.

--- a/src/main/java/com/vonage/client/legacyutils/XmlUtil.java
+++ b/src/main/java/com/vonage/client/legacyutils/XmlUtil.java
@@ -24,6 +24,10 @@ import javax.xml.parsers.DocumentBuilder;
 import java.io.IOException;
 import java.io.StringReader;
 
+/**
+ * @deprecated This will be removed in the next major release.
+ */
+@Deprecated
 public class XmlUtil {
 
     public static String stringValue(Node node) {

--- a/src/main/java/com/vonage/client/logging/LoggingUtils.java
+++ b/src/main/java/com/vonage/client/logging/LoggingUtils.java
@@ -22,6 +22,10 @@ import org.apache.http.util.EntityUtils;
 import java.io.IOException;
 import java.util.Objects;
 
+/**
+ * @deprecated This will be removed in the next major release.
+ */
+@Deprecated
 public class LoggingUtils {
 
     public static String logResponse(HttpResponse response) throws IOException {

--- a/src/main/java/com/vonage/client/redact/RedactClient.java
+++ b/src/main/java/com/vonage/client/redact/RedactClient.java
@@ -23,10 +23,7 @@ import com.vonage.client.common.HttpMethod;
 /**
  * A client for talking to the Vonage Redact API. The standard way to obtain an instance of this class is to use {@link
  * VonageClient#getRedactClient()}.
- *
- * @deprecated This API will be removed in the next major release.
  */
-@Deprecated
 public class RedactClient {
     final RestEndpoint<RedactRequest, Void> redactTransaction;
 

--- a/src/main/java/com/vonage/client/redact/RedactRequest.java
+++ b/src/main/java/com/vonage/client/redact/RedactRequest.java
@@ -43,6 +43,7 @@ public class RedactRequest implements Jsonable {
         return id;
     }
 
+    @Deprecated
     public void setId(String id) {
         this.id = id;
     }
@@ -51,6 +52,7 @@ public class RedactRequest implements Jsonable {
         return product;
     }
 
+    @Deprecated
     public void setProduct(Product product) {
         this.product = product;
     }

--- a/src/main/java/com/vonage/client/sns/SnsClient.java
+++ b/src/main/java/com/vonage/client/sns/SnsClient.java
@@ -26,7 +26,10 @@ import com.vonage.client.sns.response.SnsSubscribeResponse;
 /**
  * A client for talking to the Vonage SNS API. The standard way to obtain an instance of this class is to use {@link
  * VonageClient#getSnsClient()}.
+ *
+ * @deprecated SNS will be removed in the next major release.
  */
+@Deprecated
 public class SnsClient {
     final RestEndpoint<SnsRequest, SnsResponse> endpoint;
 

--- a/src/main/java/com/vonage/client/sns/request/SnsPublishRequest.java
+++ b/src/main/java/com/vonage/client/sns/request/SnsPublishRequest.java
@@ -17,7 +17,10 @@ package com.vonage.client.sns.request;
 
 import java.util.Map;
 
-
+/**
+ * @deprecated SNS will be removed in the next major release.
+ */
+@Deprecated
 public class SnsPublishRequest extends SnsRequest {
     private String from;
     private String message;

--- a/src/main/java/com/vonage/client/sns/request/SnsRequest.java
+++ b/src/main/java/com/vonage/client/sns/request/SnsRequest.java
@@ -19,7 +19,10 @@ import com.vonage.client.QueryParamsRequest;
 import java.util.HashMap;
 import java.util.Map;
 
-
+/**
+ * @deprecated SNS will be removed in the next major release.
+ */
+@Deprecated
 public abstract class SnsRequest implements QueryParamsRequest {
     private final String command;
     private String to;

--- a/src/main/java/com/vonage/client/sns/request/SnsSubscribeRequest.java
+++ b/src/main/java/com/vonage/client/sns/request/SnsSubscribeRequest.java
@@ -15,6 +15,10 @@
  */
 package com.vonage.client.sns.request;
 
+/**
+ * @deprecated SNS will be removed in the next major release.
+ */
+@Deprecated
 public class SnsSubscribeRequest extends SnsRequest {
     public SnsSubscribeRequest(final String to,
                                final String topicArn) {

--- a/src/main/java/com/vonage/client/sns/response/SnsPublishResponse.java
+++ b/src/main/java/com/vonage/client/sns/response/SnsPublishResponse.java
@@ -15,7 +15,10 @@
  */
 package com.vonage.client.sns.response;
 
-
+/**
+ * @deprecated SNS will be removed in the next major release.
+ */
+@Deprecated
 public class SnsPublishResponse extends SnsResponse {
     private final String transactionId;
 

--- a/src/main/java/com/vonage/client/sns/response/SnsResponse.java
+++ b/src/main/java/com/vonage/client/sns/response/SnsResponse.java
@@ -16,6 +16,10 @@
 package com.vonage.client.sns.response;
 
 
+/**
+ * @deprecated SNS will be removed in the next major release.
+ */
+@Deprecated
 public class SnsResponse {
 
     public static final int STATUS_OK = 0;

--- a/src/main/java/com/vonage/client/sns/response/SnsSubscribeResponse.java
+++ b/src/main/java/com/vonage/client/sns/response/SnsSubscribeResponse.java
@@ -18,7 +18,10 @@ package com.vonage.client.sns.response;
 
 /**
  * Represents the result of a publish service request to the Vonage SNS Service.
+ *
+ * @deprecated SNS will be removed in the next major release.
  */
+@Deprecated
 public class SnsSubscribeResponse extends SnsResponse {
     private final String subscriberArn;
 


### PR DESCRIPTION
This is likely the last commit and release to `com.vonage:client` and the 7.x branch. It is mainly a cleanup and "FYI" type of release. As such, it contains no actual changes other than deprecation annotations.