### PR TITLE
fix: EventWebhook deserialisation and JWT 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.9.2] - 2024-07-12
+- Refactoring to accommodate using v2.0.0 of Vonage JWT library
+- 
+
 # [8.9.1] - 2024-07-09
 - Fixed parsing issue in `ConversationsClient#listEvents`
 - `body` method in `CustomEvent.Builder` is now accessible
@@ -10,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # [8.9.0] - 2024-06-20
 - Added `User-to-User` header in Voice Connect SIP endpoint
 - Added missing custom `headers` field in `com.vonage.client.voice.SipEndpoint`
-- Added CAMARA Number Verification API
+- Added Number Verification API
 - Refactored Network auth
 - Reduced Verify v2 minimum channel timeout
 
@@ -26,7 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved testing of auth method application
   - Introduced intermediate interfaces
 - Added Vonage Network Auth API (intended for internal use only)
-- Added CAMARA SIM Swap API
+- Added SIM Swap API
 - Migrated to Maven from Gradle
 
 # [8.7.0] - 2024-05-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [8.9.2] - 2024-07-12
 - Refactoring to accommodate using v2.0.0 of Vonage JWT library
-- 
+- Fixed `com.vonage.client.voice.EventWebhook` deserialisation issue
+  - `getCallUuid()` and `getRecordingUuid()` now return String instead of UUID
 
 # [8.9.1] - 2024-07-09
 - Fixed parsing issue in `ConversationsClient#listEvents`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vonage Server SDK for Java
 
 ![Java](https://img.shields.io/badge/java-8%2B-red)
-[![Maven Release](https://maven-badges.herokuapp.com/maven-central/com.vonage/server-sdk/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.vonage/server-sdk)
+[![Maven Release](https://maven-badges.herokuapp.com/maven-central/com.vonage/server-sdk/badge.svg)](https://central.sonatype.com/artifact/com.vonage/server-sdk)
 [![Build Status](https://github.com/Vonage/vonage-java-sdk/actions/workflows/build.yml/badge.svg)](https://github.com/Vonage/vonage-java-sdk/actions/workflows/build.yml)
 [![codecov](https://codecov.io/gh/vonage/vonage-java-sdk/branch/main/graph/badge.svg)](https://codecov.io/gh/vonage/vonage-java-sdk)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)

--- a/bumpversion.sh
+++ b/bumpversion.sh
@@ -6,6 +6,6 @@ fi
 
 mvn versions:set -DnewVersion=$1
 mvn validate
-mvn versions:display-plugin-updates
-mvn versions:display-dependency-updates
-rm pom.xml.releaseBackup pom.xml.versionsBackup
+rm pom.xml.versionsBackup #pom.xml.releaseBackup
+#mvn versions:display-plugin-updates
+#mvn versions:display-dependency-updates

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.9.1</version>
+  <version>8.9.2</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
   <artifactId>server-sdk</artifactId>
   <version>8.9.1</version>
 
-  <packaging>jar</packaging>
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>
   <url>https://github.com/Vonage/vonage-java-sdk</url>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.vonage</groupId>
       <artifactId>jwt</artifactId>
-      <version>1.1.3</version>
+      <version>2.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -99,6 +99,24 @@
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <version>4.0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.12.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-impl</artifactId>
+      <version>0.12.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-jackson</artifactId>
+      <version>0.12.6</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,8 @@
           <source>${java.version}</source>
           <target>${java.version}</target>
           <release>${java.version}</release>
+          <testSource>${java.testVersion}</testSource>
+          <testTarget>${java.testVersion}</testTarget>
           <testRelease>${java.testVersion}</testRelease>
           <testCompilerArgument>--enable-preview</testCompilerArgument>
         </configuration>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.9.1",
+            CLIENT_VERSION = "8.9.2",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
@@ -21,12 +21,12 @@ public class JWTAuthMethod extends BearerAuthMethod {
     private static final int SORT_KEY = 10;
 
     private final Jwt jwt;
-    private final String applicationId;
+    private final String applicationId, privateKeyContents;
 
     public JWTAuthMethod(final String applicationId, final byte[] privateKey) {
         jwt = Jwt.builder()
                 .applicationId(this.applicationId = applicationId)
-                .privateKeyContents(new String(privateKey)).build();
+                .privateKeyContents(this.privateKeyContents = new String(privateKey)).build();
     }
 
     public String generateToken() {
@@ -44,7 +44,7 @@ public class JWTAuthMethod extends BearerAuthMethod {
      * @since 8.0.0-beta2
      */
     public Jwt.Builder newJwt() {
-        return Jwt.builder().applicationId(applicationId).privateKeyContents(jwt.getPrivateKeyContents());
+        return Jwt.builder().applicationId(applicationId).privateKeyContents(privateKeyContents);
     }
 
     @Override

--- a/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
+++ b/src/main/java/com/vonage/client/auth/JWTAuthMethod.java
@@ -26,7 +26,8 @@ public class JWTAuthMethod extends BearerAuthMethod {
     public JWTAuthMethod(final String applicationId, final byte[] privateKey) {
         jwt = Jwt.builder()
                 .applicationId(this.applicationId = applicationId)
-                .privateKeyContents(this.privateKeyContents = new String(privateKey)).build();
+                .privateKeyContents(this.privateKeyContents = new String(privateKey))
+                .build();
     }
 
     public String generateToken() {

--- a/src/main/java/com/vonage/client/voice/EventWebhook.java
+++ b/src/main/java/com/vonage/client/voice/EventWebhook.java
@@ -42,8 +42,8 @@ public class EventWebhook extends JsonableBaseObject {
     private Integer duration, size;
     private Double rate, price;
     private URI recordingUrl;
-    private UUID callUuid, recordingUuid;
-    private String to, from, conversationUuid, conversationUuidFrom, conversationUuidTo, network, reason;
+    private String to, from, network, reason,
+            callUuid, recordingUuid, conversationUuid, conversationUuidFrom, conversationUuidTo;
 
     protected EventWebhook() {}
 
@@ -195,21 +195,21 @@ public class EventWebhook extends JsonableBaseObject {
     /**
      * Unique identifier for the call event.
      *
-     * @return The call ID, or {@code null} not applicable.
+     * @return The call ID as a string, or {@code null} not applicable.
      */
     @JsonProperty("uuid")
     @JsonAlias({"uuid", "call_uuid"})
-    public UUID getCallUuid() {
+    public String getCallUuid() {
         return callUuid;
     }
 
     /**
      * Unique identifier for the recording. This is only present for recording events.
      *
-     * @return The recording ID, or {@code null} if not applicable.
+     * @return The recording ID as a string, or {@code null} if not applicable.
      */
     @JsonProperty("recording_uuid")
-    public UUID getRecordingUuid() {
+    public String getRecordingUuid() {
         return recordingUuid;
     }
 

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -165,7 +165,7 @@ public class AbstractMethodTest {
         request = method.makeRequest();
         assertEquals(request, method.applyAuth(request));
         assertEquals(2, request.getParameters().size());
-        var expectedHeaderStart = "Bearer eyJ0eXBlIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.";
+        var expectedHeaderStart = "Bearer eyJ";
         var authHeaderValue = request.getFirstHeader("Authorization").getValue();
         assertTrue(authHeaderValue.startsWith(expectedHeaderStart));
 

--- a/src/test/java/com/vonage/client/auth/JWTAuthMethodTest.java
+++ b/src/test/java/com/vonage/client/auth/JWTAuthMethodTest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.auth;
 
 import com.vonage.client.TestUtils;
+import static com.vonage.client.TestUtils.APPLICATION_ID_STR;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import org.junit.jupiter.api.*;
@@ -28,18 +29,18 @@ public class JWTAuthMethodTest {
     @BeforeEach
     public void setUp() throws Exception {
         byte[] keyBytes = new TestUtils().loadKey("test/keys/application_key");
-        auth = new JWTAuthMethod("application-id", keyBytes);
+        auth = new JWTAuthMethod(APPLICATION_ID_STR, keyBytes);
     }
 
     @Test
     public void testSavedKeyUsingPath() throws Exception {
-        auth = new JWTAuthMethod("application-id", Files.readAllBytes(Paths.get(
+        auth = new JWTAuthMethod(APPLICATION_ID_STR, Files.readAllBytes(Paths.get(
                 "src/test/resources/com/vonage/client/test/keys/application_key2"
         )));
     }
 
     @Test
-    public void testApply() throws Exception {
+    public void testApply() {
         String header = auth.getHeaderValue();
         assertNotNull(header);
         assertEquals("Bearer ", header.substring(0, 7));

--- a/src/test/java/com/vonage/client/auth/VonageUnacceptableAuthExceptionTest.java
+++ b/src/test/java/com/vonage/client/auth/VonageUnacceptableAuthExceptionTest.java
@@ -28,7 +28,7 @@ public class VonageUnacceptableAuthExceptionTest {
         VonageUnacceptableAuthException exception = new VonageUnacceptableAuthException(
                 Arrays.asList(new ApiKeyHeaderAuthMethod(null, null),
                         new SignatureAuthMethod(null, null),
-                        new JWTAuthMethod("application_id", new TestUtils().loadKey("test/keys/application_key"))),
+                        new JWTAuthMethod(TestUtils.APPLICATION_ID_STR, new TestUtils().loadKey("test/keys/application_key"))),
                 Arrays.asList(ApiKeyHeaderAuthMethod.class, SignatureAuthMethod.class, JWTAuthMethod.class)
         );
 

--- a/src/test/java/com/vonage/client/video/TokenOptionsTest.java
+++ b/src/test/java/com/vonage/client/video/TokenOptionsTest.java
@@ -15,19 +15,18 @@
  */
 package com.vonage.client.video;
 
+import com.vonage.client.TestUtils;
 import com.vonage.jwt.Jwt;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
 import java.time.Duration;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.*;
 
 public class TokenOptionsTest {
-	final String applicationId = UUID.randomUUID().toString();
-	final String privateKeyContents = "blah";
 
 	Jwt buildJwtWithClaims(TokenOptions options) {
-		Jwt.Builder jwtBuilder = Jwt.builder().applicationId(applicationId).privateKeyContents(privateKeyContents);
+		Jwt.Builder jwtBuilder = Jwt.builder().applicationId(TestUtils.APPLICATION_ID).unsigned();
 		options.addClaims(jwtBuilder);
 		return jwtBuilder.build();
 	}
@@ -46,12 +45,12 @@ public class TokenOptionsTest {
 
 		Jwt jwt = buildJwtWithClaims(options);
 
-		ZonedDateTime expiresAt = jwt.getExpiresAt();
-		assertFalse(expiresAt.isAfter(ZonedDateTime.now().plus(ttl)));
-		assertTrue(expiresAt.minus(ttl).isBefore(ZonedDateTime.now().plusSeconds(1)));
+		Instant expiresAt = jwt.getExpiresAt();
+		assertFalse(expiresAt.isAfter(Instant.now().plus(ttl)));
+		assertTrue(expiresAt.minus(ttl).isBefore(Instant.now().plusSeconds(1)));
 
 		Map<String, ?> claims = jwt.getClaims();
-		assertEquals(4, claims.size());
+		assertEquals(5, claims.size());
 		assertEquals(data, claims.get("connection_data"));
 		assertEquals(String.join(" ", layoutClassList), claims.get("initial_layout_class_list"));
 		assertEquals(role.toString(), claims.get("role"));
@@ -69,7 +68,7 @@ public class TokenOptionsTest {
 		Jwt jwt = buildJwtWithClaims(options);
 
 		Map<String, ?> claims = jwt.getClaims();
-		assertEquals(2, claims.size());
+		assertEquals(3, claims.size());
 		assertEquals("publisher", claims.get("role").toString());
 		assertNull(claims.get("connection_data"));
 		assertNull(claims.get("initial_layout_class_list"));
@@ -96,7 +95,7 @@ public class TokenOptionsTest {
 		Jwt jwt = buildJwtWithClaims(options);
 
 		Map<String, ?> claims = jwt.getClaims();
-		assertEquals(2, claims.size());
+		assertEquals(3, claims.size());
 		assertEquals("publisheronly", claims.get("role").toString());
 	}
 }

--- a/src/test/java/com/vonage/client/voice/EventWebhookTest.java
+++ b/src/test/java/com/vonage/client/voice/EventWebhookTest.java
@@ -48,7 +48,9 @@ public class EventWebhookTest {
                 speechResultText1 = "sales",
                 speechResultText2 = "customer";
 
-        UUID callUuid = UUID.randomUUID(), recordingUuid = UUID.randomUUID();
+        String callUuid = UUID.randomUUID().toString().replace("-", ""),
+                recordingUuid = UUID.randomUUID().toString().replace("-", "");
+
         boolean dtmfTimedOut = true;
         int duration = 6, size = 12228;
         double rate = 0.00450000,
@@ -131,7 +133,7 @@ public class EventWebhookTest {
         List<SpeechTranscript> speechResults = speech.getResults();
         assertNotNull(speechResults);
         assertEquals(2, speechResults.size());
-        SpeechTranscript speechResult1 = speechResults.get(0);
+        SpeechTranscript speechResult1 = speechResults.getFirst();
         assertNotNull(speechResult1);
         assertEquals(speechResultConfidence1, speechResult1.getConfidence());
         assertEquals(speechResultText1, speechResult1.getText());
@@ -175,7 +177,8 @@ public class EventWebhookTest {
 
     @Test
     public void testCallUuidPrimaryOnly() {
-        UUID callUuid = UUID.randomUUID(), uuid = UUID.randomUUID();
+        String callUuid = UUID.randomUUID().toString().replace("-", ""),
+                uuid = UUID.randomUUID().toString().replace("-", "");
         String json = "{\"call_uuid\":\""+callUuid+"\",\"uuid\":\""+uuid+"\"}";
         EventWebhook event = EventWebhook.fromJson(json);
         TestUtils.testJsonableBaseObject(event);


### PR DESCRIPTION
This PR updates the SDK to use [v2.0.0 of the Vonage Java JWT library](https://github.com/Vonage/vonage-jwt-jdk/releases/tag/v2.0.0), as well as changing the return types of `callUuid` and `recordingUuid` in `com.vonage.client.voice.EventWebhook` to be String instead of UUID.
