### PR TITLE
feat: Reimplement webhooks for Voice API

### DIFF
--- a/src/main/java/com/vonage/client/incoming/CallEvent.java
+++ b/src/main/java/com/vonage/client/incoming/CallEvent.java
@@ -21,6 +21,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.Jsonable;
 import java.util.Date;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.EventWebhook}.
+ */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CallEvent implements Jsonable {
     private String conversationUuid, callUuid, from, to, uuid, detail;

--- a/src/main/java/com/vonage/client/incoming/CallStatus.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatus.java
@@ -17,6 +17,10 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.CallStatus}.
+ */
+@Deprecated
 public enum CallStatus {
     STARTED,
     RINGING,

--- a/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
+++ b/src/main/java/com/vonage/client/incoming/CallStatusDetail.java
@@ -17,6 +17,10 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.CallStatusDetail}.
+ */
+@Deprecated
 public enum CallStatusDetail {
 
     /**

--- a/src/main/java/com/vonage/client/incoming/DtmfResult.java
+++ b/src/main/java/com/vonage/client/incoming/DtmfResult.java
@@ -17,11 +17,11 @@ package com.vonage.client.incoming;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.voice.EventWebhook;
 
 /**
- * Represents the DTMF event results in {@link EventWebhook#getDtmf()}.
+ * @deprecated Use {@link com.vonage.client.voice.DtmfResult}.
  */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DtmfResult {
     private String digits;

--- a/src/main/java/com/vonage/client/incoming/InputEvent.java
+++ b/src/main/java/com/vonage/client/incoming/InputEvent.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.Jsonable;
 import java.util.Date;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.EventWebhook}.
+ */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class InputEvent implements Jsonable {
     private String uuid, conversationUuid, to, from;

--- a/src/main/java/com/vonage/client/incoming/RecordEvent.java
+++ b/src/main/java/com/vonage/client/incoming/RecordEvent.java
@@ -20,6 +20,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.Jsonable;
 import java.util.Date;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.EventWebhook}.
+ */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RecordEvent implements Jsonable {
     private Date startTime, endTime, timestamp;

--- a/src/main/java/com/vonage/client/incoming/Result.java
+++ b/src/main/java/com/vonage/client/incoming/Result.java
@@ -15,28 +15,44 @@
  */
 package com.vonage.client.incoming;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class Result {
     private String text, confidence;
 
     /**
-     * 
-     * @return transcript text
+     * Transcript text representing the words that the user spoke.
+     *
+     * @return The transcript text.
      */
+    @JsonProperty("text")
     public String getText() {
         return text;
     }
 
     /**
      * @param text transcript text representing the words the user spoke.
+     *
+     * @deprecated This setter will be removed in a future release.
      */
+    @Deprecated
     public void setText(String text) {
         this.text = text;
     }
 
     /**
-     * 
-     * @return The confidence estimate between 0.0 and 1.0
+     * The confidence estimate between 0.0 and 1.0. A higher number indicates an estimated greater
+     * likelihood that the recognized words are correct.
+     *
+     * @return The confidence estimate between 0.0 and 1.0 as a String.
+     *
+     * @deprecated This will be converted to a Double in a future release.
      */
+    @Deprecated
     public String getConfidence() {
         return confidence;
     }
@@ -44,7 +60,10 @@ public class Result {
     /**
      * @param confidence The confidence estimate between 0.0 and 1.0. A higher number indicates an estimated greater
      *                   likelihood that the recognized words are correct.
+     *
+     * @deprecated This setter will be removed in a future release.
      */
+    @Deprecated
     public void setConfidence(String confidence) {
         this.confidence = confidence;
     }

--- a/src/main/java/com/vonage/client/incoming/Result.java
+++ b/src/main/java/com/vonage/client/incoming/Result.java
@@ -19,6 +19,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.SpeechTranscript}.
+ */
+@Deprecated
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class Result {

--- a/src/main/java/com/vonage/client/incoming/SpeechResults.java
+++ b/src/main/java/com/vonage/client/incoming/SpeechResults.java
@@ -22,6 +22,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.net.URI;
 import java.util.Collection;
 
+/**
+ * @deprecated Use {@link com.vonage.client.voice.SpeechResults}.
+ */
+@Deprecated
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SpeechResults {

--- a/src/main/java/com/vonage/client/incoming/package-info.java
+++ b/src/main/java/com/vonage/client/incoming/package-info.java
@@ -13,24 +13,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package com.vonage.client.incoming;
-
-import com.fasterxml.jackson.annotation.JsonCreator;
-
 /**
- * @deprecated Use {@link com.vonage.client.voice.CallDirection}.
+ * @deprecated This package will be removed in a future release.
  */
-@Deprecated
-public enum CallDirection {
-    OUTBOUND, INBOUND, UNKNOWN;
-
-    @JsonCreator
-    public static CallDirection fromString(String name) {
-        try {
-            return CallDirection.valueOf(name.toUpperCase());
-        }
-        catch (IllegalArgumentException ex) {
-            return UNKNOWN;
-        }
-    }
-}
+package com.vonage.client.incoming;

--- a/src/main/java/com/vonage/client/video/TokenOptions.java
+++ b/src/main/java/com/vonage/client/video/TokenOptions.java
@@ -135,6 +135,8 @@ public class TokenOptions {
          *     <a href="https://tokbox.com/developer/guides/moderation/">Moderation developer guide</a>.
          *     </li>
          * </ul>
+         *
+         * @return This builder.
          */
         public Builder role(Role role) {
             this.role = role;
@@ -142,21 +144,25 @@ public class TokenOptions {
         }
 
          /**
-         * Sets the expiration time for the token.
-         *
-         * @param ttl The expiration length (time-to-live) The maximum duration is 30 days. Default is 24 hours.
+          * Sets the expiration time for the token.
+          *
+          * @param ttl The expiration length (time-to-live) The maximum duration is 30 days. Default is 24 hours.
+          *
+          * @return This builder.
          */
-        public Builder expiryLength(Duration ttl) {
+         public Builder expiryLength(Duration ttl) {
             this.ttl = ttl;
             return this;
         }
 
          /**
-         * A string containing connection metadata describing the end-user. For example, you
-         * can pass the user ID, name, or other data describing the end-user. The length of the
-         * string is limited to 1000 characters. This data cannot be updated once it is set.
-         *
-         * @param data The connection metadata.
+          * A string containing connection metadata describing the end-user. For example, you
+          * can pass the user ID, name, or other data describing the end-user. The length of the
+          * string is limited to 1000 characters. This data cannot be updated once it is set.
+          *
+          * @param data The connection metadata.
+          *
+          * @return This builder.
          */
         public Builder data(String data) throws IllegalArgumentException {
             this.data = data;
@@ -164,15 +170,17 @@ public class TokenOptions {
         }
 
         /**
-        * A List of class names (strings) to be used as the initial layout classes
-        * for streams published by the client. Layout classes are used in customizing the layout
-        * of videos in
-        * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/">live streaming
-        * broadcasts</a> and
-        * <a href="https://tokbox.com/developer/guides/archiving/layout-control.html">composed
-        * archives</a>. 
-        *
-        * @param initialLayoutClassList The initial layout class list.
+         * A List of class names (strings) to be used as the initial layout classes
+         * for streams published by the client. Layout classes are used in customizing the layout
+         * of videos in
+         * <a href="https://tokbox.com/developer/guides/broadcast/live-streaming/">live streaming
+         * broadcasts</a> and
+         * <a href="https://tokbox.com/developer/guides/archiving/layout-control.html">composed
+         * archives</a>.
+         *
+         * @param initialLayoutClassList The initial layout class list.
+         *
+         * @return This builder.
         */
         public Builder initialLayoutClassList (List<String> initialLayoutClassList) {
             this.initialLayoutClassList = initialLayoutClassList;

--- a/src/main/java/com/vonage/client/voice/AdvancedMachineDetection.java
+++ b/src/main/java/com/vonage/client/voice/AdvancedMachineDetection.java
@@ -18,7 +18,9 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.*;
 
 /**
- * Configure the behavior of Vonage's advanced machine detection.
+ * Configure the behavior of Vonage's advanced machine detection. See
+ * <a href=https://developer.vonage.com/en/voice/voice-api/concepts/advanced-machine-detection>
+ * the documentation</a> for details.
  *
  * @since 7.4.0
  */
@@ -39,7 +41,14 @@ public class AdvancedMachineDetection {
 		 * Detect machine and send back a status human / machine webhook, but also when machine is detected, attempt
 		 * to detect voice mail beep and send back another status machine webhook with {@code sub_state: beep_start}.
 		 */
-		DETECT_BEEP;
+		DETECT_BEEP,
+
+		/**
+		 * Asynchronously start processing NCCO actions during the detection phase.
+		 *
+		 * @since 8.2.0
+		 */
+		DEFAULT;
 
 		@JsonCreator
 		public static Mode fromString(String value) {

--- a/src/main/java/com/vonage/client/voice/AnswerWebhook.java
+++ b/src/main/java/com/vonage/client/voice/AnswerWebhook.java
@@ -1,0 +1,133 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.Jsonable;
+import java.net.URI;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Maps the fields for data sent to the {@code answer_url} configured in your voice application.
+ * See <a href=https://developer.vonage.com/en/voice/voice-api/webhook-reference#answer-webhook>
+ * the webhook reference</a> for details.
+ *
+ * @since 8.2.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnswerWebhook implements Jsonable {
+    @JsonProperty("from") private String from;
+    @JsonProperty("from_user") private String fromUser;
+    @JsonProperty("to") private String to;
+    @JsonProperty("conversation_uuid") private String conversationUuid;
+    @JsonProperty("uuid") private UUID uuid;
+    @JsonProperty("region_url") private URI regionUrl;
+    @JsonProperty("custom_data") private Map<String, ?> customData;
+
+    protected AnswerWebhook() {}
+
+    /**
+     * The user or number that answered the call. This is the virtual number linked to in your application.
+     *
+     * @return The answering user or number in E.164 format.
+     */
+    public String getTo() {
+        return to;
+    }
+
+    /**
+     * The number or user that made the call. This could be a landline or mobile number or another virtual number if
+     * the call was made programmatically. It could also be a username if the call was made by a user.
+     *
+     * @return The calling user or number in E.164 format, or {@code null} if absent.
+     */
+    @JsonIgnore
+    public String getFrom() {
+        return from != null ? from : fromUser;
+    }
+
+    /**
+     * Unique identifier for this conversation. Starts with {@code CON-} followed by a UUID.
+     *
+     * @return The conversation ID as a string.
+     */
+    public String getConversationUuid() {
+        return conversationUuid;
+    }
+
+    /**
+     * Unique identifier for this call.
+     *
+     * @return The call ID as a UUID.
+     */
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    /**
+     * Regional API endpoint which should be used to control the call with REST API; see the
+     * <a href=https://developer.vonage.com/en/voice/voice-api/concepts/regions>full list of regions.</a>
+     *
+     * @return The configured region URL.
+     */
+    public URI getRegionUrl() {
+        return regionUrl;
+    }
+
+    /**
+     * A custom data map, optionally passed as parameter on the {@code callServer} method when a call is initiated
+     * from an application using <a href=https://developer.vonage.com/en/client-sdk/in-app-voice/guides/make-call>
+     * the Client SDK</a>.
+     *
+     * @return The custom data object as a Map, or {@code null} if absent / not applicable.
+     */
+    public Map<String, ?> getCustomData() {
+        return customData;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AnswerWebhook that = (AnswerWebhook) o;
+        return Objects.equals(from, that.from) && Objects.equals(to, that.to) &&
+                Objects.equals(fromUser, that.fromUser) && Objects.equals(uuid, that.uuid) &&
+                Objects.equals(conversationUuid, that.conversationUuid) &&
+                Objects.equals(regionUrl, that.regionUrl) && Objects.equals(customData, that.customData);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(from, fromUser, to, conversationUuid, uuid, regionUrl, customData);
+    }
+
+    /**
+     * Constructs an instance, populating this class's fields from the JSON string.
+     *
+     * @param json The JSON payload as a string.
+     *
+     * @return A new instance of this class.
+     */
+    public static AnswerWebhook fromJson(String json) {
+        return Jsonable.fromJson(json);
+    }
+}

--- a/src/main/java/com/vonage/client/voice/CallStatus.java
+++ b/src/main/java/com/vonage/client/voice/CallStatus.java
@@ -18,17 +18,93 @@ package com.vonage.client.voice;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * Describes the status of the call, and also the event in {@link EventWebhook#getStatus()}.
+ */
 public enum CallStatus {
+
+    /**
+     * Indicates that the call has been created.
+     */
     STARTED,
+
+    /**
+     * The call is ringing.
+     */
     RINGING,
+
+    /**
+     * The call was answered.
+     */
     ANSWERED,
+
+    /**
+     * The duration of the ringing phase exceeded the specified ringing timeout duration.
+     */
     TIMEOUT,
+
+    /**
+     * For an outbound call made programmatically with machine detection enabled,
+     * this indicates a machine / voicemail answered the call.
+     */
     MACHINE,
+
+    /**
+     * The call has finished.
+     */
     COMPLETED,
+
+    /**
+     * The outgoing call could not be connected.
+     */
     FAILED,
+
+    /**
+     * The call was rejected by Vonage before it was connected.
+     */
     REJECTED,
+
+    /**
+     * The destination is on the line with another caller.
+     */
     BUSY,
+
+    /**
+     * An outgoing call is cancelled by the originator before being answered.
+     */
     CANCELLED,
+
+    /**
+     * A leg has been transferred from one conversation to another.
+     */
+    TRANSFER,
+
+    /**
+     * An NCCO {@code input} action has finished.
+     */
+    INPUT,
+
+    /**
+     * For an outbound call made programmatically with machine detection enabled,
+     * this indicates a human answered the call.
+     */
+    HUMAN,
+
+    /**
+     * If the WebSocket connection is terminated from the application side for any reason,
+     * then the disconnected event callback will be sent. If the response contains an NCCO
+     * then this will be processed, if no NCCO is present then normal execution will continue.
+     */
+    DISCONNECTED,
+
+    /**
+     * Either the recipient is unreachable or the recipient declined the call.
+     */
+    UNANSWERED,
+
+    /**
+     * Unknown status or event.
+     */
     UNKNOWN;
 
     @JsonValue

--- a/src/main/java/com/vonage/client/voice/CallStatusDetail.java
+++ b/src/main/java/com/vonage/client/voice/CallStatusDetail.java
@@ -13,10 +13,16 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package com.vonage.client.incoming;
+package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 
+/**
+ * Represents the {@code detail} field in {@link EventWebhook#getDetail()}.
+ *
+ * @since 8.2.0
+ */
 public enum CallStatusDetail {
 
     /**
@@ -69,6 +75,11 @@ public enum CallStatusDetail {
      */
     UNAVAILABLE;
 
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
 
     @JsonCreator
     public static CallStatusDetail fromString(String detail) {

--- a/src/main/java/com/vonage/client/voice/DtmfResult.java
+++ b/src/main/java/com/vonage/client/voice/DtmfResult.java
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.vonage.client.incoming;
+package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.voice.EventWebhook;
 
 /**
  * Represents the DTMF event results in {@link EventWebhook#getDtmf()}.

--- a/src/main/java/com/vonage/client/voice/EventWebhook.java
+++ b/src/main/java/com/vonage/client/voice/EventWebhook.java
@@ -1,0 +1,301 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.Jsonable;
+import java.net.URI;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents all call events sent to the {@code event_url} webhook configured in your Voice application settings.
+ * See <a href=https://developer.vonage.com/en/voice/voice-api/webhook-reference#event-webhook>
+ * the webhook reference</a> for details. For the {@code answer_url} webhook, use {@link AnswerWebhook}.
+ * The fields present depends on which event has occurred. This class maps all known fields for all events.
+ *
+ * @since 8.2.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EventWebhook implements Jsonable {
+    private CallStatus status;
+    private CallDirection direction;
+    private CallStatusDetail detail;
+    private MachineDetectionStatus machineDetectionSubstate;
+    private DtmfResult dtmf;
+    private SpeechResults speech;
+    private Instant timestamp, startTime, endTime;
+    private Integer duration, size;
+    private Double rate, price;
+    private URI recordingUrl;
+    private UUID callUuid, recordingUuid;
+    private String to, from, conversationUuid, conversationUuidFrom, conversationUuidTo, network, reason;
+
+    protected EventWebhook() {}
+
+    /**
+     * Event type.
+     *
+     * @return The call status as an enum.
+     */
+    @JsonProperty("status")
+    public CallStatus getStatus() {
+        return status;
+    }
+
+    /**
+     * Call direction, can be either inbound or outbound.
+     *
+     * @return The call direction as an enum, or {@code null} if not applicable.
+     */
+    @JsonProperty("direction")
+    public CallDirection getDirection() {
+        return direction;
+    }
+
+    /**
+     * Provides a more specific status to accompany {@linkplain #getStatus()}.
+     *
+     * @return The event status detail as an enum, or {@code null} if not applicable.
+     */
+    @JsonProperty("detail")
+    public CallStatusDetail getDetail() {
+        return detail;
+    }
+
+    /**
+     * Advanced machine detection status, when call is answered by voicemail and the beep is detected. This is
+     * present if {@linkplain #getStatus()} is {@linkplain CallStatus#HUMAN} or {@linkplain CallStatus#MACHINE}.
+     *
+     * @return The machine detection substate, or {@code null} if not applicable.
+     */
+    @JsonProperty("sub_state")
+    public MachineDetectionStatus getMachineDetectionSubstate() {
+        return machineDetectionSubstate;
+    }
+
+    /**
+     * DTMF capturing results.
+     * This is only present if {@linkplain #getStatus()} is {@linkplain CallStatus#INPUT}.
+     *
+     * @return The DTMF input, or {@code null} if not applicable.
+     */
+    @JsonProperty("dtmf")
+    public DtmfResult getDtmf() {
+        return dtmf;
+    }
+
+    /**
+     * Speech recognition results.
+     * This is only present if {@linkplain #getStatus()} is {@linkplain CallStatus#INPUT}.
+     *
+     * @return The speech properties, or {@code null} if not applicable.
+     */
+    @JsonProperty("speech")
+    public SpeechResults getSpeech() {
+        return speech;
+    }
+
+    /**
+     * Event timestamp in ISO 8601 format.
+     *
+     * @return The timestamp as an Instant, or {@code null} if unknown.
+     */
+    @JsonProperty("timestamp")
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    /**
+     * Start time in ISO 8601 format. This is applicable to recording events.
+     *
+     * @return The start time as an Instant, or {@code null} if unknown / not applicable.
+     */
+    @JsonProperty("start_time")
+    public Instant getStartTime() {
+        return startTime;
+    }
+
+    /**
+     * End time in ISO 8601 format. This is applicable to recording events.
+     *
+     * @return The end time as an Instant, or {@code null} if unknown / not applicable.
+     */
+    @JsonProperty("end_time")
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    /**
+     * Call length, in seconds. This is present if {@linkplain #getStatus()} is {@linkplain CallStatus#COMPLETED}.
+     *
+     * @return The length of the call, or {@code null} if not applicable.
+     */
+    @JsonProperty("duration")
+    public Integer getDuration() {
+        return duration;
+    }
+
+    /**
+     * Size of the recording file, in bytes. This is present for recording events only.
+     *
+     * @return The file size in bytes, or {@code null} if not applicable.
+     */
+    @JsonProperty("size")
+    public Integer getSize() {
+        return size;
+    }
+
+    /**
+     * Cost per minute of the call, in Euros.
+     * This will be present if {@linkplain #getStatus()} is {@linkplain CallStatus#COMPLETED}.
+     *
+     * @return The call rate as a double, or {@code null} if not applicable.
+     */
+    @JsonProperty("rate")
+    public Double getRate() {
+        return rate;
+    }
+
+    /**
+     * Total cost of the call in Euros.
+     * This will be present if {@linkplain #getStatus()} is {@linkplain CallStatus#COMPLETED}.
+     *
+     * @return The call cost as a double, or {@code null} if not applicable.
+     */
+    @JsonProperty("price")
+    public Double getPrice() {
+        return price;
+    }
+
+    /**
+     * Where to download the recording. This is present for recording and transcription events only.
+     *
+     * @return The URL of the recording, or {@code null} if not applicable.
+     */
+    @JsonProperty("recording_url")
+    public URI getRecordingUrl() {
+        return recordingUrl;
+    }
+
+    /**
+     * Unique identifier for the call event.
+     *
+     * @return The call ID, or {@code null} not applicable.
+     */
+    @JsonProperty("uuid")
+    @JsonAlias({"uuid", "call_uuid"})
+    public UUID getCallUuid() {
+        return callUuid;
+    }
+
+    /**
+     * Unique identifier for the recording. This is only present for recording events.
+     *
+     * @return The recording ID, or {@code null} if not applicable.
+     */
+    @JsonProperty("recording_uuid")
+    public UUID getRecordingUuid() {
+        return recordingUuid;
+    }
+
+    /**
+     * Number the call was made to, in E.164 format.
+     *
+     * @return The call destination, or {@code null} if not applicable.
+     */
+    @JsonProperty("to")
+    public String getTo() {
+        return to;
+    }
+
+    /**
+     * Number the call came from, in E.164 format.
+     *
+     * @return The call source number, or {@code null} if not applicable.
+     */
+    @JsonProperty("from")
+    public String getFrom() {
+        return from;
+    }
+
+    /**
+     * Unique identifier for the conversation. Starts with {@code CON-} followed by a UUID.
+     *
+     * @return The conversation ID as a string, or {@code null} if not applicable.
+     */
+    @JsonProperty("conversation_uuid")
+    public String getConversationUuid() {
+        return conversationUuid;
+    }
+
+    /**
+     * Conversation ID that the leg was originally in.
+     * This is only present if {@linkplain #getStatus()} is {@linkplain CallStatus#TRANSFER}.
+     *
+     * @return The originating conversation ID leg, or {@code null} if not applicable.
+     */
+    @JsonProperty("conversation_uuid_from")
+    public String getConversationUuidFrom() {
+        return conversationUuidFrom;
+    }
+
+    /**
+     * Conversation ID that the leg was transferred to.
+     * This is only present if {@linkplain #getStatus()} is {@linkplain CallStatus#TRANSFER}.
+     *
+     * @return The destination conversation ID leg, or {@code null} if not applicable.
+     */
+    @JsonProperty("conversation_uuid_to")
+    public String getConversationUuidTo() {
+        return conversationUuidTo;
+    }
+
+    /**
+     * Type of network that was used in the call.
+     *
+     * @return The network, or {@code null} if unknown / not applicable.
+     */
+    @JsonProperty("network")
+    public String getNetwork() {
+        return network;
+    }
+
+    /**
+     * Information about the nature of the error. This is only present for error webhooks.
+     *
+     * @return The error description, or {@code null} if not applicable.
+     */
+    @JsonProperty("reason")
+    public String getReason() {
+        return reason;
+    }
+
+    /**
+     * Constructs an instance, populating this class's fields from the JSON string.
+     *
+     * @param json The JSON payload as a string.
+     *
+     * @return A new instance of this class.
+     */
+    public static EventWebhook fromJson(String json) {
+        return Jsonable.fromJson(json);
+    }
+}

--- a/src/main/java/com/vonage/client/voice/MachineDetectionStatus.java
+++ b/src/main/java/com/vonage/client/voice/MachineDetectionStatus.java
@@ -19,24 +19,40 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 /**
- * Represents machine detection behaviour.
+ * Represents event substates for advanced machine detection in {@link EventWebhook#getMachineDetectionSubstate()}.
+ *
+ * @since 8.2.0
  */
-public enum MachineDetection {
-    CONTINUE, HANGUP, UNKNOWN;
+public enum MachineDetectionStatus {
 
-    @JsonValue
-    @Override
-    public String toString() {
-        return name().toLowerCase();
-    }
+	/**
+	 * The beginning of the voice mail beep.
+	 */
+	BEEP_START,
 
-    @JsonCreator
-    public static MachineDetection fromString(String name) {
-        try {
-            return MachineDetection.valueOf(name.toUpperCase());
-        }
-        catch (IllegalArgumentException ex) {
-            return UNKNOWN;
-        }
-    }
+	/**
+	 * Beep wasn't received after waiting for the designated period.
+	 */
+	BEEP_TIMEOUT,
+
+	/**
+	 * Unmapped value.
+	 */
+	UNKNOWN;
+
+	@JsonValue
+	@Override
+	public String toString() {
+		return name().toLowerCase();
+	}
+
+	@JsonCreator
+	public static MachineDetectionStatus fromString(String name) {
+		try {
+			return MachineDetectionStatus.valueOf(name.toUpperCase());
+		}
+		catch (IllegalArgumentException ex) {
+			return UNKNOWN;
+		}
+	}
 }

--- a/src/main/java/com/vonage/client/voice/SpeechResults.java
+++ b/src/main/java/com/vonage/client/voice/SpeechResults.java
@@ -13,20 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.vonage.client.incoming;
+package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.net.URI;
-import java.util.Collection;
+import java.util.List;
 
+/**
+ * Represents the speech recognition results in {@link EventWebhook#getSpeech()}.
+ *
+ * @since 8.2.0
+ */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SpeechResults {
-    private TimeoutReason timeoutReason;
-    private Collection<Result> results;
+    private SpeechTimeoutReason timeoutReason;
+    private List<SpeechTranscript> results;
     private String error;
     private URI recordingUrl;
 
@@ -62,54 +66,18 @@ public class SpeechResults {
      * @return Reason for the timeout as an enum.
      */
     @JsonProperty("timeout_reason")
-    public TimeoutReason getTimeoutReason() {
+    public SpeechTimeoutReason getTimeoutReason() {
         return timeoutReason;
-    }
-
-    /**
-     * @param timeoutReason Indicates whether the input ended when the user stopped speaking, by the max duration
-     *                      timeout, or if the user didn't say anything.
-     *
-     * @deprecated This setter will be removed in a future release.
-     */
-    @Deprecated
-    public void setTimeoutReason(TimeoutReason timeoutReason) {
-        this.timeoutReason = timeoutReason;
     }
 
     /**
      * The recognised text objects.
      *
-     * @return The collection of transcript texts, or {@code null} if there are none.
+     * @return The list of transcript texts, or {@code null} if there are none.
      */
     @JsonProperty("results")
-    public Collection<Result> getResults() {
+    public List<SpeechTranscript> getResults() {
         return results;
     }
 
-    /**
-     * @param results list of speech recognition results that displays the words(s) that the user spoke and the
-     *                likelihood that the recognized word(s) in the list where the actual word(s) that the user spoke.
-     *
-     * @deprecated This setter will be removed in a future release.
-     */
-    @Deprecated
-    public void setResults(Collection<Result> results) {
-        this.results = results;
-    }
-
-    /**
-     * Represents the timeout reason in {@linkplain #getTimeoutReason()}.
-     */
-    public enum TimeoutReason {
-        END_ON_SILENCE_TIMEOUT,
-        MAX_DURATION,
-        START_TIMEOUT;
-
-        @JsonValue
-        @Override
-        public String toString() {
-            return name().toLowerCase();
-        }
-    }
 }

--- a/src/main/java/com/vonage/client/voice/SpeechTimeoutReason.java
+++ b/src/main/java/com/vonage/client/voice/SpeechTimeoutReason.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Vonage
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents the timeout reason in {@link SpeechResults#getTimeoutReason()}.
+ *
+ * @since 8.2.0
+ */
+public enum SpeechTimeoutReason {
+    END_ON_SILENCE_TIMEOUT,
+    MAX_DURATION,
+    START_TIMEOUT,
+    UNKNOWN;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+
+    @JsonCreator
+    public static SpeechTimeoutReason fromString(String name) {
+        try {
+            return SpeechTimeoutReason.valueOf(name.toUpperCase());
+        }
+        catch (IllegalArgumentException ex) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/src/main/java/com/vonage/client/voice/SpeechTranscript.java
+++ b/src/main/java/com/vonage/client/voice/SpeechTranscript.java
@@ -13,37 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.vonage.client.incoming;
+package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.voice.EventWebhook;
 
 /**
- * Represents the DTMF event results in {@link EventWebhook#getDtmf()}.
+ * Represents speech to text data contained in {@link SpeechResults#getResults()}.
+ *
+ * @since 8.2.0
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class DtmfResult {
-    private String digits;
-    private boolean timedOut;
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+public class SpeechTranscript {
+    private String text;
+    private Double confidence;
 
     /**
-     * The button sequence pressed by the user.
+     * Transcript text representing the words that the user spoke.
      *
-     * @return The buttons pressed as a String.
+     * @return The transcript text.
      */
-    @JsonProperty("digits")
-    public String getDigits() {
-        return digits;
+    @JsonProperty("text")
+    public String getText() {
+        return text;
     }
 
     /**
-     * Whether the DTMF input timed out.
+     * The confidence estimate between 0.0 and 1.0. A higher number indicates an estimated greater
+     * likelihood that the recognized words are correct.
      *
-     * @return {@code true} if the DTMF timed out, {@code false} otherwise.
+     * @return The confidence estimate between 0.0 and 1.0 as a Double.
      */
-    @JsonProperty("timed_out")
-    public boolean isTimedOut() {
-        return timedOut;
+    public Double getConfidence() {
+        return confidence;
     }
 }

--- a/src/test/java/com/vonage/client/voice/AnswerWebhookTest.java
+++ b/src/test/java/com/vonage/client/voice/AnswerWebhookTest.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import java.net.URI;
+import java.util.UUID;
+
+public class AnswerWebhookTest {
+
+    @Test
+    public void testSerdesAllParams() {
+        String regionUrl = "https://api-us-3.vonage.com",
+                to = "442079460000", fromUser = "client",
+                conversationId = "CON-55d50a94-7c84-484a-b1b7-f27633133cb4",
+                uuid = "f7aebf19-bd37-4d63-8f35-32352f48901b",
+                from = "447700900000", json = "{\n" +
+                    "  \"to\": \""+to+"\",\n" +
+                    "  \"from\": \""+from+"\",\n" +
+                    "  \"from_user\": \""+fromUser+"\",\n" +
+                    "  \"conversation_uuid\": \""+conversationId+"\",\n" +
+                    "  \"region_url\": \""+regionUrl+"\",\n" +
+                    "  \"uuid\": \""+uuid+"\"\n}";
+
+        AnswerWebhook parsed = AnswerWebhook.fromJson(json);
+        assertNotNull(parsed);
+        assertEquals(to, parsed.getTo());
+        assertEquals(from, parsed.getFrom());
+        assertEquals(conversationId, parsed.getConversationUuid());
+        assertEquals(UUID.fromString(uuid), parsed.getUuid());
+        assertEquals(URI.create(regionUrl), parsed.getRegionUrl());
+
+        AnswerWebhook parsedFromItself = AnswerWebhook.fromJson(parsed.toJson());
+        assertEquals(parsed.hashCode(), parsedFromItself.hashCode());
+        assertEquals(parsed, parsedFromItself);
+    }
+
+    @Test
+    public void testFromUserOnly() {
+        String fromUser = "client", json = "{\"from_user\":\""+fromUser+"\"}";
+        AnswerWebhook parsed = AnswerWebhook.fromJson(json);
+        assertNotNull(parsed);
+        assertEquals(fromUser, parsed.getFrom());
+        assertNull(parsed.getTo());
+        assertNull(parsed.getUuid());
+        assertNull(parsed.getConversationUuid());
+        assertNull(parsed.getRegionUrl());
+        assertNull(parsed.getCustomData());
+        AnswerWebhook parsedFromItself = AnswerWebhook.fromJson(parsed.toJson());
+        assertEquals(parsed.hashCode(), parsedFromItself.hashCode());
+    }
+}

--- a/src/test/java/com/vonage/client/voice/EventWebhookTest.java
+++ b/src/test/java/com/vonage/client/voice/EventWebhookTest.java
@@ -1,0 +1,221 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+public class EventWebhookTest {
+
+    @Test
+    public void testSerdesAllFields() {
+        String from = "442079460000",
+                to = "447700900000",
+                status = "completed",
+                subState = "beep_start",
+                conversationUuid = "CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+                direction = "inbound",
+                timestamp = "2020-01-01T12:05:01.200Z",
+                detail = "unavailable",
+                endTime = "2024-01-09T11:01:58.324Z",
+                startTime = "2023-12-30T23:59:59.999Z",
+                network = "GB-FIXED",
+                conversationUuidFrom = "CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+                conversationUuidTo = "CON-aaaaaaaa-bbbb-cccc-dddd-0123456789ab",
+                reason = "Syntax error in NCCO. Invalid value type or action.",
+                dtmfDigits = "42",
+                speechTimeoutReason = "end_on_silence_timeout",
+                speechError = "ERR1: Failed to analyze audio",
+                recordingUrl = "https://api-us.nexmo.com/v1/files/eeeeeee-ffff-0123-4567-0123456789ab",
+                speechResultText1 = "sales",
+                speechResultText2 = "customer";
+
+        UUID callUuid = UUID.randomUUID(), recordingUuid = UUID.randomUUID();
+        boolean dtmfTimedOut = true;
+        int duration = 6, size = 12228;
+        double rate = 0.00450000,
+                price = 0.00015000,
+                speechResultConfidence1 = 0.9405097,
+                speechResultConfidence2 = 0.8764321;
+
+        String json = "{\n" +
+                "  \"call_uuid\": \"" + callUuid + "\",\n" +
+                "  \"from\": \"" + from + "\",\n" +
+                "  \"to\": \"" + to + "\",\n" +
+                "  \"status\": \"" + status + "\",\n" +
+                "  \"sub_state\": \"" + subState + "\",\n" +
+                "  \"conversation_uuid\": \"" + conversationUuid + "\",\n" +
+                "  \"direction\": \"" + direction + "\",\n" +
+                "  \"timestamp\": \"" + timestamp + "\",\n" +
+                "  \"detail\": \"" + detail + "\",\n" +
+                "  \"end_time\": \"" + endTime + "\",\n" +
+                "  \"network\": \"" + network + "\",\n" +
+                "  \"duration\": " + duration + ",\n" +
+                "  \"start_time\": \"" + startTime + "\",\n" +
+                "  \"size\": " + size + ",\n" +
+                "  \"rate\": " + rate + ",\n" +
+                "  \"price\": " + price + ",\n" +
+                "  \"conversation_uuid_from\": \"" + conversationUuidFrom + "\",\n" +
+                "  \"conversation_uuid_to\": \"" + conversationUuidTo + "\",\n" +
+                "  \"reason\": \"" + reason + "\",\n" +
+                "  \"recording_url\": \"" + recordingUrl + "\",\n" +
+                "  \"recording_uuid\": \"" + recordingUuid + "\",\n" +
+                "  \"dtmf\": {\n" +
+                "    \"digits\": \"" + dtmfDigits + "\",\n" +
+                "    \"timed_out\": " + dtmfTimedOut + "\n" +
+                "  },\n" +
+                "  \"speech\": {\n" +
+                "    \"timeout_reason\": \"" + speechTimeoutReason + "\",\n" +
+                "    \"results\": [\n" +
+                "      {\n" +
+                "        \"text\": \"" + speechResultText1 + "\",\n" +
+                "        \"confidence\": " + speechResultConfidence1 + "\n" +
+                "      },\n" +
+                "      {\n" +
+                "        \"text\": \"" + speechResultText2 + "\",\n" +
+                "        \"confidence\": " + speechResultConfidence2 + "\n" +
+                "      }\n" +
+                "    ],\n" +
+                "    \"error\": \"" + speechError + "\",\n" +
+                "    \"recording_url\": \"" + recordingUrl + "\"\n" +
+                "  }\n" +
+                "}\n";
+
+        EventWebhook event = EventWebhook.fromJson(json);
+        assertNotNull(event);
+        assertEquals(callUuid, event.getCallUuid());
+        assertEquals(conversationUuid, event.getConversationUuid());
+        assertEquals(conversationUuidFrom, event.getConversationUuidFrom());
+        assertEquals(conversationUuidTo, event.getConversationUuidTo());
+        assertEquals(from, event.getFrom());
+        assertEquals(to, event.getTo());
+        assertEquals(status, event.getStatus().toString());
+        assertEquals(subState, event.getMachineDetectionSubstate().toString());
+        assertEquals(detail, event.getDetail().toString());
+        assertEquals(direction, event.getDirection().toString());
+        assertEquals(Instant.parse(timestamp), event.getTimestamp());
+        assertEquals(Instant.parse(startTime), event.getStartTime());
+        assertEquals(Instant.parse(endTime), event.getEndTime());
+        assertEquals(URI.create(recordingUrl), event.getRecordingUrl());
+        assertEquals(recordingUuid, event.getRecordingUuid());
+        assertEquals(reason,  event.getReason());
+        assertEquals(network, event.getNetwork());
+        assertEquals(size, event.getSize());
+        assertEquals(rate, event.getRate());
+        assertEquals(price, event.getPrice());
+        assertEquals(duration, event.getDuration());
+        DtmfResult dtmf = event.getDtmf();
+        assertNotNull(dtmf);
+        assertEquals(dtmfDigits, dtmf.getDigits());
+        assertEquals(dtmfTimedOut, dtmf.isTimedOut());
+        SpeechResults speech = event.getSpeech();
+        assertNotNull(speech);
+        List<SpeechTranscript> speechResults = speech.getResults();
+        assertNotNull(speechResults);
+        assertEquals(2, speechResults.size());
+        SpeechTranscript speechResult1 = speechResults.get(0);
+        assertNotNull(speechResult1);
+        assertEquals(speechResultConfidence1, speechResult1.getConfidence());
+        assertEquals(speechResultText1, speechResult1.getText());
+        SpeechTranscript speechResult2 = speechResults.get(1);
+        assertNotNull(speechResult2);
+        assertEquals(speechResultConfidence2, speechResult2.getConfidence());
+        assertEquals(speechResultText2, speechResult2.getText());
+        assertEquals(speechError, speech.getError());
+        assertEquals(speechTimeoutReason, speech.getTimeoutReason().toString());
+        assertEquals(URI.create(recordingUrl), speech.getRecordingUrl());
+    }
+
+    @Test
+    public void testParseEmptyJson() {
+        EventWebhook event = EventWebhook.fromJson("{}");
+        assertNotNull(event);
+        assertNull(event.getDetail());
+        assertNull(event.getCallUuid());
+        assertNull(event.getReason());
+        assertNull(event.getSize());
+        assertNull(event.getRecordingUuid());
+        assertNull(event.getRecordingUrl());
+        assertNull(event.getDuration());
+        assertNull(event.getPrice());
+        assertNull(event.getRate());
+        assertNull(event.getNetwork());
+        assertNull(event.getEndTime());
+        assertNull(event.getStartTime());
+        assertNull(event.getTimestamp());
+        assertNull(event.getFrom());
+        assertNull(event.getTo());
+        assertNull(event.getConversationUuid());
+        assertNull(event.getConversationUuidTo());
+        assertNull(event.getConversationUuidFrom());
+        assertNull(event.getDirection());
+        assertNull(event.getMachineDetectionSubstate());
+        assertNull(event.getStatus());
+        assertNull(event.getDtmf());
+        assertNull(event.getSpeech());
+    }
+
+    @Test
+    public void testCallUuidPrimaryOnly() {
+        UUID callUuid = UUID.randomUUID(), uuid = UUID.randomUUID();
+        String json = "{\"call_uuid\":\""+callUuid+"\",\"uuid\":\""+uuid+"\"}";
+        EventWebhook event = EventWebhook.fromJson(json);
+        assertNotNull(event);
+        assertEquals(uuid, event.getCallUuid());
+        assertEquals(uuid, EventWebhook.fromJson("{\"uuid\": \""+uuid+"\"}").getCallUuid());
+    }
+
+    @Test
+    public void testCallStatusDetail() {
+        String json = "{\"status\":\"unanswered\",\"detail\":\"oops\"}";
+        EventWebhook event = EventWebhook.fromJson(json);
+        assertEquals(CallStatus.UNANSWERED, event.getStatus());
+        assertEquals(CallStatusDetail.UNMAPPED_DETAIL, event.getDetail());
+        assertEquals(CallStatusDetail.NO_DETAIL, CallStatusDetail.fromString(null));
+    }
+
+    @Test
+    public void testMachineDetectionStatusUnknown() {
+        CallStatus status = CallStatus.REJECTED;
+        String json = "{\"status\":\"" + status + "\",\"sub_state\": \"L0L\"}";
+        EventWebhook event = EventWebhook.fromJson(json);
+        assertEquals(status, event.getStatus());
+        assertEquals(MachineDetectionStatus.UNKNOWN, event.getMachineDetectionSubstate());
+    }
+
+    @Test
+    public void testSpeechTimeoutReasonUnknown() {
+        CallStatus status = CallStatus.INPUT;
+        String json = "{\n" +
+            "  \"status\":\"" + status + "\",\n" +
+            "  \"speech\": {\n" +
+            "    \"timeout_reason\": \"who_knows\"\n" +
+            "  }\n" +
+            "}";
+        EventWebhook event = EventWebhook.fromJson(json);
+        assertEquals(status, event.getStatus());
+        SpeechResults speech = event.getSpeech();
+        assertNotNull(speech);
+        assertEquals(SpeechTimeoutReason.UNKNOWN, speech.getTimeoutReason());
+        assertNull(speech.getResults());
+        assertNull(speech.getRecordingUrl());
+        assertNull(speech.getError());
+    }
+}


### PR DESCRIPTION
The current implementation of webhooks for Voice in the `com.vonage.client.incoming.*` package is incomplete as described in #475. Furthermore, it requires _a priori_ knowledge of the event type, which further devalues the classes since some form of parsing is needed to determine the correct class to map the JSON payload to. This PR aims to follow the same approach as the implementations for [Messages](https://github.com/Vonage/vonage-java-sdk/blob/main/src/main/java/com/vonage/client/messages/InboundMessage.java) and [Verify v2](https://github.com/Vonage/vonage-java-sdk/blob/main/src/main/java/com/vonage/client/verify2/VerificationCallback.java): use a single class for each inbound URL. That way, the user can simply call the `fromJson` method on a single class based on which URL is hit, and obtain the relevant fields based on the event type.