### PR TITLE
feat: Tidy up SMS workflow & add new parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added Number Insight v2 API implementation
 - New webhook deserialisation POJOs for Voice: `AnswerWebhook` and `EventWebhook`
 - `toString`, `equals` and `hashCode` implemented for all domain response objects
+- Added `content_id` and `entity_id` parameters for Verify v2 SMS workflow
+- Added Builder for Verify v2 SMS & Silent Auth workflow requests
 
 # [8.1.0] - 2024-01-04
 - Added various missing fields in Messages API:

--- a/src/main/java/com/vonage/client/verify2/AbstractNumberWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/AbstractNumberWorkflow.java
@@ -16,19 +16,37 @@
 package com.vonage.client.verify2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.vonage.client.common.E164;
 
 /**
- * Defines workflow properties for sending a verification code to a user over a voice call.
+ * Intermediate class for number recipients.
+ *
+ * @since 8.2.0
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class VoiceWorkflow extends AbstractNumberWorkflow {
+abstract class AbstractNumberWorkflow extends Workflow {
 
-	/**
-	 * Constructs a new Voice verification workflow.
-	 *
-	 * @param to The number to call, in E.164 format.
-	 */
-	public VoiceWorkflow(String to) {
-		super(Channel.VOICE, to);
+	protected AbstractNumberWorkflow(Builder<?, ?> builder) {
+		super(builder);
+	}
+
+	protected AbstractNumberWorkflow(Channel channel, String to) {
+		super(channel, to);
+	}
+
+	@Override
+	protected String validateTo(String to) {
+		return new E164(super.validateTo(to)).toString();
+	}
+
+	protected abstract static class Builder<
+				N extends AbstractNumberWorkflow,
+				B extends Builder<? extends N, ? extends B>
+			> extends Workflow.Builder<N, B> {
+
+		protected Builder(Channel channel, String to) {
+			super(channel);
+			to(to);
+		}
 	}
 }

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -17,7 +17,6 @@ package com.vonage.client.verify2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.common.E164;
 import java.net.URI;
 
 /**
@@ -26,7 +25,7 @@ import java.net.URI;
  * for an overview of how this works.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class SilentAuthWorkflow extends Workflow {
+public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	private Boolean sandbox;
 	private URI redirectUrl;
 
@@ -36,7 +35,7 @@ public final class SilentAuthWorkflow extends Workflow {
 	 * @param to The number to registered to the device on the network to authenticate.
 	 */
 	public SilentAuthWorkflow(String to) {
-		super(Channel.SILENT_AUTH, new E164(to).toString());
+		super(Channel.SILENT_AUTH, to);
 	}
 
 	/**

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -26,8 +26,14 @@ import java.net.URI;
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
-	private Boolean sandbox;
-	private URI redirectUrl;
+	private final Boolean sandbox;
+	private final URI redirectUrl;
+
+	SilentAuthWorkflow(Builder builder) {
+		super(builder);
+		sandbox = builder.sandbox;
+		redirectUrl = builder.redirectUrl != null ? URI.create(builder.redirectUrl) : null;
+	}
 
 	/**
 	 * Constructs a new Silent Auth verification workflow.
@@ -35,7 +41,7 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * @param to The number to registered to the device on the network to authenticate.
 	 */
 	public SilentAuthWorkflow(String to) {
-		super(Channel.SILENT_AUTH, to);
+		this(builder(to));
 	}
 
 	/**
@@ -47,8 +53,7 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * @since 7.10.0
 	 */
 	public SilentAuthWorkflow(String to, boolean sandbox) {
-		this(to);
-		this.sandbox = sandbox;
+		this(builder(to).sandbox(sandbox));
 	}
 
 	/**
@@ -62,8 +67,7 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * @since 8.0.0
 	 */
 	public SilentAuthWorkflow(String to, boolean sandbox, String redirectUrl) {
-		this(to, sandbox);
-		this.redirectUrl = URI.create(redirectUrl);
+		this(builder(to).redirectUrl(redirectUrl).sandbox(sandbox));
 	}
 
 	/**
@@ -87,5 +91,62 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	@JsonProperty("redirect_url")
 	public URI getRedirectUrl() {
 		return redirectUrl;
+	}
+
+	/**
+	 * Entrypoint for constructing an instance of this class.
+	 *
+	 * @param to (REQUIRED) The number to registered to the device on the network to authenticate.
+	 *
+	 * @return A new Builder.
+	 *
+	 * @since 8.2.0
+	 */
+	public static Builder builder(String to) {
+		return new Builder(to);
+	}
+
+	/**
+	 * Builder for constructing a Silent Authentication workflow.
+	 *
+	 * @since 8.2.0
+	 */
+	public static final class Builder extends AbstractNumberWorkflow.Builder<SilentAuthWorkflow, Builder> {
+		private Boolean sandbox;
+		private String redirectUrl;
+
+		Builder(String to) {
+			super(Channel.SILENT_AUTH, to);
+		}
+
+		/**
+		 * (OPTIONAL) Whether the Vonage Sandbox should be used (for testing purposes).
+		 *
+		 * @param sandbox {@code true} to use the Vonage sandbox.
+		 *
+		 * @return This builder.
+		 */
+		public Builder sandbox(boolean sandbox) {
+			this.sandbox = sandbox;
+			return this;
+		}
+
+		/**
+		 * (OPTIONAL) Final redirect after {@link VerificationResponse#getCheckUrl()}.
+		 * See the documentation for integrations.
+		 *
+		 * @param redirectUrl The full redirect URL as a string.
+		 *
+		 * @return This builder.
+		 */
+		public Builder redirectUrl(String redirectUrl) {
+			this.redirectUrl = redirectUrl;
+			return this;
+		}
+
+		@Override
+		public SilentAuthWorkflow build() {
+			return new SilentAuthWorkflow(this);
+		}
 	}
 }

