### PR TITLE
Fix Whatsapp API `latitude` and `longitude` field names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 # [8.12.0] - 2024-10-??
 - Added `network_apis` capability to Application API
 - Added `@JsonCreator` annotation to webhook classes' `fromJson(String)` method
+- Fixed Whatsapp API `latitude` and `longitude` field names
 
 # [8.11.0] - 2024-09-25
 - Added custom user agent property setting to `HttpConfig`

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -37,3 +37,4 @@ documentation, or tests are eligible to be added to this list.
 - Joakim Waltersson ([@jwalter](https://github.com/jwalter))
 - Mofi Rahman ([@moficodes](https://github.com/moficodes))
 - Sina Madani ([@SMadani](https://github.com/SMadani))
+- Jeremy Chan ([@jeremychan](https://github.com/jeremychan))

--- a/src/main/java/com/vonage/client/messages/whatsapp/Location.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/Location.java
@@ -39,12 +39,12 @@ public final class Location extends JsonableBaseObject {
 		address = builder.address;
 	}
 
-	@JsonProperty("lat")
+	@JsonProperty("latitude")
 	public double getLatitude() {
 		return latitude;
 	}
 
-	@JsonProperty("long")
+	@JsonProperty("longitude")
 	public double getLongitude() {
 		return longitude;
 	}


### PR DESCRIPTION
According to the API https://developer.vonage.com/en/messages/code-snippets/whatsapp/send-location for sending location the field names should be "latitude" and "longitude". Currently "lat" and "long" is causing the message to not deliver properly