### PR TITLE
feat: Add redirect_url to Silent Auth workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = v8.0.0-rc2
+current_version = v8.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.0.0] - 2023-11-??
+- Added `redirect_url` parameter to `SilentAuthWorkflow`
+
 # [8.0.0-rc2] - 2023-11-07
 - Removed packages:
   - `com.vonage.client.legacyutils`

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ See all of our SDKs and integrations on the [Vonage Developer portal](https://de
 
 ## Installation
 
-Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/server-sdk/8.0.0-rc2/snippets).
+Releases are published to [Maven Central](https://central.sonatype.com/artifact/com.vonage/server-sdk/8.0.0/snippets).
 Instructions for your build system can be found in the snippets section.
-They're also available from [here](https://mvnrepository.com/artifact/com.vonage/server-sdk/8.0.0-rc2).
+They're also available from [here](https://mvnrepository.com/artifact/com.vonage/server-sdk/8.0.0).
 Release notes can be found in the [changelog](CHANGELOG.md).
 
 ### Build It Yourself

--- a/build.gradle
+++ b/build.gradle
@@ -24,18 +24,22 @@ repositories {
 }
 
 dependencies {
-    implementation 'commons-codec:commons-codec:1.16.0'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    implementation 'org.apache.httpcomponents:httpmime:4.5.14'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.3'
-    implementation 'com.vonage:jwt:1.1.0'
+    def jacksonVersion = '2.15.3'
+    def httpclientVersion = '4.5.14'
+    def junitVersion = '5.10.1'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.1'
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.10.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
-    testImplementation 'org.mockito:mockito-inline:4.11.0'
-    testImplementation 'jakarta.servlet:jakarta.servlet-api:4.0.4'
+    implementation "commons-codec:commons-codec:1.16.0"
+    implementation "org.apache.httpcomponents:httpclient:$httpclientVersion"
+    implementation "org.apache.httpcomponents:httpmime:$httpclientVersion"
+    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion"
+    implementation "com.vonage:jwt:1.1.0"
+
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+    testImplementation "org.junit.vintage:junit-vintage-engine:$junitVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+    testImplementation "org.mockito:mockito-inline:4.11.0"
+    testImplementation "jakarta.servlet:jakarta.servlet-api:4.0.4"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = "com.vonage"
 archivesBaseName = "server-sdk"
-version = "8.0.0-rc2"
+version = "8.0.0"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -30,7 +30,7 @@ import java.nio.charset.StandardCharsets;
  */
 public class HttpWrapper {
     private static final String CLIENT_NAME = "vonage-java-sdk";
-    private static final String CLIENT_VERSION = "8.0.0-rc2";
+    private static final String CLIENT_VERSION = "8.0.0";
     private static final String JAVA_VERSION = System.getProperty("java.version");
     private static final String USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -18,6 +18,7 @@ package com.vonage.client.verify2;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.common.E164;
+import java.net.URI;
 
 /**
  * Defines properties for mobile network-based authentication. See the
@@ -27,6 +28,7 @@ import com.vonage.client.common.E164;
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class SilentAuthWorkflow extends Workflow {
 	private Boolean sandbox;
+	private URI redirectUrl;
 
 	/**
 	 * Constructs a new Silent Auth verification workflow.
@@ -51,6 +53,21 @@ public final class SilentAuthWorkflow extends Workflow {
 	}
 
 	/**
+	 * Constructs a new Silent Auth verification workflow.
+	 *
+	 * @param to The number to registered to the device on the network to authenticate.
+	 * @param sandbox Whether the Vonage Sandbox should be used (for testing purposes).
+	 * @param redirectUrl Optional final redirect added at the end of the check_url request/response lifecycle.
+	 *                    Will contain the request_id and code as a URL fragment after the URL.
+	 *
+	 * @since 8.0.0
+	 */
+	public SilentAuthWorkflow(String to, boolean sandbox, String redirectUrl) {
+		this(to, sandbox);
+		this.redirectUrl = URI.create(redirectUrl);
+	}
+
+	/**
 	 * Optional parameter if using the Vonage Sandbox to test Silent Auth integrations.
 	 *
 	 * @return Whether the Vonage Sandbox will be used, or {@code null} if not specified (the default).
@@ -60,5 +77,16 @@ public final class SilentAuthWorkflow extends Workflow {
 	@JsonProperty("sandbox")
 	public Boolean getSandbox() {
 		return sandbox;
+	}
+
+	/**
+	 * Final redirect after {@link VerificationResponse#getCheckUrl()}. See the documentation for integrations.
+	 *
+	 * @return The optional {@code redirect_url}, or {@code null} if not set (the default).
+	 * @since 8.0.0
+	 */
+	@JsonProperty("redirect_url")
+	public URI getRedirectUrl() {
+		return redirectUrl;
 	}
 }

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -34,7 +34,8 @@ public class VerificationRequestTest {
 			TO_EMAIL = "alice@example.org",
 			FROM_EMAIL = "bob@example.org",
 			CLIENT_REF = "my-personal-reference",
-			APP_HASH = "kkeid8sksd3";
+			APP_HASH = "kkeid8sksd3",
+			REDIRECT_URL = "https://acme-app.com/sa/redirect";
 
 	Builder newBuilder() {
 		return VerificationRequest.builder().brand(BRAND);
@@ -66,7 +67,7 @@ public class VerificationRequestTest {
 	Workflow getWorkflowAllParamsForChannel(Channel channel) {
 		switch (channel) {
 			case SILENT_AUTH:
-				return new SilentAuthWorkflow(TO_NUMBER, SANDBOX);
+				return new SilentAuthWorkflow(TO_NUMBER, SANDBOX, REDIRECT_URL);
 			case SMS:
 				return new SmsWorkflow(TO_NUMBER, APP_HASH);
 			case WHATSAPP:
@@ -117,7 +118,7 @@ public class VerificationRequestTest {
 		}
 		if (channel == Channel.SILENT_AUTH) {
 			prefix = TO_NUMBER + '"';
-			replacement = prefix + ",\"sandbox\":" + SANDBOX;
+			replacement = prefix + ",\"sandbox\":" + SANDBOX + ",\"redirect_url\":\"" + REDIRECT_URL + '"';
 			expectedJson = expectedJson.replace(prefix, replacement);
 		}
 


### PR DESCRIPTION
Adds the optional `redirect-url` parameter to `SilentAuthWorkflow`, as described [in the API spec](https://developer.vonage.com/en/api/verify.v2#newRequest-req-body).