--- a/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
@@ -16,7 +16,6 @@
 package com.vonage.client.verify2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.vonage.client.common.E164;
 
 /**
  * Defines properties for sending a verification code to a user over WhatsApp
@@ -28,7 +27,7 @@ import com.vonage.client.common.E164;
  * Please contact sales in order to configure Verify v2 to use your company’s WABA.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class WhatsappCodelessWorkflow extends Workflow {
+public final class WhatsappCodelessWorkflow extends AbstractNumberWorkflow {
 
 	/**
 	 * Constructs a new WhatsApp interactive verification workflow.
@@ -36,6 +35,6 @@ public final class WhatsappCodelessWorkflow extends Workflow {
 	 * @param to The number to send the verification prompt to, in E.164 format.
 	 */
 	public WhatsappCodelessWorkflow(String to) {
-		super(Channel.WHATSAPP_INTERACTIVE, new E164(to).toString());
+		super(Channel.WHATSAPP_INTERACTIVE, to);
 	}
 }

--- a/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
@@ -17,7 +17,6 @@ package com.vonage.client.verify2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.vonage.client.common.E164;
 
 /**
  * Defines properties for sending a verification code to a user over a WhatsApp message.
@@ -26,8 +25,11 @@ import com.vonage.client.common.E164;
  * Please contact sales in order to configure Verify v2 to use your company’s WABA.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class WhatsappWorkflow extends Workflow {
+public final class WhatsappWorkflow extends AbstractNumberWorkflow {
 
+	WhatsappWorkflow(Builder builder) {
+		super(builder);
+	}
 
 	/**
 	 * Constructs a new WhatsApp verification workflow.
@@ -46,7 +48,7 @@ public final class WhatsappWorkflow extends Workflow {
 	 * Note that you will need to get in touch with the Vonage sales team to enable use of the field.
 	 */
 	public WhatsappWorkflow(String to, String from) {
-		super(Channel.WHATSAPP, new E164(to).toString(), from);
+		this(builder(to).from(from));
 	}
 
 	/**
@@ -57,5 +59,21 @@ public final class WhatsappWorkflow extends Workflow {
 	@JsonProperty("from")
 	public String getFrom() {
 		return from;
+	}
+
+	static Builder builder(String to) {
+		return new Builder(to);
+	}
+
+	static class Builder extends AbstractNumberWorkflow.Builder<WhatsappWorkflow, Builder> {
+
+		Builder(String to) {
+			super(Channel.WHATSAPP, to);
+		}
+
+		@Override
+		public WhatsappWorkflow build() {
+			return new WhatsappWorkflow(this);
+		}
 	}
 }

--- a/src/main/java/com/vonage/client/verify2/Workflow.java
+++ b/src/main/java/com/vonage/client/verify2/Workflow.java
@@ -25,8 +25,12 @@ import java.util.Objects;
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
 public class Workflow extends JsonableBaseObject {
-	protected Channel channel;
+	protected final Channel channel;
 	protected String to, from;
+
+	protected Workflow(Builder<?, ?> builder) {
+		this(builder.channel, builder.to, builder.from);
+	}
 
 	protected Workflow(Channel channel, String to) {
 		this(channel, to, null);
@@ -34,12 +38,22 @@ public class Workflow extends JsonableBaseObject {
 
 	protected Workflow(Channel channel, String to, String from) {
 		this.channel = Objects.requireNonNull(channel, "Verification channel is required.");
+		this.to = validateTo(to);
+		this.from = validateFrom(from);
+	}
+
+	protected String validateTo(String to) {
 		if ((this.to = to) == null || to.trim().isEmpty()) {
 			throw new IllegalArgumentException("Recipient is required.");
 		}
-		if ((this.from = from) != null && from.trim().isEmpty()) {
+		return to;
+	}
+
+	protected String validateFrom(String from) {
+		if (from != null && from.trim().isEmpty()) {
 			throw new IllegalArgumentException("Sender cannot be empty.");
 		}
+		return from;
 	}
 
 	/**
@@ -60,5 +74,37 @@ public class Workflow extends JsonableBaseObject {
 	@JsonProperty("to")
 	public String getTo() {
 		return to;
+	}
+
+	/**
+	 * Builder class for an SMS workflow.
+	 *
+	 * @since 8.2.0
+	 */
+	@SuppressWarnings("unchecked")
+	protected abstract static class Builder<W extends Workflow, B extends Builder<? extends W, ? extends B>>  {
+		protected final Channel channel;
+		protected String to, from;
+
+		protected Builder(Channel channel) {
+			this.channel = channel;
+		}
+
+		protected B to(String to) {
+			this.to = to;
+			return (B) this;
+		}
+
+		protected B from(String from) {
+			this.from = from;
+			return (B) this;
+		}
+
+		/**
+		 * Builds the workflow.
+		 *
+		 * @return A new instance of the workflow with this builder's fields.
+		 */
+		public abstract W build();
 	}
 }

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -36,6 +36,8 @@ public class VerificationRequestTest {
 			FROM_EMAIL = "bob@example.org",
 			CLIENT_REF = "my-personal-reference",
 			APP_HASH = "kkeid8sksd3",
+			CONTENT_ID = "1107158078772563946",
+			ENTITY_ID = "1101407360000017170",
 			REDIRECT_URL = "https://acme-app.com/sa/redirect";
 
 	Builder newBuilder() {
@@ -70,9 +72,11 @@ public class VerificationRequestTest {
 			case SILENT_AUTH:
 				return new SilentAuthWorkflow(TO_NUMBER, SANDBOX, REDIRECT_URL);
 			case SMS:
-				return new SmsWorkflow(TO_NUMBER, FROM_NUMBER, APP_HASH);
+				return SmsWorkflow.builder(TO_NUMBER)
+						.contentId(CONTENT_ID).entityId(ENTITY_ID)
+						.from(FROM_NUMBER).appHash(APP_HASH).build();
 			case WHATSAPP:
-				return new WhatsappWorkflow(TO_NUMBER, FROM_NUMBER);
+				return WhatsappWorkflow.builder(TO_NUMBER).from(FROM_NUMBER).build();
 			case EMAIL:
 				return new EmailWorkflow(TO_EMAIL, FROM_EMAIL);
 			default:
@@ -104,7 +108,8 @@ public class VerificationRequestTest {
 
 		if (channel == Channel.SMS) {
 			prefix = TO_NUMBER + '"';
-			replacement = prefix + ",\"app_hash\":\""+APP_HASH+"\"";
+			replacement = prefix + ",\"app_hash\":\""+APP_HASH+"\"," +
+					"\"content_id\":\""+CONTENT_ID+"\",\"entity_id\":\""+ENTITY_ID+"\"";
 			expectedJson = expectedJson.replace(prefix, replacement);
 		}
 		if (channel == Channel.WHATSAPP || channel == Channel.SMS) {
@@ -275,12 +280,38 @@ public class VerificationRequestTest {
 	}
 
 	@Test
-	public void testInvalidAppHash() {
-		assertThrows(IllegalArgumentException.class, () -> new SmsWorkflow(TO_NUMBER, "1234567890"));
-		assertThrows(IllegalArgumentException.class, () -> new SmsWorkflow(TO_NUMBER, "1234567890ab"));
-		String appHash = new SmsWorkflow(TO_NUMBER, "1234567890a").getAppHash();
+	public void testInvalidSmsAppHash() {
+		SmsWorkflow.Builder builder = SmsWorkflow.builder(TO_NUMBER);
+		String valid = "1234567890a";
+		assertThrows(IllegalArgumentException.class, () -> builder.appHash(valid.substring(1)).build());
+		assertThrows(IllegalArgumentException.class, () -> builder.appHash(valid + 'b').build());
+		SmsWorkflow workflow = builder.appHash(valid).build();
+		String appHash = workflow.getAppHash();
 		assertNotNull(appHash);
 		assertEquals(11, appHash.length());
+		assertEquals(workflow, new SmsWorkflow(TO_NUMBER, appHash));
+	}
+
+	@Test
+	public void testInvalidSmsContentId() {
+		SmsWorkflow.Builder builder = SmsWorkflow.builder(TO_NUMBER);
+		String valid = "1234567890abcdefghij";
+		assertThrows(IllegalArgumentException.class, () -> builder.contentId("").build());
+		assertThrows(IllegalArgumentException.class, () -> builder.contentId(valid + 'k').build());
+		String contentId = builder.contentId(valid).build().getContentId();
+		assertNotNull(valid);
+		assertEquals(20, contentId.length());
+	}
+
+	@Test
+	public void testInvalidSmsEntityId() {
+		SmsWorkflow.Builder builder = SmsWorkflow.builder(TO_NUMBER);
+		String valid = "1234567890abcdefghij";
+		assertThrows(IllegalArgumentException.class, () -> builder.entityId("").build());
+		assertThrows(IllegalArgumentException.class, () -> builder.entityId(valid + 'k').build());
+		String entityId = builder.entityId(valid).build().getEntityId();
+		assertNotNull(valid);
+		assertEquals(20, entityId.length());
 	}
 
 	@Test

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -31,7 +31,7 @@ public class VerificationRequestTest {
 	static final String
 			BRAND = "Vonage",
 			TO_NUMBER = "447700900000",
-			FROM_NUMBER = "447900100000",
+			FROM_NUMBER = "447900100002",
 			TO_EMAIL = "alice@example.org",
 			FROM_EMAIL = "bob@example.org",
 			CLIENT_REF = "my-personal-reference",
@@ -185,7 +185,7 @@ public class VerificationRequestTest {
 	@Test
 	public void testAllWorkflowsWithoutRecipient() {
 		for (String invalid : new String[]{"", " ", null}) {
-			assertThrows(RuntimeException.class, () -> new SilentAuthWorkflow(invalid));
+			assertThrows(RuntimeException.class, () -> SilentAuthWorkflow.builder(invalid).build());
 			assertThrows(RuntimeException.class, () -> new SmsWorkflow(invalid));
 			assertThrows(RuntimeException.class, () -> new VoiceWorkflow(invalid));
 			assertThrows(RuntimeException.class, () -> new WhatsappWorkflow(invalid));


### PR DESCRIPTION
This PR adds Builder pattern to `com.vonage.client.verify2.Workflow` and some of its subclasses, since the optional parameters list is expected to grow. Namely, the SMS and SIlent Auth workflows now have a Builder. Additionally, SMS workflow has the new `entity_id` and `content_id` fields.