### PR TITLE
feat: Add SipEndpoint headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Java CI
+name: Build & Test
 on:
   push:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to Nexus
+name: Publish to Maven Central
 on:
   release:
     types: [published]

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 <img src="https://developer.nexmo.com/assets/images/Vonage_Nexmo.svg" height="48px" alt="Nexmo is now known as Vonage" />
 
-You can use this Java Server SDK to add [Vonage APIs](https://developer.vonage.com/api) to your application. To use this, you'll
-need a Vonage account. You'll need to have [created a Vonage account](https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=java-client-library).
+This Java SDK allows you to use [Vonage APIs](https://developer.vonage.com/api) in any JVM-based application.
+You'll need to have [created a Vonage account](https://dashboard.nexmo.com/sign-up?utm_source=DEV_REL&utm_medium=github&utm_campaign=java-client-library).
 
 * [Supported APIs](#supported-apis)
 * [Other SDKs](#other-sdks)

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
   <scm>
     <connection>scm:git@github.com:Vonage/vonage-java-sdk</connection>
-    <developerConnection>scm:git@github.com:Vonage/vonage-java-sdk</developerConnection>
+    <developerConnection>${project.scm.connection}</developerConnection>
     <url>${project.url}</url>
   </scm>
   <issueManagement>

--- a/src/main/java/com/vonage/client/voice/SipEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/SipEndpoint.java
@@ -17,18 +17,76 @@ package com.vonage.client.voice;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.JsonableBaseObject;
+import com.vonage.client.users.channels.Sip;
+import static com.vonage.client.voice.SipHeader.USER_TO_USER;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
+/**
+ * Endpoint for connecting to a SIP URI.
+ */
 public class SipEndpoint extends JsonableBaseObject implements Endpoint {
     private static final String TYPE = "sip";
     private String uri;
+    private Map<String, ?> headers;
+    private Map<SipHeader, String> standardHeaders;
 
     protected SipEndpoint() {
     }
 
+    /**
+     * Creates a new SIP endpoint request.
+     *
+     * @param uri (REQUIRED) SIP URI to connect to.
+     */
     public SipEndpoint(String uri) {
-        this.uri = uri;
+        this(uri, null, null);
     }
 
+    /**
+     * Creates a new SIP endpoint request.
+     *
+     * @param uri (REQUIRED) SIP URI to connect to.
+     * @param userToUserHeader (OPTIONAL) The User-to-User header, as per RFC 7433.
+     * @since 8.9.0
+     */
+    public SipEndpoint(String uri, String userToUserHeader) {
+        this(uri, null, userToUserHeader);
+    }
+
+    /**
+     * Creates a new SIP endpoint request.
+     *
+     * @param uri (REQUIRED) URI of the websocket to connect to.
+     * @param headers (OPTIONAL) Custom headers to include.
+     * @since 8.9.0
+     */
+    public SipEndpoint(String uri, Map<String, ?> headers) {
+        this(uri, headers, null);
+    }
+
+    /**
+     * Creates a new SIP endpoint request.
+     *
+     * @param uri (REQUIRED) SIP URI to connect to.
+     * @param headers (OPTIONAL) Custom headers to include.
+     * @param userToUserHeader (OPTIONAL) The User-to-User header, as per RFC 7433.
+     * @since 8.9.0
+     */
+    public SipEndpoint(String uri, Map<String, ?> headers, String userToUserHeader) {
+        this.uri = uri;
+        this.headers = headers;
+        if (userToUserHeader != null) {
+            standardHeaders = Collections.singletonMap(USER_TO_USER, userToUserHeader);
+        }
+    }
+
+    /**
+     * SIP URI to connect to.
+     *
+     * @return The SIP URI as a String.
+     */
     @JsonProperty("uri")
     public String getUri() {
         return uri;
@@ -38,6 +96,29 @@ public class SipEndpoint extends JsonableBaseObject implements Endpoint {
     @Override
     public String getType() {
         return TYPE;
+    }
+
+    /**
+     * Defines custom headers to be sent as part of the SIP INVITE request.
+     * All keys will be prepended with the {@code X-} prefix.
+     *
+     * @return The custom headers as a Map, or {@code null} if unspecified.
+     * @since 8.9.0
+     */
+    @JsonProperty("headers")
+    public Map<String, ?> getHeaders() {
+        return headers;
+    }
+
+    /**
+     * Headers that are RFC standards, i.e. not prepended with {@code X-}.
+     *
+     * @return The standard headers, or {@code null} if unspecified.
+     * @since 8.9.0
+     */
+    @JsonProperty("standard_headers")
+    public Map<SipHeader, String> getStandardHeaders() {
+        return standardHeaders;
     }
 
     @Override

--- a/src/main/java/com/vonage/client/voice/SipHeader.java
+++ b/src/main/java/com/vonage/client/voice/SipHeader.java
@@ -1,0 +1,47 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Represents standard headers for SIP Connect endpoint.
+ *
+ * @since 8.9.0
+ */
+public enum SipHeader {
+    USER_TO_USER;
+
+    @JsonValue
+    @Override
+    public String toString() {
+        return "User-to-User";
+    }
+
+    /**
+     * Converts a SIP header string to a known enum.
+     *
+     * @param value String representation of the SIP header.
+     * @return The SIP header enum, or {@code null} if the value was empty.
+     * @throws IllegalArgumentException If this enum type has no constant with the specified name.
+     */
+    @JsonCreator
+    public static SipHeader fromString(String value) {
+        if (value == null || value.isEmpty()) return null;
+        return valueOf(value.toUpperCase().replace('-', '_'));
+    }
+}

--- a/src/main/java/com/vonage/client/voice/ncco/SipEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/SipEndpoint.java
@@ -17,7 +17,9 @@ package com.vonage.client.voice.ncco;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.JsonableBaseObject;
+import com.vonage.client.voice.SipHeader;
 import java.net.URI;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -30,10 +32,12 @@ public class SipEndpoint extends JsonableBaseObject implements Endpoint {
 
     private final URI uri;
     private final Map<String, ?> headers;
+    private final Map<SipHeader, String> standardHeaders;
 
     private SipEndpoint(Builder builder) {
-        this.uri = builder.uri;
-        this.headers = builder.headers;
+        uri = builder.uri;
+        headers = builder.headers;
+        standardHeaders = builder.standardHeaders;
     }
 
     @JsonProperty("type")
@@ -42,60 +46,124 @@ public class SipEndpoint extends JsonableBaseObject implements Endpoint {
         return TYPE;
     }
 
+    /**
+     * URI of the SIP endpoint.
+     *
+     * @return The URI.
+     */
     @JsonProperty("uri")
     public URI getUri() {
         return uri;
     }
 
+    /**
+     * Defines custom headers to be sent as part of the SIP INVITE request.
+     * All keys will be prepended with the {@code X-} prefix.
+     *
+     * @return The custom headers as a Map, or {@code null} if unspecified.
+     */
     @JsonProperty("headers")
     public Map<String, ?> getHeaders() {
         return headers;
     }
 
     /**
-     * Entry point for constructing an instance of this class.
+     * Headers that are RFC standards, i.e. not prepended with {@code X-}.
      *
-     * @param uri The URI as a string.
-     *
-     * @return A new Builder.
+     * @return The standard headers, or {@code null} if unspecified.
+     * @since 8.9.0
      */
-    public static Builder builder(String uri) {
-        return builder(URI.create(uri));
+    @JsonProperty("standardHeaders")
+    public Map<SipHeader, String> getStandardHeaders() {
+        return standardHeaders;
     }
 
     /**
      * Entry point for constructing an instance of this class.
      *
-     * @param uri The URI object.
+     * @param uri The SIP URI as a string.
+     *
+     * @return A new Builder.
+     */
+    public static Builder builder(String uri) {
+        return new Builder().uri(uri);
+    }
+
+    /**
+     * Entry point for constructing an instance of this class.
+     *
+     * @param uri The SIP URI.
      *
      * @return A new Builder.
      */
     public static Builder builder(URI uri) {
-        return new Builder(uri);
+        return new Builder().uri(uri);
     }
 
     public static class Builder {
         private URI uri;
         private Map<String, ?> headers;
+        private Map<SipHeader, String> standardHeaders;
 
-        Builder(URI uri) {
-            this.uri = uri;
+        private Builder() {}
+
+        private Builder addStandardHeader(SipHeader key, String value) {
+            if (standardHeaders == null) {
+                standardHeaders = new LinkedHashMap<>(2);
+            }
+            standardHeaders.put(key, value);
+            return this;
         }
 
+        /**
+         * Sets the URI.
+         *
+         * @param uri The URI.
+         * @return This builder.
+         */
         public Builder uri(URI uri) {
             this.uri = uri;
             return this;
         }
 
+        /**
+         * Sets the URI.
+         *
+         * @param uri The URI as a string.
+         * @return This builder.
+         */
         public Builder uri(String uri) {
             return uri(URI.create(uri));
         }
 
+        /**
+         * Sets the custom headers, which will be prepended with {@code X-} by Vonage.
+         *
+         * @param headers The custom headers as a Map.
+         * @return This builder.
+         */
         public Builder headers(Map<String, ?> headers) {
             this.headers = headers;
             return this;
         }
 
+        /**
+         * (OPTIONAL) The User-to-User header, as per RFC 7433.
+         *
+         * @param value Value of the {@code User-to-User} header as string.
+         *
+         * @return This builder.
+         * @since 8.9.0
+         */
+        public Builder userToUserHeader(String value) {
+            return addStandardHeader(SipHeader.USER_TO_USER, value);
+        }
+
+        /**
+         * Builds the SIP endpoint.
+         *
+         * @return A new SipEndpoint with this builder's properties.
+         */
         public SipEndpoint build() {
             return new SipEndpoint(this);
         }

--- a/src/test/java/com/vonage/client/voice/ncco/ConnectActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/ConnectActionTest.java
@@ -19,6 +19,7 @@ import com.vonage.client.voice.AdvancedMachineDetection;
 import com.vonage.client.voice.MachineDetection;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import java.util.Map;
 
 public class ConnectActionTest {
 
@@ -67,18 +68,21 @@ public class ConnectActionTest {
 
     @Test
     public void testAllFieldsWithSipEndpoint() {
-        SipEndpoint endpoint = SipEndpoint.builder("sip:test@sip.example.com").build();
+        String uri = "sip:test@sip.example.com", user2User = "someRandomValue;encoding=L0L";
+        SipEndpoint endpoint = SipEndpoint.builder(uri)
+                .userToUserHeader(user2User).headers(Map.of()).build();
+
         ConnectAction connect = ConnectAction.builder(endpoint)
                 .from("15554449876")
                 .eventType(EventType.SYNCHRONOUS)
-                .timeOut(3)
-                .limit(2)
+                .timeOut(3).limit(2)
                 .machineDetection(MachineDetection.CONTINUE)
                 .eventUrl("https://example.com")
                 .eventMethod(EventMethod.POST)
                 .build();
 
-        String expectedJson = "[{\"endpoint\":[{\"uri\":\"sip:test@sip.example.com\",\"type\":\"sip\"}]," +
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\""+uri+"\",\"headers\":{},\"standardHeaders\":" +
+                "{\"User-to-User\":\""+user2User+"\"},\"type\":\"sip\"}]," +
                 "\"from\":\"15554449876\",\"eventType\":\"synchronous\",\"limit\":2,\"timeout\":3," +
                 "\"machineDetection\":\"continue\",\"eventUrl\":[\"https://example.com\"]," +
                 "\"eventMethod\":\"POST\",\"action\":\"connect\"}]";

--- a/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
@@ -17,21 +17,26 @@ package com.vonage.client.voice.ncco;
 
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import java.net.URI;
 import java.util.Collections;
 
 public class SipEndpointTest {
 
     @Test
     public void testAllFields() {
-        SipEndpoint endpoint = SipEndpoint.builder("")
-                .uri("sip:test@example.com")
-                .headers(Collections.singletonMap("k1", "v1"))
-                .build();
+        assertThrows(IllegalArgumentException.class, () -> SipEndpoint.builder(",}").build());
+        String uri = "sip:test@example.com";
+        String user2UserHeader = "342342ef34;encoding=hex";
+        SipEndpoint endpoint = SipEndpoint.builder(URI.create("foo"))
+                .uri(uri).headers(Collections.singletonMap("k1", "v1"))
+                .userToUserHeader(user2UserHeader).build();
 
         ConnectAction connect = ConnectAction.builder(endpoint).build();
 
-        String expectedJson = "[{\"endpoint\":[{\"uri\":\"sip:test@example.com\"," +
-                "\"headers\":{\"k1\":\"v1\"},\"type\":\"sip\"}],\"action\":\"connect\"}]";
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\""+uri+"\"," +
+                "\"headers\":{\"k1\":\"v1\"}," +
+                "\"standardHeaders\":{\"User-to-User\":\""+user2UserHeader+"\"}," +
+                "\"type\":\"sip\"}],\"action\":\"connect\"}]";
         assertEquals(expectedJson, new Ncco(connect).toJson());
     }
 }


### PR DESCRIPTION
Adds the `User-to-User` header for SIP (both NCCO and Answer URL) along with custom headers for Answer URL SIP Connect endpoint.