### PR TITLE
feat: Interfaces for MessageRequest builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [8.11.0] - 2024-09-2?
+# [8.11.0] - 2024-09-24
 - Added RCS channel to Messages API
 - Added `ackInboundMessage` and `revokeOutboundMessage` methods to `MessagesClient`
 - Fixed `viber_service` deserialization in `com.vonage.client.messages.Channel`
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added `content` property to `InboundMessage` for MMS messages
 - Removed `com.vonage.client.messages.internal.Text`
 - Factored out common properties & validation for text, media and custom messages into `MessageRequest`
+- Added interfaces for text and media `MessageRequest` builders
 
 # [8.10.0] - 2024-08-02
 - Added `targetApiKey` for buy & cancel number endpoints

--- a/src/main/java/com/vonage/client/messages/CaptionMediaMessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/CaptionMediaMessageRequest.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+/**
+ * Convenience interface to indicate that a media message may have a caption.
+ *
+ * @since 8.11.0
+ */
+public interface CaptionMediaMessageRequest extends MediaMessageRequest {
+
+    /**
+     * Interface for builders with a media URL and caption.
+     * @param <B> The concrete builder type.
+     */
+    interface Builder<B extends MessageRequest.Builder<? extends CaptionMediaMessageRequest, ? extends B>> extends MediaMessageRequest.Builder<B> {
+
+        /**
+         * Sets the media's caption text.
+         * 
+         * @param caption The caption string.
+         * @return This builder.
+         */
+        B caption(String caption);
+    }
+}

--- a/src/main/java/com/vonage/client/messages/MediaMessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/MediaMessageRequest.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+/**
+ * Convenience interface to indicate that {@link MessageRequest#getMessageType()} is media (has a URL).
+ *
+ * @since 8.11.0
+ */
+public interface MediaMessageRequest {
+
+    /**
+     * Interface for builders with a media URL.
+     * @param <B> The concrete builder type.
+     */
+    interface Builder<B extends MessageRequest.Builder<? extends MediaMessageRequest, ? extends B>> {
+
+        /**
+         * Sets the media URL of the message request.
+         *
+         * @param url The media URL as a string.
+         * @return This builder.
+         */
+        B url(String url);
+    }
+}

