### PR TITLE
feat: Add from to Whatsapp Interactive Verify v2 workflow

### DIFF
--- a/src/main/java/com/vonage/client/verify2/AbstractWhatsappWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/AbstractWhatsappWorkflow.java
@@ -1,0 +1,61 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.verify2;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.common.E164;
+
+/**
+ * Intermediate class for WhatsApp workflows.
+ *
+ * @since 8.3.0
+ */
+@JsonInclude(value = JsonInclude.Include.NON_NULL)
+abstract class AbstractWhatsappWorkflow extends AbstractNumberWorkflow {
+
+	protected AbstractWhatsappWorkflow(Builder<?, ?> builder) {
+		super(builder);
+	}
+
+	@Override
+	protected String validateFrom(String from) {
+		// TODO: remove this when removing deprecated constructors
+		if (from == null) return null;
+		return new E164(super.validateFrom(from)).toString();
+	}
+
+	/**
+	 * The number to send the verification request from.
+	 *
+	 * @return The sender WABA number in E.164 format.
+	 */
+	@JsonProperty("from")
+	public String getFrom() {
+		return from;
+	}
+
+	protected abstract static class Builder<
+			N extends AbstractWhatsappWorkflow,
+			B extends AbstractWhatsappWorkflow.Builder<? extends N, ? extends B>
+			> extends AbstractNumberWorkflow.Builder<N, B> {
+
+		protected Builder(Channel channel, String to, String from) {
+			super(channel, to);
+			from(from);
+		}
+	}
+}

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -115,7 +115,7 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 		private Boolean sandbox;
 		private String redirectUrl;
 
