### PR TITLE
chore: Update license copyright year

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2023 Vonage
+   Copyright 2024 Vonage
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    def jacksonVersion = '2.16.0'
+    def jacksonVersion = '2.16.1'
     def httpclientVersion = '4.5.14'
     def junitVersion = '5.10.1'
 
@@ -51,7 +51,6 @@ test {
 }
 
 javadoc {
-    /* info for JavaDoc options https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#overviewcomment */
     title "Vonage Java Server SDK"
     // uncomment this to use a custom javadoc overview
     //options.overview = file("src/main/javadoc/overview.html")

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/BinaryRequest.java
+++ b/src/main/java/com/vonage/client/BinaryRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/HttpConfig.java
+++ b/src/main/java/com/vonage/client/HttpConfig.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/Jsonable.java
+++ b/src/main/java/com/vonage/client/Jsonable.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/QueryParamsRequest.java
+++ b/src/main/java/com/vonage/client/QueryParamsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/RestEndpoint.java
+++ b/src/main/java/com/vonage/client/RestEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageApiResponseException.java
+++ b/src/main/java/com/vonage/client/VonageApiResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageBadRequestException.java
+++ b/src/main/java/com/vonage/client/VonageBadRequestException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageClientCreationException.java
+++ b/src/main/java/com/vonage/client/VonageClientCreationException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageClientException.java
+++ b/src/main/java/com/vonage/client/VonageClientException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageMethodFailedException.java
+++ b/src/main/java/com/vonage/client/VonageMethodFailedException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageResponseParseException.java
+++ b/src/main/java/com/vonage/client/VonageResponseParseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageUnableToReadPrivateKeyException.java
+++ b/src/main/java/com/vonage/client/VonageUnableToReadPrivateKeyException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/VonageUnexpectedException.java
+++ b/src/main/java/com/vonage/client/VonageUnexpectedException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/AccountClient.java
+++ b/src/main/java/com/vonage/client/account/AccountClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/AccountResponseException.java
+++ b/src/main/java/com/vonage/client/account/AccountResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/BalanceResponse.java
+++ b/src/main/java/com/vonage/client/account/BalanceResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/Country.java
+++ b/src/main/java/com/vonage/client/account/Country.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/CreateSecretRequest.java
+++ b/src/main/java/com/vonage/client/account/CreateSecretRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/FullPricingRequest.java
+++ b/src/main/java/com/vonage/client/account/FullPricingRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/FullPricingResponse.java
+++ b/src/main/java/com/vonage/client/account/FullPricingResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/ListSecretsResponse.java
+++ b/src/main/java/com/vonage/client/account/ListSecretsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/Network.java
+++ b/src/main/java/com/vonage/client/account/Network.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/PrefixPricingRequest.java
+++ b/src/main/java/com/vonage/client/account/PrefixPricingRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/PrefixPricingResponse.java
+++ b/src/main/java/com/vonage/client/account/PrefixPricingResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/PricingRequest.java
+++ b/src/main/java/com/vonage/client/account/PricingRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/PricingResponse.java
+++ b/src/main/java/com/vonage/client/account/PricingResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/SecretRequest.java
+++ b/src/main/java/com/vonage/client/account/SecretRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/SecretResponse.java
+++ b/src/main/java/com/vonage/client/account/SecretResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/ServiceType.java
+++ b/src/main/java/com/vonage/client/account/ServiceType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/SettingsRequest.java
+++ b/src/main/java/com/vonage/client/account/SettingsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/SettingsResponse.java
+++ b/src/main/java/com/vonage/client/account/SettingsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/account/TopUpRequest.java
+++ b/src/main/java/com/vonage/client/account/TopUpRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/Application.java
+++ b/src/main/java/com/vonage/client/application/Application.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/ApplicationClient.java
+++ b/src/main/java/com/vonage/client/application/ApplicationClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/ApplicationList.java
+++ b/src/main/java/com/vonage/client/application/ApplicationList.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/ApplicationResponseException.java
+++ b/src/main/java/com/vonage/client/application/ApplicationResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/ListApplicationRequest.java
+++ b/src/main/java/com/vonage/client/application/ListApplicationRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Capability.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Capability.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Messages.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Messages.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Region.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Region.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Rtc.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Rtc.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Vbc.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Vbc.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/capabilities/Voice.java
+++ b/src/main/java/com/vonage/client/application/capabilities/Voice.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/application/package-info.java
+++ b/src/main/java/com/vonage/client/application/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/AuthCollection.java
+++ b/src/main/java/com/vonage/client/auth/AuthCollection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/AuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/AuthMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/RequestSigning.java
+++ b/src/main/java/com/vonage/client/auth/RequestSigning.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/SignatureAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/SignatureAuthMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/TokenAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/TokenAuthMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/VonageAuthException.java
+++ b/src/main/java/com/vonage/client/auth/VonageAuthException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
+++ b/src/main/java/com/vonage/client/auth/VonageUnacceptableAuthException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/AbstractHasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/AbstractHasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/HashUtil.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/HashUtil.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/HmacMd5Hasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/HmacMd5Hasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/HmacSha1Hasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/HmacSha1Hasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/HmacSha256Hasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/HmacSha256Hasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/HmacSha512Hasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/HmacSha512Hasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/hashutils/Md5Hasher.java
+++ b/src/main/java/com/vonage/client/auth/hashutils/Md5Hasher.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/auth/package-info.java
+++ b/src/main/java/com/vonage/client/auth/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/E164.java
+++ b/src/main/java/com/vonage/client/common/E164.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/HalLinks.java
+++ b/src/main/java/com/vonage/client/common/HalLinks.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/HalPageResponse.java
+++ b/src/main/java/com/vonage/client/common/HalPageResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/HttpMethod.java
+++ b/src/main/java/com/vonage/client/common/HttpMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/UrlContainer.java
+++ b/src/main/java/com/vonage/client/common/UrlContainer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/common/Webhook.java
+++ b/src/main/java/com/vonage/client/common/Webhook.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/conversion/ConversionClient.java
+++ b/src/main/java/com/vonage/client/conversion/ConversionClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/conversion/ConversionRequest.java
+++ b/src/main/java/com/vonage/client/conversion/ConversionRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/CallDirection.java
+++ b/src/main/java/com/vonage/client/incoming/CallDirection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/CallEvent.java
+++ b/src/main/java/com/vonage/client/incoming/CallEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/CallStatus.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
@@ -19,44 +19,44 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum CallStatusDetail {
     /**
-     * no detail field present
-     * **/
+     * No detail field present
+     */
     NO_DETAIL,
     /**
-     * detail present, but has not been mapped to an enum yet
-     * **/
+     * Detail present, but has not been mapped to an enum yet
+     */
     UNMAPPED_DETAIL,
     /**
-     * number invalid
-     * **/
+     * Number invalid
+     */
     INVALID_NUMBER,
     /**
-     * Rejected By Carrier
-     * **/
+     * Rejected by carrier
+     */
     RESTRICTED,
     /**
-     * call rejected by callee
-     * **/
+     * Call rejected by callee
+     */
     DECLINED,
     /**
-     * cannot route to the number
-     * **/
+     * Cannot route to the number
+     */
     CANNOT_ROUTE,
     /**
-     * number is no longer available
-     * **/
+     * Number is no longer available
+     */
     NUMBER_OUT_OF_SERVICE,
     /**
      * Server error or failure
-     * **/
+     */
     INTERNAL_ERROR,
     /**
      * Carrier timed out
-     * **/
+     */
     CARRIER_TIMEOUT,
     /**
      * Callee is temporarily unavailable.
-     * **/
+     */
     UNAVAILABLE;
 
 

--- a/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/DtmfResult.java
+++ b/src/main/java/com/vonage/client/incoming/DtmfResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/InputEvent.java
+++ b/src/main/java/com/vonage/client/incoming/InputEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/MessageEvent.java
+++ b/src/main/java/com/vonage/client/incoming/MessageEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/MessageType.java
+++ b/src/main/java/com/vonage/client/incoming/MessageType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/NotifyEvent.java
+++ b/src/main/java/com/vonage/client/incoming/NotifyEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/RecordEvent.java
+++ b/src/main/java/com/vonage/client/incoming/RecordEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/Result.java
+++ b/src/main/java/com/vonage/client/incoming/Result.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/incoming/SpeechResults.java
+++ b/src/main/java/com/vonage/client/incoming/SpeechResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/BaseInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/BaseInsightRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/BasicInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/BasicInsightRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/BasicInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/BasicInsightResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/CallerIdentity.java
+++ b/src/main/java/com/vonage/client/insight/CallerIdentity.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/CallerType.java
+++ b/src/main/java/com/vonage/client/insight/CallerType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/CarrierDetails.java
+++ b/src/main/java/com/vonage/client/insight/CarrierDetails.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/InsightClient.java
+++ b/src/main/java/com/vonage/client/insight/InsightClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/InsightStatus.java
+++ b/src/main/java/com/vonage/client/insight/InsightStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/LookupOutcome.java
+++ b/src/main/java/com/vonage/client/insight/LookupOutcome.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/PortedStatus.java
+++ b/src/main/java/com/vonage/client/insight/PortedStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/Reachability.java
+++ b/src/main/java/com/vonage/client/insight/Reachability.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/RealTimeData.java
+++ b/src/main/java/com/vonage/client/insight/RealTimeData.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/RoamingDetails.java
+++ b/src/main/java/com/vonage/client/insight/RoamingDetails.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/StandardInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/StandardInsightRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/StandardInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/StandardInsightResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/insight/Validity.java
+++ b/src/main/java/com/vonage/client/insight/Validity.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/Application.java
+++ b/src/main/java/com/vonage/client/meetings/Application.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/AvailableFeatures.java
+++ b/src/main/java/com/vonage/client/meetings/AvailableFeatures.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/CallbackUrls.java
+++ b/src/main/java/com/vonage/client/meetings/CallbackUrls.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/DeleteThemeRequest.java
+++ b/src/main/java/com/vonage/client/meetings/DeleteThemeRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/DialInNumber.java
+++ b/src/main/java/com/vonage/client/meetings/DialInNumber.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/EventType.java
+++ b/src/main/java/com/vonage/client/meetings/EventType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/FinalizeLogosRequest.java
+++ b/src/main/java/com/vonage/client/meetings/FinalizeLogosRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/GetLogoUploadUrlsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/GetLogoUploadUrlsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/InitialJoinOptions.java
+++ b/src/main/java/com/vonage/client/meetings/InitialJoinOptions.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/JoinApprovalLevel.java
+++ b/src/main/java/com/vonage/client/meetings/JoinApprovalLevel.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ListDialNumbersResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListDialNumbersResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ListRecordingsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListRecordingsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ListRoomsRequest.java
+++ b/src/main/java/com/vonage/client/meetings/ListRoomsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ListRoomsResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListRoomsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ListThemesResponse.java
+++ b/src/main/java/com/vonage/client/meetings/ListThemesResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/LogoType.java
+++ b/src/main/java/com/vonage/client/meetings/LogoType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/LogoUploadsUrlResponse.java
+++ b/src/main/java/com/vonage/client/meetings/LogoUploadsUrlResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/MeetingRoom.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingRoom.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/MeetingsClient.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingsClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/MeetingsEventCallback.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingsEventCallback.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/MeetingsResponseException.java
+++ b/src/main/java/com/vonage/client/meetings/MeetingsResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/MicrophoneState.java
+++ b/src/main/java/com/vonage/client/meetings/MicrophoneState.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/Recording.java
+++ b/src/main/java/com/vonage/client/meetings/Recording.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RecordingLinks.java
+++ b/src/main/java/com/vonage/client/meetings/RecordingLinks.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RecordingOptions.java
+++ b/src/main/java/com/vonage/client/meetings/RecordingOptions.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RecordingStatus.java
+++ b/src/main/java/com/vonage/client/meetings/RecordingStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RoomLanguage.java
+++ b/src/main/java/com/vonage/client/meetings/RoomLanguage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RoomLinks.java
+++ b/src/main/java/com/vonage/client/meetings/RoomLinks.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/RoomType.java
+++ b/src/main/java/com/vonage/client/meetings/RoomType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/Theme.java
+++ b/src/main/java/com/vonage/client/meetings/Theme.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/ThemeDomain.java
+++ b/src/main/java/com/vonage/client/meetings/ThemeDomain.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/UISettings.java
+++ b/src/main/java/com/vonage/client/meetings/UISettings.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/UpdateApplicationRequest.java
+++ b/src/main/java/com/vonage/client/meetings/UpdateApplicationRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/UpdateRoomRequest.java
+++ b/src/main/java/com/vonage/client/meetings/UpdateRoomRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/UrlContainer.java
+++ b/src/main/java/com/vonage/client/meetings/UrlContainer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/meetings/package-info.java
+++ b/src/main/java/com/vonage/client/meetings/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/Channel.java
+++ b/src/main/java/com/vonage/client/messages/Channel.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/InboundMessage.java
+++ b/src/main/java/com/vonage/client/messages/InboundMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/MessageRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessageResponse.java
+++ b/src/main/java/com/vonage/client/messages/MessageResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessageResponseException.java
+++ b/src/main/java/com/vonage/client/messages/MessageResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessageStatus.java
+++ b/src/main/java/com/vonage/client/messages/MessageStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessageType.java
+++ b/src/main/java/com/vonage/client/messages/MessageType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessagesClient.java
+++ b/src/main/java/com/vonage/client/messages/MessagesClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/MessagesVersion.java
+++ b/src/main/java/com/vonage/client/messages/MessagesVersion.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/internal/MessagePayload.java
+++ b/src/main/java/com/vonage/client/messages/internal/MessagePayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/internal/Text.java
+++ b/src/main/java/com/vonage/client/messages/internal/Text.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/Category.java
+++ b/src/main/java/com/vonage/client/messages/messenger/Category.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/Messenger.java
+++ b/src/main/java/com/vonage/client/messages/messenger/Messenger.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/messenger/Tag.java
+++ b/src/main/java/com/vonage/client/messages/messenger/Tag.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/package-info.java
+++ b/src/main/java/com/vonage/client/messages/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/sms/EncodingType.java
+++ b/src/main/java/com/vonage/client/messages/sms/EncodingType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
+++ b/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/sms/SmsInboundMetadata.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsInboundMetadata.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/Action.java
+++ b/src/main/java/com/vonage/client/messages/viber/Action.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/Category.java
+++ b/src/main/java/com/vonage/client/messages/viber/Category.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/File.java
+++ b/src/main/java/com/vonage/client/messages/viber/File.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberFileRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberService.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberService.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/viber/Video.java
+++ b/src/main/java/com/vonage/client/messages/viber/Video.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Context.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Context.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/ContextStatus.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ContextStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/ConversationType.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ConversationType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Locale.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Location.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Location.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Order.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Order.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Policy.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Policy.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/ProductItem.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ProductItem.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/ProductSection.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ProductSection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Profile.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Profile.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Referral.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Referral.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/ReferredProduct.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ReferredProduct.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Reply.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Reply.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Sticker.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Sticker.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Template.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Template.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Whatsapp.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappLocationRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappLocationRequest.java
@@ -1,6 +1,6 @@
 
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappMultiProductRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappMultiProductRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappSingleProductRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappSingleProductRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappStickerRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappStickerRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/AvailableNumber.java
+++ b/src/main/java/com/vonage/client/numbers/AvailableNumber.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/BaseNumberRequest.java
+++ b/src/main/java/com/vonage/client/numbers/BaseNumberRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/BuyNumberRequest.java
+++ b/src/main/java/com/vonage/client/numbers/BuyNumberRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/CancelNumberRequest.java
+++ b/src/main/java/com/vonage/client/numbers/CancelNumberRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/ListNumbersFilter.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersFilter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
+++ b/src/main/java/com/vonage/client/numbers/ListNumbersResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/NumbersClient.java
+++ b/src/main/java/com/vonage/client/numbers/NumbersClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/NumbersResponseException.java
+++ b/src/main/java/com/vonage/client/numbers/NumbersResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/OwnedNumber.java
+++ b/src/main/java/com/vonage/client/numbers/OwnedNumber.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersFilter.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersFilter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/SearchNumbersResponse.java
+++ b/src/main/java/com/vonage/client/numbers/SearchNumbersResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/SearchPattern.java
+++ b/src/main/java/com/vonage/client/numbers/SearchPattern.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/Type.java
+++ b/src/main/java/com/vonage/client/numbers/Type.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/numbers/UpdateNumberRequest.java
+++ b/src/main/java/com/vonage/client/numbers/UpdateNumberRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/package-info.java
+++ b/src/main/java/com/vonage/client/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ContactsList.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ContactsList.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/Datasource.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/Datasource.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/Event.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/Event.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/EventType.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/EventType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/HalRequestWrapper.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/HalRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListAttribute.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListAttribute.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsFilter.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsFilter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListEventsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItem.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItem.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItemRequestWrapper.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItemRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListItemsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ListListsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ManualDatasource.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ManualDatasource.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectResponseException.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/ProactiveConnectResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/SalesforceDatasource.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SalesforceDatasource.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/SortOrder.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SortOrder.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/SourceType.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SourceType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/SyncStatus.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SyncStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/SyncStatusValue.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/SyncStatusValue.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsRequestWrapper.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsResponse.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/UploadListItemsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/proactiveconnect/package-info.java
+++ b/src/main/java/com/vonage/client/proactiveconnect/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/redact/RedactClient.java
+++ b/src/main/java/com/vonage/client/redact/RedactClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/redact/RedactRequest.java
+++ b/src/main/java/com/vonage/client/redact/RedactRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/HexUtil.java
+++ b/src/main/java/com/vonage/client/sms/HexUtil.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/MessageStatus.java
+++ b/src/main/java/com/vonage/client/sms/MessageStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/SmsClient.java
+++ b/src/main/java/com/vonage/client/sms/SmsClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
+++ b/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/SmsSubmissionResponseMessage.java
+++ b/src/main/java/com/vonage/client/sms/SmsSubmissionResponseMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/callback/VonageCallbackRequestValidationException.java
+++ b/src/main/java/com/vonage/client/sms/callback/VonageCallbackRequestValidationException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/callback/messages/MO.java
+++ b/src/main/java/com/vonage/client/sms/callback/messages/MO.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/messages/BinaryMessage.java
+++ b/src/main/java/com/vonage/client/sms/messages/BinaryMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/messages/Message.java
+++ b/src/main/java/com/vonage/client/sms/messages/Message.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/sms/messages/TextMessage.java
+++ b/src/main/java/com/vonage/client/sms/messages/TextMessage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/AbstractTransfer.java
+++ b/src/main/java/com/vonage/client/subaccounts/AbstractTransfer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/Account.java
+++ b/src/main/java/com/vonage/client/subaccounts/Account.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/CreateSubaccountRequest.java
+++ b/src/main/java/com/vonage/client/subaccounts/CreateSubaccountRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/ListSubaccountsResponse.java
+++ b/src/main/java/com/vonage/client/subaccounts/ListSubaccountsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/ListTransfersFilter.java
+++ b/src/main/java/com/vonage/client/subaccounts/ListTransfersFilter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/ListTransfersResponseWrapper.java
+++ b/src/main/java/com/vonage/client/subaccounts/ListTransfersResponseWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/MoneyTransfer.java
+++ b/src/main/java/com/vonage/client/subaccounts/MoneyTransfer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/NumberTransfer.java
+++ b/src/main/java/com/vonage/client/subaccounts/NumberTransfer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/SubaccountsClient.java
+++ b/src/main/java/com/vonage/client/subaccounts/SubaccountsClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/SubaccountsResponseException.java
+++ b/src/main/java/com/vonage/client/subaccounts/SubaccountsResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/UpdateSubaccountRequest.java
+++ b/src/main/java/com/vonage/client/subaccounts/UpdateSubaccountRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/subaccounts/package-info.java
+++ b/src/main/java/com/vonage/client/subaccounts/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/BaseUser.java
+++ b/src/main/java/com/vonage/client/users/BaseUser.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/ListUsersRequest.java
+++ b/src/main/java/com/vonage/client/users/ListUsersRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/ListUsersResponse.java
+++ b/src/main/java/com/vonage/client/users/ListUsersResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/User.java
+++ b/src/main/java/com/vonage/client/users/User.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/UsersClient.java
+++ b/src/main/java/com/vonage/client/users/UsersClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/UsersResponseException.java
+++ b/src/main/java/com/vonage/client/users/UsersResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Channel.java
+++ b/src/main/java/com/vonage/client/users/channels/Channel.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Channels.java
+++ b/src/main/java/com/vonage/client/users/channels/Channels.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Messenger.java
+++ b/src/main/java/com/vonage/client/users/channels/Messenger.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Mms.java
+++ b/src/main/java/com/vonage/client/users/channels/Mms.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/NumberChannel.java
+++ b/src/main/java/com/vonage/client/users/channels/NumberChannel.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Pstn.java
+++ b/src/main/java/com/vonage/client/users/channels/Pstn.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Sip.java
+++ b/src/main/java/com/vonage/client/users/channels/Sip.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Sms.java
+++ b/src/main/java/com/vonage/client/users/channels/Sms.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Vbc.java
+++ b/src/main/java/com/vonage/client/users/channels/Vbc.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Viber.java
+++ b/src/main/java/com/vonage/client/users/channels/Viber.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Websocket.java
+++ b/src/main/java/com/vonage/client/users/channels/Websocket.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/channels/Whatsapp.java
+++ b/src/main/java/com/vonage/client/users/channels/Whatsapp.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/users/package-info.java
+++ b/src/main/java/com/vonage/client/users/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/BaseRequest.java
+++ b/src/main/java/com/vonage/client/verify/BaseRequest.java
@@ -1,23 +1,17 @@
 /*
- * Copyright 2011-2017 Nexmo Inc
+ *   Copyright 2024 Vonage
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package com.vonage.client.verify;
 

--- a/src/main/java/com/vonage/client/verify/CheckRequest.java
+++ b/src/main/java/com/vonage/client/verify/CheckRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/CheckResponse.java
+++ b/src/main/java/com/vonage/client/verify/CheckResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/ControlRequest.java
+++ b/src/main/java/com/vonage/client/verify/ControlRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/ControlResponse.java
+++ b/src/main/java/com/vonage/client/verify/ControlResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/Psd2Request.java
+++ b/src/main/java/com/vonage/client/verify/Psd2Request.java
@@ -1,23 +1,17 @@
 /*
- * Copyright 2011-2017 Nexmo Inc
+ *   Copyright 2024 Vonage
  *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
  *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ *        http://www.apache.org/licenses/LICENSE-2.0
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
  */
 package com.vonage.client.verify;
 

--- a/src/main/java/com/vonage/client/verify/SearchRequest.java
+++ b/src/main/java/com/vonage/client/verify/SearchRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/SearchVerifyResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/SearchVerifyResponseDeserializer.java
+++ b/src/main/java/com/vonage/client/verify/SearchVerifyResponseDeserializer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyCheck.java
+++ b/src/main/java/com/vonage/client/verify/VerifyCheck.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyClient.java
+++ b/src/main/java/com/vonage/client/verify/VerifyClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyControlCommand.java
+++ b/src/main/java/com/vonage/client/verify/VerifyControlCommand.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyDetails.java
+++ b/src/main/java/com/vonage/client/verify/VerifyDetails.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyException.java
+++ b/src/main/java/com/vonage/client/verify/VerifyException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyRequest.java
+++ b/src/main/java/com/vonage/client/verify/VerifyRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyResponse.java
+++ b/src/main/java/com/vonage/client/verify/VerifyResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyStatus.java
+++ b/src/main/java/com/vonage/client/verify/VerifyStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify/VerifyStatusDeserializer.java
+++ b/src/main/java/com/vonage/client/verify/VerifyStatusDeserializer.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/CallbackType.java
+++ b/src/main/java/com/vonage/client/verify2/CallbackType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/Channel.java
+++ b/src/main/java/com/vonage/client/verify2/Channel.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/EmailWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/EmailWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/SmsWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SmsWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerificationCallback.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationCallback.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerificationRequest.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerificationResponse.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerificationStatus.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/Verify2Client.java
+++ b/src/main/java/com/vonage/client/verify2/Verify2Client.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerifyCodeRequestWrapper.java
+++ b/src/main/java/com/vonage/client/verify2/VerifyCodeRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VerifyResponseException.java
+++ b/src/main/java/com/vonage/client/verify2/VerifyResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/VoiceWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/VoiceWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/Workflow.java
+++ b/src/main/java/com/vonage/client/verify2/Workflow.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/WorkflowStatus.java
+++ b/src/main/java/com/vonage/client/verify2/WorkflowStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/verify2/package-info.java
+++ b/src/main/java/com/vonage/client/verify2/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/Archive.java
+++ b/src/main/java/com/vonage/client/video/Archive.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ArchiveMode.java
+++ b/src/main/java/com/vonage/client/video/ArchiveMode.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ArchiveStatus.java
+++ b/src/main/java/com/vonage/client/video/ArchiveStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/Broadcast.java
+++ b/src/main/java/com/vonage/client/video/Broadcast.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/BroadcastStatus.java
+++ b/src/main/java/com/vonage/client/video/BroadcastStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/BroadcastUrls.java
+++ b/src/main/java/com/vonage/client/video/BroadcastUrls.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/CreateSessionRequest.java
+++ b/src/main/java/com/vonage/client/video/CreateSessionRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/CreateSessionResponse.java
+++ b/src/main/java/com/vonage/client/video/CreateSessionResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/GetStreamResponse.java
+++ b/src/main/java/com/vonage/client/video/GetStreamResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/Hls.java
+++ b/src/main/java/com/vonage/client/video/Hls.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ListArchivesResponse.java
+++ b/src/main/java/com/vonage/client/video/ListArchivesResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ListBroadcastsResponse.java
+++ b/src/main/java/com/vonage/client/video/ListBroadcastsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ListStreamCompositionsRequest.java
+++ b/src/main/java/com/vonage/client/video/ListStreamCompositionsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ListStreamsResponse.java
+++ b/src/main/java/com/vonage/client/video/ListStreamsResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/MediaMode.java
+++ b/src/main/java/com/vonage/client/video/MediaMode.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/MuteSessionRequest.java
+++ b/src/main/java/com/vonage/client/video/MuteSessionRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/MuteSessionResponse.java
+++ b/src/main/java/com/vonage/client/video/MuteSessionResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/PatchComposedStreamsRequest.java
+++ b/src/main/java/com/vonage/client/video/PatchComposedStreamsRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ProjectDetails.java
+++ b/src/main/java/com/vonage/client/video/ProjectDetails.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ProjectEnvironment.java
+++ b/src/main/java/com/vonage/client/video/ProjectEnvironment.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ProjectStatus.java
+++ b/src/main/java/com/vonage/client/video/ProjectStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/Role.java
+++ b/src/main/java/com/vonage/client/video/Role.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/Rtmp.java
+++ b/src/main/java/com/vonage/client/video/Rtmp.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/RtmpStatus.java
+++ b/src/main/java/com/vonage/client/video/RtmpStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/ScreenLayoutType.java
+++ b/src/main/java/com/vonage/client/video/ScreenLayoutType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SendDtmfRequest.java
+++ b/src/main/java/com/vonage/client/video/SendDtmfRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SessionResourceRequestWrapper.java
+++ b/src/main/java/com/vonage/client/video/SessionResourceRequestWrapper.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SessionStream.java
+++ b/src/main/java/com/vonage/client/video/SessionStream.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SetStreamLayoutRequest.java
+++ b/src/main/java/com/vonage/client/video/SetStreamLayoutRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SignalRequest.java
+++ b/src/main/java/com/vonage/client/video/SignalRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SipDialRequest.java
+++ b/src/main/java/com/vonage/client/video/SipDialRequest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/SipDialResponse.java
+++ b/src/main/java/com/vonage/client/video/SipDialResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/StreamComposition.java
+++ b/src/main/java/com/vonage/client/video/StreamComposition.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/StreamCompositionLayout.java
+++ b/src/main/java/com/vonage/client/video/StreamCompositionLayout.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/TokenOptions.java
+++ b/src/main/java/com/vonage/client/video/TokenOptions.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/VideoClient.java
+++ b/src/main/java/com/vonage/client/video/VideoClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/VideoResponseException.java
+++ b/src/main/java/com/vonage/client/video/VideoResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/VideoStream.java
+++ b/src/main/java/com/vonage/client/video/VideoStream.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/VideoType.java
+++ b/src/main/java/com/vonage/client/video/VideoType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/video/package-info.java
+++ b/src/main/java/com/vonage/client/video/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/AdvancedMachineDetection.java
+++ b/src/main/java/com/vonage/client/voice/AdvancedMachineDetection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/AppEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/AppEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/Call.java
+++ b/src/main/java/com/vonage/client/voice/Call.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallDirection.java
+++ b/src/main/java/com/vonage/client/voice/CallDirection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallEvent.java
+++ b/src/main/java/com/vonage/client/voice/CallEvent.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallInfo.java
+++ b/src/main/java/com/vonage/client/voice/CallInfo.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallInfoPage.java
+++ b/src/main/java/com/vonage/client/voice/CallInfoPage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallOrder.java
+++ b/src/main/java/com/vonage/client/voice/CallOrder.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallStatus.java
+++ b/src/main/java/com/vonage/client/voice/CallStatus.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/CallsFilter.java
+++ b/src/main/java/com/vonage/client/voice/CallsFilter.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/DtmfPayload.java
+++ b/src/main/java/com/vonage/client/voice/DtmfPayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/DtmfResponse.java
+++ b/src/main/java/com/vonage/client/voice/DtmfResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/EmbeddedCalls.java
+++ b/src/main/java/com/vonage/client/voice/EmbeddedCalls.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/Endpoint.java
+++ b/src/main/java/com/vonage/client/voice/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/MachineDetection.java
+++ b/src/main/java/com/vonage/client/voice/MachineDetection.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ModifyCallAction.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ModifyCallPayload.java
+++ b/src/main/java/com/vonage/client/voice/ModifyCallPayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/PageLink.java
+++ b/src/main/java/com/vonage/client/voice/PageLink.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/PageLinks.java
+++ b/src/main/java/com/vonage/client/voice/PageLinks.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/SipEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/SipEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/StreamPayload.java
+++ b/src/main/java/com/vonage/client/voice/StreamPayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/StreamResponse.java
+++ b/src/main/java/com/vonage/client/voice/StreamResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/TalkPayload.java
+++ b/src/main/java/com/vonage/client/voice/TalkPayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/TalkResponse.java
+++ b/src/main/java/com/vonage/client/voice/TalkResponse.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
+++ b/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/TransferCallPayload.java
+++ b/src/main/java/com/vonage/client/voice/TransferCallPayload.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/TransferDestination.java
+++ b/src/main/java/com/vonage/client/voice/TransferDestination.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/VbcEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/VbcEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/VoiceClient.java
+++ b/src/main/java/com/vonage/client/voice/VoiceClient.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/VoiceResponseException.java
+++ b/src/main/java/com/vonage/client/voice/VoiceResponseException.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/Action.java
+++ b/src/main/java/com/vonage/client/voice/ncco/Action.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/AppEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/AppEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/ConnectAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/ConnectAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/ConversationAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/ConversationAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/DtmfSettings.java
+++ b/src/main/java/com/vonage/client/voice/ncco/DtmfSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/Endpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/Endpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/EventMethod.java
+++ b/src/main/java/com/vonage/client/voice/ncco/EventMethod.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/EventType.java
+++ b/src/main/java/com/vonage/client/voice/ncco/EventType.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/InputAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/InputAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/Ncco.java
+++ b/src/main/java/com/vonage/client/voice/ncco/Ncco.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/NotifyAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/NotifyAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/PhoneEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/PhoneEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/RecordAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/RecordAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/RecordingFormat.java
+++ b/src/main/java/com/vonage/client/voice/ncco/RecordingFormat.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/SipEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/SipEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/SpeechSettings.java
+++ b/src/main/java/com/vonage/client/voice/ncco/SpeechSettings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/SplitRecording.java
+++ b/src/main/java/com/vonage/client/voice/ncco/SplitRecording.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/StreamAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/StreamAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/TalkAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/TalkAction.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/VbcEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/VbcEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/ncco/package-info.java
+++ b/src/main/java/com/vonage/client/voice/ncco/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/main/java/com/vonage/client/voice/package-info.java
+++ b/src/main/java/com/vonage/client/voice/package-info.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/ClientTest.java
+++ b/src/test/java/com/vonage/client/ClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/DynamicEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/DynamicEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/HttpConfigTest.java
+++ b/src/test/java/com/vonage/client/HttpConfigTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/HttpWrapperTest.java
+++ b/src/test/java/com/vonage/client/HttpWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/TestUtils.java
+++ b/src/test/java/com/vonage/client/TestUtils.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/VonageApiResponseExceptionTest.java
+++ b/src/test/java/com/vonage/client/VonageApiResponseExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/VonageClientTest.java
+++ b/src/test/java/com/vonage/client/VonageClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/account/AccountClientTest.java
+++ b/src/test/java/com/vonage/client/account/AccountClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/account/AccountEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/account/AccountEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/account/AccountSecretsEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/account/AccountSecretsEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/ApplicationClientTest.java
+++ b/src/test/java/com/vonage/client/application/ApplicationClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/ApplicationEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/application/ApplicationEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/ApplicationTest.java
+++ b/src/test/java/com/vonage/client/application/ApplicationTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/capabilities/MessagesTest.java
+++ b/src/test/java/com/vonage/client/application/capabilities/MessagesTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/capabilities/RtcTest.java
+++ b/src/test/java/com/vonage/client/application/capabilities/RtcTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/capabilities/VbcTest.java
+++ b/src/test/java/com/vonage/client/application/capabilities/VbcTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/application/capabilities/VoiceTest.java
+++ b/src/test/java/com/vonage/client/application/capabilities/VoiceTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
+++ b/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/auth/JWTAuthMethodTest.java
+++ b/src/test/java/com/vonage/client/auth/JWTAuthMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/auth/RequestSigningTest.java
+++ b/src/test/java/com/vonage/client/auth/RequestSigningTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/auth/TokenAuthMethodTest.java
+++ b/src/test/java/com/vonage/client/auth/TokenAuthMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/auth/VonageUnacceptableAuthExceptionTest.java
+++ b/src/test/java/com/vonage/client/auth/VonageUnacceptableAuthExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/conversion/ConversionClientTest.java
+++ b/src/test/java/com/vonage/client/conversion/ConversionClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/CallDirectionTest.java
+++ b/src/test/java/com/vonage/client/incoming/CallDirectionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/CallEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/CallEventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/CallStatusTest.java
+++ b/src/test/java/com/vonage/client/incoming/CallStatusTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/InputEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/InputEventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/MessageEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/MessageEventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/MessageTypeTest.java
+++ b/src/test/java/com/vonage/client/incoming/MessageTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/NotifyEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/NotifyEventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/RecordEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/RecordEventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/incoming/SpeechResultsTest.java
+++ b/src/test/java/com/vonage/client/incoming/SpeechResultsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/AdvancedInsightRequestTest.java
+++ b/src/test/java/com/vonage/client/insight/AdvancedInsightRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/AdvancedInsightResponseTest.java
+++ b/src/test/java/com/vonage/client/insight/AdvancedInsightResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/BasicInsightRequestTest.java
+++ b/src/test/java/com/vonage/client/insight/BasicInsightRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/BasicInsightResponseTest.java
+++ b/src/test/java/com/vonage/client/insight/BasicInsightResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/InsightClientTest.java
+++ b/src/test/java/com/vonage/client/insight/InsightClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/StandardInsightRequestTest.java
+++ b/src/test/java/com/vonage/client/insight/StandardInsightRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/insight/StandardInsightResponseTest.java
+++ b/src/test/java/com/vonage/client/insight/StandardInsightResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/meetings/MeetingRoomTest.java
+++ b/src/test/java/com/vonage/client/meetings/MeetingRoomTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/meetings/MeetingsClientTest.java
+++ b/src/test/java/com/vonage/client/meetings/MeetingsClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/meetings/MeetingsEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/meetings/MeetingsEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/meetings/MeetingsEventCallbackTest.java
+++ b/src/test/java/com/vonage/client/meetings/MeetingsEventCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/meetings/ThemeTest.java
+++ b/src/test/java/com/vonage/client/meetings/ThemeTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/InboundMessageTest.java
+++ b/src/test/java/com/vonage/client/messages/InboundMessageTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/MessageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/MessageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/MessageResponseTest.java
+++ b/src/test/java/com/vonage/client/messages/MessageResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/MessageStatusTest.java
+++ b/src/test/java/com/vonage/client/messages/MessageStatusTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/MessagesClientTest.java
+++ b/src/test/java/com/vonage/client/messages/MessagesClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/messenger/MessengerAudioRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/messenger/MessengerAudioRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/messenger/MessengerFileRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/messenger/MessengerFileRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/messenger/MessengerImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/messenger/MessengerImageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/messenger/MessengerTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/messenger/MessengerTextRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/messenger/MessengerVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/messenger/MessengerVideoRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/mms/MmsAudioRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsAudioRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/mms/MmsVcardRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsVcardRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/mms/MmsVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsVideoRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/viber/ViberFileRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/viber/ViberFileRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/viber/ViberImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/viber/ViberImageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/viber/ViberTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/viber/ViberTextRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/viber/ViberVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/viber/ViberVideoRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappCustomRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappFileRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappFileRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappImageRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappLocationRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappLocationRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappMultiProductRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappMultiProductRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappSingleProductRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappSingleProductRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappStickerRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappStickerRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTemplateRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappTextRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/numbers/ListNumbersFilterAndResponseTest.java
+++ b/src/test/java/com/vonage/client/numbers/ListNumbersFilterAndResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/numbers/NumbersClientTest.java
+++ b/src/test/java/com/vonage/client/numbers/NumbersClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/numbers/NumbersEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/numbers/NumbersEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/numbers/SearchNumbersFilterAndResponseTest.java
+++ b/src/test/java/com/vonage/client/numbers/SearchNumbersFilterAndResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/numbers/TypeTest.java
+++ b/src/test/java/com/vonage/client/numbers/TypeTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/proactiveconnect/ContactsListTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ContactsListTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/proactiveconnect/EventTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/EventTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/ProactiveConnectEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/proactiveconnect/SyncStatusTest.java
+++ b/src/test/java/com/vonage/client/proactiveconnect/SyncStatusTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/redact/RedactClientTest.java
+++ b/src/test/java/com/vonage/client/redact/RedactClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/redact/RedactRequestTest.java
+++ b/src/test/java/com/vonage/client/redact/RedactRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/sms/HexUtilTest.java
+++ b/src/test/java/com/vonage/client/sms/HexUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/sms/SmsClientTest.java
+++ b/src/test/java/com/vonage/client/sms/SmsClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/subaccounts/CreateSubaccountRequestTest.java
+++ b/src/test/java/com/vonage/client/subaccounts/CreateSubaccountRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/subaccounts/ListSubaccountsResponseTest.java
+++ b/src/test/java/com/vonage/client/subaccounts/ListSubaccountsResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/subaccounts/SubaccountsClientTest.java
+++ b/src/test/java/com/vonage/client/subaccounts/SubaccountsClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/subaccounts/SubaccountsEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/subaccounts/SubaccountsEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/subaccounts/UpdateSubaccountRequestTest.java
+++ b/src/test/java/com/vonage/client/subaccounts/UpdateSubaccountRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/users/UserEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/users/UserEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/users/UserTest.java
+++ b/src/test/java/com/vonage/client/users/UserTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/users/UsersClientTest.java
+++ b/src/test/java/com/vonage/client/users/UsersClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/CheckResponseTest.java
+++ b/src/test/java/com/vonage/client/verify/CheckResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/ControlResponseTest.java
+++ b/src/test/java/com/vonage/client/verify/ControlResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/Psd2RequestTest.java
+++ b/src/test/java/com/vonage/client/verify/Psd2RequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyClientCheckEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientCheckEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyClientPsd2EndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientPsd2EndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyClientSearchEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientSearchEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyClientVerifyControlEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientVerifyControlEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyClientVerifyEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyDetailsTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyDetailsTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/verify/VerifyEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyRequestTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify/VerifyResponseTest.java
+++ b/src/test/java/com/vonage/client/verify/VerifyResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify2/VerificationCallbackTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationCallbackTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify2/VerificationResponseTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify2/Verify2ClientTest.java
+++ b/src/test/java/com/vonage/client/verify2/Verify2ClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/verify2/Verify2EndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/verify2/Verify2EndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/ArchiveTest.java
+++ b/src/test/java/com/vonage/client/video/ArchiveTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/BroadcastTest.java
+++ b/src/test/java/com/vonage/client/video/BroadcastTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/CreateSessionRequestTest.java
+++ b/src/test/java/com/vonage/client/video/CreateSessionRequestTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2023 Vonage
+/* Copyright 2024 Vonage
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/vonage/client/video/CreateSessionResponseTest.java
+++ b/src/test/java/com/vonage/client/video/CreateSessionResponseTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2023 Vonage
+/* Copyright 2024 Vonage
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/vonage/client/video/GetStreamResponseTest.java
+++ b/src/test/java/com/vonage/client/video/GetStreamResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/ListArchivesResponseTest.java
+++ b/src/test/java/com/vonage/client/video/ListArchivesResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/ListStreamCompositionsRequestTest.java
+++ b/src/test/java/com/vonage/client/video/ListStreamCompositionsRequestTest.java
@@ -1,4 +1,4 @@
-/* Copyright 2023 Vonage
+/* Copyright 2024 Vonage
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/test/java/com/vonage/client/video/ListStreamsResponseTest.java
+++ b/src/test/java/com/vonage/client/video/ListStreamsResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/MuteSessionRequestTest.java
+++ b/src/test/java/com/vonage/client/video/MuteSessionRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/PatchVideoStreamRequestTest.java
+++ b/src/test/java/com/vonage/client/video/PatchVideoStreamRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/ProjectDetailsTest.java
+++ b/src/test/java/com/vonage/client/video/ProjectDetailsTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/SetScreenLayoutTypeRequestTest.java
+++ b/src/test/java/com/vonage/client/video/SetScreenLayoutTypeRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/SignalRequestTest.java
+++ b/src/test/java/com/vonage/client/video/SignalRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/SipDialRequestTest.java
+++ b/src/test/java/com/vonage/client/video/SipDialRequestTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/TokenOptionsTest.java
+++ b/src/test/java/com/vonage/client/video/TokenOptionsTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/VideoClientTest.java
+++ b/src/test/java/com/vonage/client/video/VideoClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/video/VideoEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/video/VideoEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/AdvancedMachineDetectionTest.java
+++ b/src/test/java/com/vonage/client/voice/AdvancedMachineDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/CallInfoPageTest.java
+++ b/src/test/java/com/vonage/client/voice/CallInfoPageTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/CallInfoTest.java
+++ b/src/test/java/com/vonage/client/voice/CallInfoTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/CallTest.java
+++ b/src/test/java/com/vonage/client/voice/CallTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/CallsFilterTest.java
+++ b/src/test/java/com/vonage/client/voice/CallsFilterTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/DtmfResponseTest.java
+++ b/src/test/java/com/vonage/client/voice/DtmfResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/MachineDetectionTest.java
+++ b/src/test/java/com/vonage/client/voice/MachineDetectionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ModifyCallActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ModifyCallActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/PhoneEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/PhoneEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/StreamPayloadTest.java
+++ b/src/test/java/com/vonage/client/voice/StreamPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/StreamResponseTest.java
+++ b/src/test/java/com/vonage/client/voice/StreamResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/TalkPayloadTest.java
+++ b/src/test/java/com/vonage/client/voice/TalkPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/TalkResponseTest.java
+++ b/src/test/java/com/vonage/client/voice/TalkResponseTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/TextToSpeechLanguageTest.java
+++ b/src/test/java/com/vonage/client/voice/TextToSpeechLanguageTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/TransferCallPayloadTest.java
+++ b/src/test/java/com/vonage/client/voice/TransferCallPayloadTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/VoiceEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/voice/VoiceEndpointTestSpec.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/AppEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/AppEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/ConnectActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/ConnectActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/ConversationActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/ConversationActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/InputActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/InputActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/NccoTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/NccoTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/NotifyActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/NotifyActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/PhoneEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/PhoneEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/RecordActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/RecordActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/RecordingFormatTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/RecordingFormatTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/SpeechSettingsTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/SpeechSettingsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Vonage
+ * Copyright 2024 Vonage
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/StreamActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/StreamActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/TalkActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/TalkActionTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/VbcEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/VbcEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.

--- a/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright 2023 Vonage
+ *   Copyright 2024 Vonage
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.


### PR DESCRIPTION
Bumps Jackson version and updates the copyright year to 2024.
