### PR TITLE
fix: Verify v1 length overload method

### DIFF
--- a/src/main/java/com/vonage/client/account/AccountClient.java
+++ b/src/main/java/com/vonage/client/account/AccountClient.java
@@ -221,6 +221,8 @@ public class AccountClient {
      * @return SecretResponse object which contains the results from the API.
      *
      * @throws AccountResponseException If there was an error making the request or retrieving the response.
+     *
+     * @since 7.9.0
      */
     public SecretResponse getSecret(String secretId) throws AccountResponseException {
         return getSecret(apiKeyGetter.get(), secretId);
@@ -250,6 +252,8 @@ public class AccountClient {
      * @return SecretResponse object which contains the created secret from the API.
      *
      * @throws AccountResponseException If there was an error making the request or retrieving the response.
+     *
+     * @since 7.9.0
      */
     public SecretResponse createSecret(String secret) throws AccountResponseException {
         return createSecret(apiKeyGetter.get(), secret);
@@ -277,6 +281,8 @@ public class AccountClient {
      * @param secretId The id of the secret to revoke.
      *
      * @throws AccountResponseException If there was an error making the request or retrieving the response.
+     *
+     * @since 7.9.0
      */
     public void revokeSecret(String secretId) throws AccountResponseException {
         revokeSecret(apiKeyGetter.get(), secretId);

--- a/src/main/java/com/vonage/client/verify/VerifyClient.java
+++ b/src/main/java/com/vonage/client/verify/VerifyClient.java
@@ -160,11 +160,7 @@ public class VerifyClient {
                                  final String from,
                                  final int length,
                                  final Locale locale) throws VonageClientException, VonageResponseParseException {
-        return verify(new VerifyRequest.Builder(number, brand)
-                .senderId(from)
-                .locale(locale)
-                .build()
-        );
+        return verify(VerifyRequest.builder(number, brand).length(length).senderId(from).locale(locale).build());
     }
 
     /**
@@ -208,7 +204,6 @@ public class VerifyClient {
     public CheckResponse check(final String requestId, final String code) throws VonageClientException, VonageResponseParseException {
         return check(new CheckRequest(requestId, code));
     }
-
 
     /**
      * Search for a previous verification request.

--- a/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
@@ -31,25 +31,6 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
     }
 
     @Test
-    public void testVerifyWithNumberBrandFromLengthLocaleLineType() throws Exception {
-        stubResponse(200,
-                "{\n" + "  \"request_id\": \"not-really-a-request-id\",\n" + "  \"status\": 0,\n"
-                        + "  \"error_text\": \"error\"\n" + "}"
-        );
-
-        VerifyResponse response = client.verify("447700900999",
-                "TestBrand",
-                "15555215554",
-                6,
-                Locale.US
-        );
-
-        assertEquals(VerifyStatus.OK, response.getStatus());
-        assertEquals("error", response.getErrorText());
-        assertEquals("not-really-a-request-id", response.getRequestId());
-    }
-
-    @Test
     public void testVerifyWithNumberBrandFromLengthLocale() throws Exception {
         stubResponse(200,
                 "{\n" + "  \"request_id\": \"not-really-a-request-id\",\n" + "  \"status\": 0,\n"
@@ -131,7 +112,8 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
                 .senderId("15555215554")
                 .length(6)
                 .locale(Locale.US)
-                .build());
+                .build()
+        );
 
         assertEquals(VerifyStatus.INTERNAL_ERROR, response.getStatus());
         assertEquals("error", response.getErrorText());
@@ -195,7 +177,7 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
             }
 
             @Override
-            protected Map<String, ?> sampleQueryParams() {
+            protected Map<String, String> sampleQueryParams() {
                 Map<String, String> params = new LinkedHashMap<>();
                 params.put("number", "4477990090090");
                 params.put("brand", "Brand.com");
@@ -207,7 +189,17 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
                 params.put("pin_expiry", "60");
                 params.put("next_event_wait", "90");
                 params.put("workflow_id", "3");
+                return params;
+            }
 
+            @Override
+            public void runTests() throws Exception {
+                super.runTests();
+                assertQueryParamsMatchRequest();
+            }
+
+            private void assertQueryParamsMatchRequest() {
+                Map<String, String> params = sampleQueryParams();
                 VerifyRequest request = sampleRequest();
                 assertNotNull(request.toString());
                 assertEquals(request.getNumber(), params.get("number"));
@@ -220,8 +212,6 @@ public class VerifyClientVerifyEndpointTest extends ClientTest<VerifyClient> {
                 assertEquals(request.getPinExpiry().toString(), params.get("pin_expiry"));
                 assertEquals(request.getNextEventWait().toString(), params.get("next_event_wait"));
                 assertEquals(String.valueOf(request.getWorkflow().getId()), params.get("workflow_id"));
-                
-                return params;
             }
         }
         .runTests();


### PR DESCRIPTION
Updates AccountClient missing description and fixes the Verify v1 length not being set in the `VerifyClient#verify(String number, String brand, String from, int length, Locale locale)` method signature.