--- a/src/main/java/com/vonage/client/messages/TextMessageRequest.java
+++ b/src/main/java/com/vonage/client/messages/TextMessageRequest.java
@@ -1,0 +1,46 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+/**
+ * Convenience interface to indicate that {@link MessageRequest#getMessageType()} is {@link MessageType#TEXT}.
+ *
+ * @since 8.11.0
+ */
+public interface TextMessageRequest {
+
+    /**
+     * Get the {@code text} field of the message.
+     *
+     * @return The message text as set on the builder.
+     */
+    String getText();
+
+    /**
+     * Interface for builders where {@linkplain MessageRequest#getMessageType()} is {@link MessageType#TEXT}.
+     * @param <B> The concrete builder type.
+     */
+    interface Builder<B extends MessageRequest.Builder<? extends TextMessageRequest, ? extends B>> {
+
+        /**
+         * Sets the text of the message request.
+         *
+         * @param text The message text.
+         * @return This builder.
+         */
+        B text(String text);
+    }
+}

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerAudioRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.messenger;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class MessengerAudioRequest extends MessengerRequest {
+public final class MessengerAudioRequest extends MessengerRequest implements MediaMessageRequest {
 
 	MessengerAudioRequest(Builder builder) {
 		super(builder, MessageType.AUDIO);
@@ -36,7 +37,7 @@ public final class MessengerAudioRequest extends MessengerRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MessengerRequest.Builder<MessengerAudioRequest, Builder> {
+	public static final class Builder extends MessengerRequest.Builder<MessengerAudioRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerFileRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.messenger;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class MessengerFileRequest extends MessengerRequest {
+public final class MessengerFileRequest extends MessengerRequest implements MediaMessageRequest {
 
 	MessengerFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);
@@ -34,7 +35,7 @@ public final class MessengerFileRequest extends MessengerRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MessengerRequest.Builder<MessengerFileRequest, Builder> {
+	public static final class Builder extends MessengerRequest.Builder<MessengerFileRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerImageRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.messenger;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class MessengerImageRequest extends MessengerRequest {
+public final class MessengerImageRequest extends MessengerRequest implements MediaMessageRequest {
 
 	MessengerImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);
@@ -35,7 +36,7 @@ public final class MessengerImageRequest extends MessengerRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MessengerRequest.Builder<MessengerImageRequest, Builder> {
+	public static final class Builder extends MessengerRequest.Builder<MessengerImageRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerTextRequest.java
@@ -16,8 +16,9 @@
 package com.vonage.client.messages.messenger;
 
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.TextMessageRequest;
 
-public final class MessengerTextRequest extends MessengerRequest {
+public final class MessengerTextRequest extends MessengerRequest implements TextMessageRequest {
 
 	MessengerTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);
@@ -37,7 +38,7 @@ public final class MessengerTextRequest extends MessengerRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MessengerRequest.Builder<MessengerTextRequest, Builder> {
+	public static final class Builder extends MessengerRequest.Builder<MessengerTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/messenger/MessengerVideoRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.messenger;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class MessengerVideoRequest extends MessengerRequest {
+public final class MessengerVideoRequest extends MessengerRequest implements MediaMessageRequest {
 
 	MessengerVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);
@@ -35,7 +36,7 @@ public final class MessengerVideoRequest extends MessengerRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MessengerRequest.Builder<MessengerVideoRequest, Builder> {
+	public static final class Builder extends MessengerRequest.Builder<MessengerVideoRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsAudioRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
-public final class MmsAudioRequest extends MmsRequest {
+public final class MmsAudioRequest extends MmsRequest implements CaptionMediaMessageRequest {
 
 	MmsAudioRequest(Builder builder) {
 		super(builder, MessageType.AUDIO);
@@ -34,7 +35,7 @@ public final class MmsAudioRequest extends MmsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MmsRequest.Builder<MmsAudioRequest, Builder> {
+	public static final class Builder extends MmsRequest.Builder<MmsAudioRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
-public final class MmsImageRequest extends MmsRequest {
+public final class MmsImageRequest extends MmsRequest implements CaptionMediaMessageRequest {
 
 	MmsImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);
@@ -35,7 +36,7 @@ public final class MmsImageRequest extends MmsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MmsRequest.Builder<MmsImageRequest, Builder> {
+	public static final class Builder extends MmsRequest.Builder<MmsImageRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVcardRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
-public final class MmsVcardRequest extends MmsRequest {
+public final class MmsVcardRequest extends MmsRequest implements CaptionMediaMessageRequest {
 
 	MmsVcardRequest(Builder builder) {
 		super(builder, MessageType.VCARD);
@@ -35,7 +36,7 @@ public final class MmsVcardRequest extends MmsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MmsRequest.Builder<MmsVcardRequest, Builder> {
+	public static final class Builder extends MmsRequest.Builder<MmsVcardRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsVideoRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.mms;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
-public final class MmsVideoRequest extends MmsRequest {
+public final class MmsVideoRequest extends MmsRequest implements CaptionMediaMessageRequest {
 
 	MmsVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);
@@ -34,7 +35,7 @@ public final class MmsVideoRequest extends MmsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends MmsRequest.Builder<MmsVideoRequest, Builder> {
+	public static final class Builder extends MmsRequest.Builder<MmsVideoRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/rcs/RcsFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsFileRequest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.messages.rcs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
@@ -24,7 +25,7 @@ import com.vonage.client.messages.internal.MessagePayload;
  *
  * @since 8.11.0
  */
-public final class RcsFileRequest extends RcsRequest {
+public final class RcsFileRequest extends RcsRequest implements MediaMessageRequest {
 
 	RcsFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);
@@ -40,7 +41,7 @@ public final class RcsFileRequest extends RcsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends RcsRequest.Builder<RcsFileRequest, Builder> {
+	public static final class Builder extends RcsRequest.Builder<RcsFileRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/rcs/RcsImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsImageRequest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.messages.rcs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
@@ -24,7 +25,7 @@ import com.vonage.client.messages.internal.MessagePayload;
  *
  * @since 8.11.0
  */
-public final class RcsImageRequest extends RcsRequest {
+public final class RcsImageRequest extends RcsRequest implements MediaMessageRequest {
 
 	RcsImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);
@@ -40,7 +41,7 @@ public final class RcsImageRequest extends RcsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends RcsRequest.Builder<RcsImageRequest, Builder> {
+	public static final class Builder extends RcsRequest.Builder<RcsImageRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/rcs/RcsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsTextRequest.java
@@ -16,13 +16,14 @@
 package com.vonage.client.messages.rcs;
 
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.TextMessageRequest;
 
 /**
  * {@link com.vonage.client.messages.Channel#RCS}, {@link MessageType#TEXT} request.
  *
  * @since 8.11.0
  */
-public final class RcsTextRequest extends RcsRequest {
+public final class RcsTextRequest extends RcsRequest implements TextMessageRequest {
 
 	RcsTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);
@@ -42,7 +43,7 @@ public final class RcsTextRequest extends RcsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends RcsRequest.Builder<RcsTextRequest, Builder> {
+	public static final class Builder extends RcsRequest.Builder<RcsTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/rcs/RcsVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsVideoRequest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.messages.rcs;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
@@ -24,7 +25,7 @@ import com.vonage.client.messages.internal.MessagePayload;
  *
  * @since 8.11.0
  */
-public final class RcsVideoRequest extends RcsRequest {
+public final class RcsVideoRequest extends RcsRequest implements MediaMessageRequest {
 
 	RcsVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);
@@ -40,7 +41,7 @@ public final class RcsVideoRequest extends RcsRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends RcsRequest.Builder<RcsVideoRequest, Builder> {
+	public static final class Builder extends RcsRequest.Builder<RcsVideoRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -19,8 +19,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.Channel;
 import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.TextMessageRequest;
 
-public final class SmsTextRequest extends MessageRequest {
+public final class SmsTextRequest extends MessageRequest implements TextMessageRequest {
 	final OutboundSettings sms;
 
 	SmsTextRequest(Builder builder) {
@@ -47,7 +48,7 @@ public final class SmsTextRequest extends MessageRequest {
 		return new Builder();
 	}
 
-	public final static class Builder extends MessageRequest.Builder<SmsTextRequest, Builder> {
+	public final static class Builder extends MessageRequest.Builder<SmsTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 		String contentId, entityId;
 		EncodingType encodingType;
 

--- a/src/main/java/com/vonage/client/messages/viber/ViberFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberFileRequest.java
@@ -16,13 +16,14 @@
 package com.vonage.client.messages.viber;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import com.vonage.client.messages.internal.MessagePayload;
 
 /**
  * @since 7.2.0
  */
-public final class ViberFileRequest extends ViberRequest {
+public final class ViberFileRequest extends ViberRequest implements MediaMessageRequest {
 
 	ViberFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);
@@ -41,7 +42,7 @@ public final class ViberFileRequest extends ViberRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends ViberRequest.Builder<ViberFileRequest, Builder> {
+	public static final class Builder extends ViberRequest.Builder<ViberFileRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberImageRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.viber;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class ViberImageRequest extends ViberRequest {
+public final class ViberImageRequest extends ViberRequest implements MediaMessageRequest {
 
 	ViberImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);
@@ -35,7 +36,7 @@ public final class ViberImageRequest extends ViberRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends ViberRequest.Builder<ViberImageRequest, Builder> {
+	public static final class Builder extends ViberRequest.Builder<ViberImageRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberTextRequest.java
@@ -16,8 +16,9 @@
 package com.vonage.client.messages.viber;
 
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.TextMessageRequest;
 
-public final class ViberTextRequest extends ViberRequest {
+public final class ViberTextRequest extends ViberRequest implements TextMessageRequest {
 
 	ViberTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);
@@ -32,7 +33,7 @@ public final class ViberTextRequest extends ViberRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends ViberRequest.Builder<ViberTextRequest, Builder> {
+	public static final class Builder extends ViberRequest.Builder<ViberTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/viber/ViberVideoRequest.java
@@ -16,13 +16,14 @@
 package com.vonage.client.messages.viber;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.MessageType;
 import java.util.Objects;
 
 /**
  * @since 7.2.0
  */
-public final class ViberVideoRequest extends ViberRequest {
+public final class ViberVideoRequest extends ViberRequest implements CaptionMediaMessageRequest {
 	final Video video;
 
 	ViberVideoRequest(Builder builder) {
@@ -41,7 +42,7 @@ public final class ViberVideoRequest extends ViberRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends ViberRequest.Builder<ViberVideoRequest, Builder> {
+	public static final class Builder extends ViberRequest.Builder<ViberVideoRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		String thumbUrl;
 
 		Builder() {}

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappAudioRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class WhatsappAudioRequest extends WhatsappRequest {
+public final class WhatsappAudioRequest extends WhatsappRequest implements MediaMessageRequest {
 
 	WhatsappAudioRequest(Builder builder) {
 		super(builder, MessageType.AUDIO);
@@ -36,7 +37,7 @@ public final class WhatsappAudioRequest extends WhatsappRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends WhatsappRequest.Builder<WhatsappAudioRequest, Builder> {
+	public static final class Builder extends WhatsappRequest.Builder<WhatsappAudioRequest, Builder> implements MediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappFileRequest.java
@@ -16,10 +16,12 @@
 package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
+import com.vonage.client.messages.MediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class WhatsappFileRequest extends WhatsappRequest {
+public final class WhatsappFileRequest extends WhatsappRequest implements CaptionMediaMessageRequest {
 
 	WhatsappFileRequest(Builder builder) {
 		super(builder, MessageType.FILE);
@@ -34,7 +36,7 @@ public final class WhatsappFileRequest extends WhatsappRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends WhatsappRequest.Builder<WhatsappFileRequest, Builder> {
+	public static final class Builder extends WhatsappRequest.Builder<WhatsappFileRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 
@@ -58,6 +60,7 @@ public final class WhatsappFileRequest extends WhatsappRequest {
 		 * @param caption The caption string.
 		 * @return This builder.
 		 */
+		@Override
 		public Builder caption(String caption) {
 			return super.caption(caption);
 		}

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappImageRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class WhatsappImageRequest extends WhatsappRequest {
+public final class WhatsappImageRequest extends WhatsappRequest implements CaptionMediaMessageRequest {
 
 	WhatsappImageRequest(Builder builder) {
 		super(builder, MessageType.IMAGE);
@@ -36,7 +37,7 @@ public final class WhatsappImageRequest extends WhatsappRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends WhatsappRequest.Builder<WhatsappImageRequest, Builder> {
+	public static final class Builder extends WhatsappRequest.Builder<WhatsappImageRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappTextRequest.java
@@ -15,10 +15,10 @@
  */
 package com.vonage.client.messages.whatsapp;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.messages.MessageType;
+import com.vonage.client.messages.TextMessageRequest;
 
-public final class WhatsappTextRequest extends WhatsappRequest {
+public final class WhatsappTextRequest extends WhatsappRequest implements TextMessageRequest {
 
 	WhatsappTextRequest(Builder builder) {
 		super(builder, MessageType.TEXT);
@@ -38,7 +38,7 @@ public final class WhatsappTextRequest extends WhatsappRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends WhatsappRequest.Builder<WhatsappTextRequest, Builder> {
+	public static final class Builder extends WhatsappRequest.Builder<WhatsappTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 
 		Builder() {}
 

--- a/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/WhatsappVideoRequest.java
@@ -16,10 +16,11 @@
 package com.vonage.client.messages.whatsapp;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.messages.CaptionMediaMessageRequest;
 import com.vonage.client.messages.internal.MessagePayload;
 import com.vonage.client.messages.MessageType;
 
-public final class WhatsappVideoRequest extends WhatsappRequest {
+public final class WhatsappVideoRequest extends WhatsappRequest implements CaptionMediaMessageRequest {
 
 	WhatsappVideoRequest(Builder builder) {
 		super(builder, MessageType.VIDEO);
@@ -35,7 +36,7 @@ public final class WhatsappVideoRequest extends WhatsappRequest {
 		return new Builder();
 	}
 
-	public static final class Builder extends WhatsappRequest.Builder<WhatsappVideoRequest, Builder> {
+	public static final class Builder extends WhatsappRequest.Builder<WhatsappVideoRequest, Builder> implements CaptionMediaMessageRequest.Builder<Builder> {
 		Builder() {}
 
 		/**

--- a/src/test/java/com/vonage/client/messages/MessagesClientTest.java
+++ b/src/test/java/com/vonage/client/messages/MessagesClientTest.java
@@ -61,6 +61,32 @@ public class MessagesClientTest extends AbstractClientTest<MessagesClient> {
 		stubResponse(202, responseJson);
 		MessageResponse responseObject = client.sendMessage(request);
 		assertEquals(UUID.fromString(MESSAGE_ID), responseObject.getMessageUuid());
+		var messageType = request.getMessageType();
+		var channel = request.getChannel();
+        if (messageType == MessageType.TEXT) {
+            assertInstanceOf(TextMessageRequest.class, request);
+        }
+		else if (channel == Channel.MMS || channel == Channel.RCS || channel == Channel.MESSENGER) {
+			if (messageType != MessageType.CUSTOM) {
+            	assertInstanceOf(MediaMessageRequest.class, request);
+			}
+        }
+		else if (messageType == MessageType.VCARD ||
+				messageType == MessageType.FILE ||
+				messageType == MessageType.VIDEO ||
+				messageType == MessageType.AUDIO ||
+				messageType == MessageType.IMAGE
+		) {
+			if (
+				(channel == Channel.WHATSAPP && messageType == MessageType.AUDIO) ||
+				(channel == Channel.VIBER && (messageType == MessageType.IMAGE || messageType == MessageType.FILE))
+			) {
+				assertInstanceOf(MediaMessageRequest.class, request);
+			}
+			else {
+				assertInstanceOf(CaptionMediaMessageRequest.class, request);
+			}
+		}
 	}
 
 	void assertException(int statusCode, String json) throws Exception {


### PR DESCRIPTION
Adds `MessageRequest.Builder` interfaces for convenience, allowing users to set common properties such as text and URL without having to enumerate every concrete implementation. Useful when working with multiple channels.
