### PR TITLE
fix: Call modification & signature verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-# [8.0.0] - 2023-11-??
+# [8.0.0] - 2023-11-30
 - Added `redirect_url` parameter to `SilentAuthWorkflow`
 - Bumped Jackson version to 2.16.0
+- Use String instead of UUID in `VoiceClient` call modification methods
+- Added public `verifyRequestSignature` method to `RequestSigning`
 
 # [8.0.0-rc2] - 2023-11-07
 - Removed packages:

--- a/src/main/java/com/vonage/client/auth/RequestSigning.java
+++ b/src/main/java/com/vonage/client/auth/RequestSigning.java
@@ -153,6 +153,25 @@ public class RequestSigning {
      * @param inputStream The request data stream.
      * @param parameterMap The request parameters.
      * @param secretKey The pre-shared secret key used by the sender of the request to create the signature.
+     *
+     * @return true if the signature is correct for this request and secret key.
+     *
+     * @since 8.0.0
+     */
+    public static boolean verifyRequestSignature(InputStream inputStream,
+                                                    String contentType,
+                                                    Map<String, String[]> parameterMap,
+                                                    String secretKey) {
+        return verifyRequestSignature(contentType, inputStream, parameterMap, secretKey, System.currentTimeMillis());
+    }
+
+    /**
+     * Verifies the signature in an HttpServletRequest. Hashing strategy is MD5.
+     *
+     * @param contentType The request Content-Type header.
+     * @param inputStream The request data stream.
+     * @param parameterMap The request parameters.
+     * @param secretKey The pre-shared secret key used by the sender of the request to create the signature.
      * @param currentTimeMillis The current time, in milliseconds.
      *
      * @return true if the signature is correct for this request and secret key.

--- a/src/main/java/com/vonage/client/voice/CallEvent.java
+++ b/src/main/java/com/vonage/client/voice/CallEvent.java
@@ -20,6 +20,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.Jsonable;
 
+/**
+ * Represents metadata about a call.
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CallEvent implements Jsonable {
@@ -27,21 +30,42 @@ public class CallEvent implements Jsonable {
     private CallStatus status;
     private CallDirection direction;
 
+    /**
+     * The unique identifier for this call leg. The UUID is created when your call request is accepted by Vonage.
+     * You use the UUID in all requests for individual live calls.
+     *
+     * @return The call ID.
+     */
     @JsonProperty("uuid")
     public String getUuid() {
         return uuid;
     }
 
+    /**
+     * The unique identifier for the conversation this call leg is part of.
+     *
+     * @return The conversation ID as a string.
+     */
     @JsonProperty("conversation_uuid")
     public String getConversationUuid() {
         return conversationUuid;
     }
 
+    /**
+     * The status of the call.
+     *
+     * @return The call's status as an enum.
+     */
     @JsonProperty("status")
     public CallStatus getStatus() {
         return status;
     }
 
+    /**
+     * Whether the call is inbound or outbound.
+     *
+     * @return The call direction as an enum.
+     */
     @JsonProperty("direction")
     public CallDirection getDirection() {
         return direction;

--- a/src/main/java/com/vonage/client/voice/TransferDestination.java
+++ b/src/main/java/com/vonage/client/voice/TransferDestination.java
@@ -34,10 +34,6 @@ class TransferDestination {
         this(Type.NCCO, null, ncco);
     }
 
-    public TransferDestination(Type type, String url) {
-        this(type, url, null);
-    }
-
     public TransferDestination(Type type, String url, Ncco ncco) {
         this.type = type;
         this.urls = url != null ? new String[]{url} : null;

--- a/src/main/java/com/vonage/client/voice/VoiceClient.java
+++ b/src/main/java/com/vonage/client/voice/VoiceClient.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.function.Function;
 
 /**
@@ -142,8 +141,8 @@ public class VoiceClient {
     /**
      * Look up the status of a single call initiated by {@link #createCall(Call)}.
      *
-     * @param uuid (required) The UUID of the call, obtained from the object returned by {@link #createCall(Call)}. This
-     *             value can be obtained with {@link CallEvent#getUuid()}.
+     * @param uuid (required) The UUID of the call, obtained from the object returned by {@link #createCall(Call)}.
+     *             This value can be obtained with {@link CallEvent#getUuid()}.
      *
      * @return A CallInfo object, representing the response from the Vonage Voice API.
      *
@@ -172,8 +171,8 @@ public class VoiceClient {
         return sendDtmf.execute(new DtmfPayload(digits, validateUuid(uuid)));
     }
 
-    private void modifyCall(UUID callId, ModifyCallAction action) throws VoiceResponseException {
-        modifyCall.execute(new ModifyCallPayload(action, callId.toString()));
+    private void modifyCall(String callId, ModifyCallAction action) throws VoiceResponseException {
+        modifyCall.execute(new ModifyCallPayload(action, validateUuid(callId)));
     }
 
     /**
@@ -186,7 +185,7 @@ public class VoiceClient {
      *
      * @since 7.11.0
      */
-    public void earmuffCall(UUID callId) throws VoiceResponseException {
+    public void earmuffCall(String callId) throws VoiceResponseException {
         modifyCall(callId, ModifyCallAction.EARMUFF);
     }
 
@@ -200,7 +199,7 @@ public class VoiceClient {
      *
      * @since 7.11.0
      */
-    public void unearmuffCall(UUID callId) throws VoiceResponseException {
+    public void unearmuffCall(String callId) throws VoiceResponseException {
         modifyCall(callId, ModifyCallAction.UNEARMUFF);
     }
 
@@ -213,7 +212,7 @@ public class VoiceClient {
      *
      * @since 7.11.0
      */
-    public void muteCall(UUID callId) throws VoiceResponseException {
+    public void muteCall(String callId) throws VoiceResponseException {
         modifyCall(callId, ModifyCallAction.MUTE);
     }
 
@@ -226,7 +225,7 @@ public class VoiceClient {
      *
      * @since 7.11.0
      */
-    public void unmuteCall(UUID callId) throws VoiceResponseException {
+    public void unmuteCall(String callId) throws VoiceResponseException {
         modifyCall(callId, ModifyCallAction.UNMUTE);
     }
 
@@ -239,7 +238,7 @@ public class VoiceClient {
      *
      * @since 7.11.0
      */
-    public void terminateCall(UUID callId) throws VoiceResponseException {
+    public void terminateCall(String callId) throws VoiceResponseException {
         modifyCall(callId, ModifyCallAction.HANGUP);
     }
 

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -130,37 +130,37 @@ public class VoiceClientTest extends ClientTest<VoiceClient> {
 
     @Test
     public void testTerminateCall() throws Exception {
-        stubResponseAndRun(204, () -> client.terminateCall(SAMPLE_CALL_UUID));
+        stubResponseAndRun(204, () -> client.terminateCall(SAMPLE_CALL_ID));
         stubResponseAndAssertThrows(204, () -> client.terminateCall(null), NullPointerException.class);
-        stubResponseAndAssertThrows(404, () -> client.terminateCall(SAMPLE_CALL_UUID), VoiceResponseException.class);
+        stubResponseAndAssertThrows(404, () -> client.terminateCall(SAMPLE_CALL_ID), VoiceResponseException.class);
     }
 
     @Test
     public void testMuteCall() throws Exception {
-        stubResponseAndRun(204, () -> client.muteCall(SAMPLE_CALL_UUID));
+        stubResponseAndRun(204, () -> client.muteCall(SAMPLE_CALL_ID));
         stubResponseAndAssertThrows(204, () -> client.muteCall(null), NullPointerException.class);
-        stubResponseAndAssertThrows(404, () -> client.muteCall(SAMPLE_CALL_UUID), VoiceResponseException.class);
+        stubResponseAndAssertThrows(404, () -> client.muteCall(SAMPLE_CALL_ID), VoiceResponseException.class);
     }
 
     @Test
     public void testUnmuteCall() throws Exception {
-        stubResponseAndRun(204, () -> client.unmuteCall(SAMPLE_CALL_UUID));
+        stubResponseAndRun(204, () -> client.unmuteCall(SAMPLE_CALL_ID));
         stubResponseAndAssertThrows(204, () -> client.unmuteCall(null), NullPointerException.class);
-        stubResponseAndAssertThrows(404, () -> client.unmuteCall(SAMPLE_CALL_UUID), VoiceResponseException.class);
+        stubResponseAndAssertThrows(404, () -> client.unmuteCall(SAMPLE_CALL_ID), VoiceResponseException.class);
     }
 
     @Test
     public void testEarmuffCall() throws Exception {
-        stubResponseAndRun(204, () -> client.earmuffCall(SAMPLE_CALL_UUID));
+        stubResponseAndRun(204, () -> client.earmuffCall(SAMPLE_CALL_ID));
         stubResponseAndAssertThrows(204, () -> client.earmuffCall(null), NullPointerException.class);
-        stubResponseAndAssertThrows(404, () -> client.earmuffCall(SAMPLE_CALL_UUID), VoiceResponseException.class);
+        stubResponseAndAssertThrows(404, () -> client.earmuffCall(SAMPLE_CALL_ID), VoiceResponseException.class);
     }
 
     @Test
     public void testUnearmuffCall() throws Exception {
-        stubResponseAndRun(204, () -> client.unearmuffCall(SAMPLE_CALL_UUID));
+        stubResponseAndRun(204, () -> client.unearmuffCall(SAMPLE_CALL_ID));
         stubResponseAndAssertThrows(204, () -> client.unearmuffCall(null), NullPointerException.class);
-        stubResponseAndAssertThrows(404, () -> client.unearmuffCall(SAMPLE_CALL_UUID), VoiceResponseException.class);
+        stubResponseAndAssertThrows(404, () -> client.unearmuffCall(SAMPLE_CALL_ID), VoiceResponseException.class);
     }
 
     @Test


### PR DESCRIPTION
This PR updates the signatures of the newly added call modification methods in `VoiceClient` to accept a String instead of UUID, for consistency with the rest of the API. It also adds a public `verifyRequestSignature` method to `RequestSigning` for MD5 signatures. This was previously removed due to its dependency on `HttpServletRequest`, but has now been implemented in a manner which works around this.