-		Builder(String to) {
+		private Builder(String to) {
 			super(Channel.SILENT_AUTH, to);
 		}
 

--- a/src/main/java/com/vonage/client/verify2/SmsWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SmsWorkflow.java
@@ -142,7 +142,7 @@ public final class SmsWorkflow extends AbstractNumberWorkflow {
 	public static final class Builder extends AbstractNumberWorkflow.Builder<SmsWorkflow, Builder> {
 		private String from, appHash, contentId, entityId;
 
-		Builder(String to) {
+		private Builder(String to) {
 			super(Channel.SMS, to);
 		}
 

--- a/src/main/java/com/vonage/client/verify2/VerificationRequest.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationRequest.java
@@ -200,7 +200,7 @@ public class VerificationRequest implements Jsonable {
 		Locale locale;
 		List<Workflow> workflows = new ArrayList<>(1);
 
-		Builder() {}
+		private Builder() {}
 
 		/**
 		 * (REQUIRED)

--- a/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappCodelessWorkflow.java
@@ -23,18 +23,51 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  * <a href=https://developer.vonage.com/en/verify/verify-v2/guides/using-whatsapp-interactive>
  * WhatsApp Interactive guide</a> for an overview of how this works.
  * <p>
- * By default, WhatsApp messages will be sent using a Vonage WhatsApp Business Account (WABA).
- * Please contact sales in order to configure Verify v2 to use your company’s WABA.
+ * You must have a WhatsApp Business Account configured to use the {@code from} field, which
+ * is now a requirement for WhatsApp workflows.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class WhatsappCodelessWorkflow extends AbstractNumberWorkflow {
+public final class WhatsappCodelessWorkflow extends AbstractWhatsappWorkflow {
+
+	WhatsappCodelessWorkflow(Builder builder) {
+		super(builder);
+	}
 
 	/**
 	 * Constructs a new WhatsApp interactive verification workflow.
 	 *
 	 * @param to The number to send the verification prompt to, in E.164 format.
+	 * @deprecated This no longer works and will be removed in a future release.
 	 */
+	@Deprecated
 	public WhatsappCodelessWorkflow(String to) {
-		super(Channel.WHATSAPP_INTERACTIVE, to);
+		this(to, null);
+	}
+
+	/**
+	 * Constructs a new WhatsApp interactive verification workflow.
+	 *
+	 * @param to The number to send the verification prompt to, in E.164 format.
+	 * @param from The WhatsApp Business Account number to send the message from, in E.164 format.
+	 * @since 8.3.0
+	 */
+	public WhatsappCodelessWorkflow(String to, String from) {
+		this(builder(to, from));
+	}
+
+	static Builder builder(String to, String from) {
+		return new Builder(to, from);
+	}
+
+	static class Builder extends AbstractWhatsappWorkflow.Builder<WhatsappCodelessWorkflow, Builder> {
+
+		private Builder(String to, String from) {
+			super(Channel.WHATSAPP_INTERACTIVE, to, from);
+		}
+
+		@Override
+		public WhatsappCodelessWorkflow build() {
+			return new WhatsappCodelessWorkflow(this);
+		}
 	}
 }

--- a/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/WhatsappWorkflow.java
@@ -16,16 +16,15 @@
 package com.vonage.client.verify2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Defines properties for sending a verification code to a user over a WhatsApp message.
  * <p>
- * By default, WhatsApp messages will be sent using a Vonage WhatsApp Business Account (WABA).
- * Please contact sales in order to configure Verify v2 to use your company’s WABA.
+ * You must have a WhatsApp Business Account configured to use the {@code from} field, which
+ * is now a requirement for WhatsApp workflows.
  */
 @JsonInclude(value = JsonInclude.Include.NON_NULL)
-public final class WhatsappWorkflow extends AbstractNumberWorkflow {
+public final class WhatsappWorkflow extends AbstractWhatsappWorkflow {
 
 	WhatsappWorkflow(Builder builder) {
 		super(builder);
@@ -35,7 +34,9 @@ public final class WhatsappWorkflow extends AbstractNumberWorkflow {
 	 * Constructs a new WhatsApp verification workflow.
 	 *
 	 * @param to The number to send the message to, in E.164 format.
+	 * @deprecated This no longer works and will be removed in a future release.
 	 */
+	@Deprecated
 	public WhatsappWorkflow(String to) {
 		this(to, null);
 	}
@@ -44,31 +45,20 @@ public final class WhatsappWorkflow extends AbstractNumberWorkflow {
 	 * Constructs a new WhatsApp verification workflow with a custom sender number.
 	 *
 	 * @param to The number to send the message to, in E.164 format.
-	 * @param from The number to send the message from, in E.164 format.
-	 * Note that you will need to get in touch with the Vonage sales team to enable use of the field.
+	 * @param from The WhatsApp Business Account number to send the message from, in E.164 format.
 	 */
 	public WhatsappWorkflow(String to, String from) {
-		this(builder(to).from(from));
+		this(builder(to, from));
 	}
 
-	/**
-	 * The number to send the verification request from, if configured.
-	 *
-	 * @return The sender phone number, or {@code null} if unset.
-	 */
-	@JsonProperty("from")
-	public String getFrom() {
-		return from;
+	static Builder builder(String to, String from) {
+		return new Builder(to, from);
 	}
 
-	static Builder builder(String to) {
-		return new Builder(to);
-	}
+	static class Builder extends AbstractWhatsappWorkflow.Builder<WhatsappWorkflow, Builder> {
 
-	static class Builder extends AbstractNumberWorkflow.Builder<WhatsappWorkflow, Builder> {
-
-		Builder(String to) {
-			super(Channel.WHATSAPP, to);
+		Builder(String to, String from) {
+			super(Channel.WHATSAPP, to, from);
 		}
 
 		@Override

--- a/src/test/java/com/vonage/client/verify2/Verify2ClientTest.java
+++ b/src/test/java/com/vonage/client/verify2/Verify2ClientTest.java
@@ -37,12 +37,13 @@ public class Verify2ClientTest extends ClientTest<Verify2Client> {
 	}
 
 	void assert429ResponseException(Executable invocation) throws Exception {
-		String response = "{\n" +
-				"   \"title\": \"Rate Limit Hit\",\n" +
-				"   \"type\": \"https://www.developer.vonage.com/api-errors#throttled\",\n" +
-				"   \"detail\": \"Please wait, then retry your request\",\n" +
-				"   \"instance\": \"bf0ca0bf927b3b52e3cb03217e1a1ddf\"\n" +
-				"}";
+		String response = """
+                {
+                   "title": "Rate Limit Hit",
+                   "type": "https://www.developer.vonage.com/api-errors#throttled",
+                   "detail": "Please wait, then retry your request",
+                   "instance": "bf0ca0bf927b3b52e3cb03217e1a1ddf"
+                }""";
 		assertApiResponseException(429, response, VerifyResponseException.class, invocation);
 	}
 
@@ -55,7 +56,7 @@ public class Verify2ClientTest extends ClientTest<Verify2Client> {
 				new EmailWorkflow(toEmail, fromEmail),
 				new VoiceWorkflow(toNumber),
 				new WhatsappWorkflow(toNumber, fromNumber),
-				new WhatsappCodelessWorkflow(toNumber)
+				new WhatsappCodelessWorkflow(toNumber, fromNumber)
 		);
 		return VerificationRequest.builder()
 				.brand("Nexmo").fraudCheck(false)
@@ -107,7 +108,9 @@ public class Verify2ClientTest extends ClientTest<Verify2Client> {
 			protected VerificationRequest sampleRequest() {
 				return VerificationRequest.builder()
 						.clientRef("my-personal-reference").locale("ar-XA")
-						.addWorkflow(new SmsWorkflow("447700900001", "447900000002", "FA+9qCX9VSu"))
+						.addWorkflow(SmsWorkflow.builder("447700900001")
+								.from("447900000002").appHash("FA+9qCX9VSu").build()
+						)
 						.brand("ACME, Inc").codeLength(6).channelTimeout(320).build();
 			}
 


### PR DESCRIPTION
This PR adds the `from` parameter for WhatsApp Interactive workflow and now requires it to be set for both the regular WhatsApp and WhatsApp Interactive channels, since the shared WABA is no longer working. For backwards compatibility, the SDK will not throw an exception on construction, but in a future release the receiver-only constructors will be removed and have now been deprecated.
