### PR TITLE
feat: Append custom string to User-Agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [8, 17, 22]
+        java: [8, 17, 23]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout the repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [8.11.0] - 2024-09-24
+- Added custom user agent property setting to `HttpConfig`
 - Added RCS channel to Messages API
 - Added `ackInboundMessage` and `revokeOutboundMessage` methods to `MessagesClient`
 - Fixed `viber_service` deserialization in `com.vonage.client.messages.Channel`

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -59,6 +59,11 @@ public class HttpWrapper {
         this(httpConfig, new AuthCollection(authMethods));
     }
 
+    /**
+     * Gets the underlying {@link HttpClient} instance used by the SDK.
+     *
+     * @return The Apache HTTP client instance.
+     */
     public HttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = createHttpClient();
@@ -106,6 +111,11 @@ public class HttpWrapper {
         this.httpConfig = httpConfig;
     }
 
+    /**
+     * Gets the authentication settings used by the client.
+     *
+     * @return The available authentication methods object.
+     */
     public AuthCollection getAuthCollection() {
         return authCollection;
     }
@@ -137,18 +147,43 @@ public class HttpWrapper {
 
         return HttpClientBuilder.create()
                 .setConnectionManager(connectionManager)
-                .setUserAgent(USER_AGENT)
+                .setUserAgent(getUserAgent())
                 .setDefaultRequestConfig(requestConfig)
                 .useSystemProperties()
                 .disableRedirectHandling()
                 .build();
     }
 
+    /**
+     * Gets the HTTP configuration settings for the client.
+     *
+     * @return The request configuration settings object.
+     */
     public HttpConfig getHttpConfig() {
         return httpConfig;
     }
 
+    /**
+     * Gets the {@code User-Agent} header to be used in HTTP requests.
+     * This includes the Java runtime and SDK version, as well as the custom user agent string, if present.
+     *
+     * @return The user agent string.
+     */
     public String getUserAgent() {
-        return USER_AGENT;
+        String ua = USER_AGENT, custom = httpConfig.getCustomUserAgent();
+        if (custom != null) {
+            ua += " " + httpConfig.getCustomUserAgent();
+        }
+        return ua;
+    }
+
+    /**
+     * Gets the SDK version.
+     *
+     * @return The SDK version as a string.
+     * @since 8.11.0
+     */
+    public String getClientVersion() {
+        return CLIENT_VERSION;
     }
 }

--- a/src/test/java/com/vonage/client/HttpConfigTest.java
+++ b/src/test/java/com/vonage/client/HttpConfigTest.java
@@ -110,4 +110,18 @@ public class HttpConfigTest {
             assertEquals(region, ApiRegion.fromString(toString));
         }
     }
+
+    @Test
+    public void testCustomUserAgentValidation() {
+        assertEquals("Abc123", HttpConfig.builder().appendUserAgent(" Abc123\t\n").build().getCustomUserAgent());
+        assertThrows(NullPointerException.class, () ->
+                HttpConfig.builder().appendUserAgent(null).build()
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+                HttpConfig.builder().appendUserAgent("   \t\n").build()
+        );
+        assertThrows(IllegalArgumentException.class, () ->
+                HttpConfig.builder().appendUserAgent("d".repeat(128)).build()
+        );
+    }
 }

--- a/src/test/java/com/vonage/client/HttpWrapperTest.java
+++ b/src/test/java/com/vonage/client/HttpWrapperTest.java
@@ -50,4 +50,21 @@ public class HttpWrapperTest {
         assertNotNull(config);
         HttpConfigTest.assertDefaults(config);
     }
+
+    @Test
+    public void testDefaultUserAgent() {
+        assertNull(wrapper.getHttpConfig().getCustomUserAgent());
+        assertEquals(
+                "vonage-java-sdk/"+wrapper.getClientVersion()+" java/" + System.getProperty("java.version"),
+                wrapper.getUserAgent()
+        );
+    }
+
+    @Test
+    public void testValidCustomUserAgent() {
+        String customUa = "my-custom-agent", defaultUa = wrapper.getUserAgent();
+        wrapper = new HttpWrapper(HttpConfig.builder().appendUserAgent(customUa).build());
+        assertEquals(customUa, wrapper.getHttpConfig().getCustomUserAgent());
+        assertEquals(defaultUa + " " + customUa, wrapper.getUserAgent());
+    }
 }


### PR DESCRIPTION
This PR enables appending to the `User-Agent` header by calling the `appendUserAgent` on `HttpConfig.Builder`.