### PR TITLE
ci: Bump Mockito & test compile version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11, 20]
+        java: [20]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,22 +11,51 @@ permissions:
   contents: read
   deployments: read
   issues: write
-  discussions: write
+  discussions: read
   packages: none
-  pages: write
+  pages: read
   pull-requests: write
   security-events: write
   statuses: write
 
 jobs:
-  build:
+  build_only:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        java: [20]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        java: [ 8, 11 ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
 
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: ${{ matrix.java }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -52,4 +81,3 @@ jobs:
 
       - name: Run Codecov
         uses: codecov/codecov-action@v3
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11 ]
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        java: [8, 11]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [17]
+        java: [20]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,5 +51,5 @@ jobs:
         run: ./gradlew build
 
       - name: Run Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 11]
+        java: [8, 11, 17]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [20]
+        java: [21]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ permissions:
   statuses: write
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ java {
 }
 
 compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = sourceCompatibility
 }
 
@@ -46,7 +46,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-    testImplementation "org.mockito:mockito-inline:5.2.0"
+    testImplementation "org.mockito:mockito-core:5.10.0"
     testImplementation "jakarta.servlet:jakarta.servlet-api:4.0.4"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,11 @@ java {
     targetCompatibility = sourceCompatibility
 }
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = sourceCompatibility
+}
+
 dependencies {
     def jacksonVersion = '2.16.1'
     def httpclientVersion = '4.5.14'
@@ -41,7 +46,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-    testImplementation "org.mockito:mockito-inline:4.11.0"
+    testImplementation "org.mockito:mockito-inline:5.2.0"
     testImplementation "jakarta.servlet:jakarta.servlet-api:4.0.4"
 }
 


### PR DESCRIPTION
Now it's possible to use Java 21 for tests whilst the SDK maintains Java 8 compatibility.
