### PR TITLE
fix: Close HttpResponse in AbstractMethod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.14.0] - 2024-11-??
+- Close HTTP responses to prevent resource leaks
+- Added `RedactResponseException` and deprecated `VonageBadRequestException`
+
 # [8.13.0] - 2024-10-28
 - Added support for Verify custom templates
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.13.1</version>
+  <version>8.14.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.13.1",
+            CLIENT_VERSION = "8.14.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -23,6 +23,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.ConnectionConfig;
 import org.apache.http.config.SocketConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import java.nio.charset.StandardCharsets;
@@ -39,7 +40,7 @@ public class HttpWrapper {
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 
     private AuthCollection authCollection;
-    private HttpClient httpClient;
+    private CloseableHttpClient httpClient;
     private HttpConfig httpConfig;
 
     public HttpWrapper(HttpConfig httpConfig, AuthCollection authCollection) {
@@ -64,7 +65,7 @@ public class HttpWrapper {
      *
      * @return The Apache HTTP client instance.
      */
-    public HttpClient getHttpClient() {
+    public CloseableHttpClient getHttpClient() {
         if (httpClient == null) {
             httpClient = createHttpClient();
         }
@@ -103,7 +104,7 @@ public class HttpWrapper {
 
     @Deprecated
     public void setHttpClient(HttpClient httpClient) {
-        this.httpClient = httpClient;
+        this.httpClient = (CloseableHttpClient) httpClient;
     }
 
     @Deprecated
@@ -125,7 +126,7 @@ public class HttpWrapper {
         this.authCollection = authCollection;
     }
 
-    protected HttpClient createHttpClient() {
+    protected CloseableHttpClient createHttpClient() {
         PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
         connectionManager.setDefaultMaxPerRoute(200);
         connectionManager.setMaxTotal(200);

--- a/src/main/java/com/vonage/client/VonageBadRequestException.java
+++ b/src/main/java/com/vonage/client/VonageBadRequestException.java
@@ -15,6 +15,7 @@
  */
 package com.vonage.client;
 
+@Deprecated
 public class VonageBadRequestException extends VonageClientException {
     public VonageBadRequestException() {
         super();

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -52,7 +52,7 @@ import java.util.UUID;
  * <p>.
  */
 public class VonageClient {
-    private final HttpWrapper httpWrapper;
+    final HttpWrapper httpWrapper;
     private final AccountClient account;
     private final ApplicationClient application;
     private final InsightClient insight;
@@ -76,7 +76,9 @@ public class VonageClient {
 
     private VonageClient(Builder builder) {
         httpWrapper = new HttpWrapper(builder.httpConfig, builder.authCollection);
-        httpWrapper.setHttpClient(builder.httpClient);
+        if (builder.httpClient != null) {
+            httpWrapper.setHttpClient(builder.httpClient);
+        }
 
         account = new AccountClient(httpWrapper);
         application = new ApplicationClient(httpWrapper);
@@ -256,13 +258,6 @@ public class VonageClient {
      */
     public String generateJwt() throws VonageUnacceptableAuthException {
         return httpWrapper.getAuthCollection().getAuth(JWTAuthMethod.class).generateToken();
-    }
-
-    /**
-     * @return The {@link HttpWrapper}
-     */
-    HttpWrapper getHttpWrapper() {
-        return httpWrapper;
     }
 
     /**

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -52,7 +53,11 @@ import java.util.UUID;
  * <p>.
  */
 public class VonageClient {
+    /**
+     * The HTTP wrapper for this client and its sub-clients.
+     */
     final HttpWrapper httpWrapper;
+
     private final AccountClient account;
     private final ApplicationClient application;
     private final InsightClient insight;
@@ -74,6 +79,11 @@ public class VonageClient {
     private final SimSwapClient simSwap;
     private final NumberVerificationClient numberVerification;
 
+    /**
+     * Constructor which uses the builder pattern for instantiation.
+     *
+     * @param builder The builder object to use for configuration.
+     */
     private VonageClient(Builder builder) {
         httpWrapper = new HttpWrapper(builder.httpConfig, builder.authCollection);
         if (builder.httpClient != null) {
@@ -102,45 +112,91 @@ public class VonageClient {
         numberVerification = new NumberVerificationClient(httpWrapper);
     }
 
+    /**
+     * Returns the Account API client.
+     *
+     * @return The {@linkplain AccountClient}.
+     */
     public AccountClient getAccountClient() {
         return account;
     }
 
+    /**
+     * Returns the Application API client.
+     *
+     * @return The {@linkplain ApplicationClient}.
+     */
     public ApplicationClient getApplicationClient() {
         return application;
     }
 
+    /**
+     * Returns the Number Insight API client.
+     *
+     * @return The {@linkplain InsightClient}.
+     */
     public InsightClient getInsightClient() {
         return insight;
     }
 
+    /**
+     * Returns the Numbers API client.
+     *
+     * @return The {@linkplain NumbersClient}.
+     */
     public NumbersClient getNumbersClient() {
         return numbers;
     }
 
+    /**
+     * Returns the SMS API client.
+     *
+     * @return The {@linkplain SmsClient}.
+     */
     public SmsClient getSmsClient() {
         return sms;
     }
 
+    /**
+     * Returns the Verify v1 API client.
+     *
+     * @return The {@linkplain VerifyClient}.
+     */
     public VerifyClient getVerifyClient() {
         return verify;
     }
 
+    /**
+     * Returns the Voice API client.
+     *
+     * @return The {@linkplain VoiceClient}.
+     */
     public VoiceClient getVoiceClient() {
         return voice;
     }
 
+    /**
+     * Returns the Conversion API client.
+     *
+     * @return The {@linkplain ConversionClient}.
+     */
     public ConversionClient getConversionClient() {
         return conversion;
     }
 
+    /**
+     * Returns the Redact API client.
+     *
+     * @return The {@linkplain RedactClient}.
+     */
     public RedactClient getRedactClient() {
         return redact;
     }
 
     /**
+     * Returns the Messages v1 API client.
      *
-     * @return The Messages v1 client.
+     * @return The {@linkplain MessagesClient}.
      * @since 6.5.0
      */
     public MessagesClient getMessagesClient() {
@@ -148,8 +204,9 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Proactive Connect API client.
      *
-     * @return The Proactive Connect client.
+     * @return The {@linkplain ProactiveConnectClient}.
      * @since 7.6.0
      * @deprecated This API is sunset and will be removed in the next major release.
      */
@@ -159,10 +216,10 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Meetings API client.
      *
-     * @return The Meetings client.
+     * @return The {@linkplain MeetingsClient}.
      * @since 7.6.0
-     *
      * @deprecated Support for this API will be removed in the next major release.
      */
     @Deprecated
@@ -171,8 +228,9 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Verify v2 API client.
      *
-     * @return The Verify v2 client.
+     * @return The {@linkplain Verify2Client}.
      * @since 7.4.0
      */
     public Verify2Client getVerify2Client() {
@@ -180,9 +238,9 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Subaccounts API client.
      *
-     *
-     * @return The Subaccounts client.
+     * @return The {@linkplain SubaccountsClient}.
      * @since 7.5.0
      */
     public SubaccountsClient getSubaccountsClient() {
@@ -190,9 +248,9 @@ public class VonageClient {
     }
 
     /**
+     * Returns the Users API client.
      *
-     *
-     * @return The Users client.
+     * @return The {@linkplain UsersClient}.
      * @since 7.7.0
      */
     public UsersClient getUsersClient() {
@@ -200,9 +258,9 @@ public class VonageClient {
     }
 
     /**
-     * Returns the Video client.
+     * Returns the Video API client.
      *
-     * @return The Video API client.
+     * @return The {@linkplain VideoClient}.
      * @since 8.0.0-beta1
      */
     public VideoClient getVideoClient() {
@@ -210,9 +268,9 @@ public class VonageClient {
     }
 
     /**
-     * Returns the Number Insight v2 client.
+     * Returns the Fraud Detection API client.
      *
-     * @return The NI v2 client.
+     * @return The {@linkplain NumberInsight2Client}.
      * @since 8.2.0
      */
     public NumberInsight2Client getNumberInsight2Client() {
@@ -230,9 +288,9 @@ public class VonageClient {
     }
 
     /**
-     * Returns the CAMARA SIM Swap client.
+     * Returns the CAMARA SIM Swap API client.
      *
-     * @return The SIM Swap client.
+     * @return The {@linkplain SimSwapClient}.
      * @since 8.8.0
      */
     public SimSwapClient getSimSwapClient() {
@@ -240,9 +298,9 @@ public class VonageClient {
     }
 
     /**
-     * Returns the CAMARA Number Verification client.
+     * Returns the CAMARA Number Verification API client.
      *
-     * @return The Number Verification client.
+     * @return The {@linkplain NumberVerificationClient}.
      * @since 8.9.0
      */
     public NumberVerificationClient getNumberVerificationClient() {
@@ -269,6 +327,9 @@ public class VonageClient {
         return new Builder();
     }
 
+    /**
+     * Builder for specifying the properties of the client.
+     */
     public static class Builder {
         private AuthCollection authCollection;
         private HttpConfig httpConfig = HttpConfig.defaultConfig();
@@ -279,6 +340,8 @@ public class VonageClient {
         private HashUtil.HashType hashType = HashUtil.HashType.MD5;
 
         /**
+         * Configure the HTTP client parameters.
+         *
          * @param httpConfig Configuration options for the {@link HttpWrapper}.
          *
          * @return This builder.
@@ -289,6 +352,8 @@ public class VonageClient {
         }
 
         /**
+         * Set the underlying HTTP client instance.
+         *
          * @param httpClient Custom implementation of {@link HttpClient}.
          *
          * @return This builder.
@@ -365,8 +430,9 @@ public class VonageClient {
         }
 
         /**
+         * Sets the hash type to use for signing requests.
          *
-         * @param hashType The hashing strategy for signature keys.
+         * @param hashType The hashing strategy for signature keys as an enum.
          *
          * @return This builder.
          */
@@ -433,7 +499,9 @@ public class VonageClient {
         }
 
         /**
-         * @return a new {@link VonageClient} from the stored builder options.
+         * Builds the client with this builder's parameters.
+         *
+         * @return A new {@link VonageClient} from the stored builder options.
          *
          * @throws VonageClientCreationException if credentials aren't provided in a valid pairing or there were issues
          *                                      generating an {@link JWTAuthMethod} with the provided credentials.

--- a/src/main/java/com/vonage/client/VonageResponseParseException.java
+++ b/src/main/java/com/vonage/client/VonageResponseParseException.java
@@ -15,13 +15,16 @@
  */
 package com.vonage.client;
 
-
 /**
  * An exception that indicates the contents of an HttpResponse could not be parsed.
  */
 public class VonageResponseParseException extends VonageUnexpectedException {
     public VonageResponseParseException(String message) {
         this(message, null);
+    }
+
+    public VonageResponseParseException(Throwable ex) {
+        this("Failed to parse the API response.", ex);
     }
 
     public VonageResponseParseException(String message, Throwable t) {

--- a/src/main/java/com/vonage/client/redact/RedactClient.java
+++ b/src/main/java/com/vonage/client/redact/RedactClient.java
@@ -32,10 +32,10 @@ public class RedactClient {
             Endpoint(R... type) {
                 super(DynamicEndpoint.<T, R> builder(type)
                         .wrapper(wrapper).requestMethod(HttpMethod.POST)
-                        .responseExceptionType(VonageBadRequestException.class)
+                        .responseExceptionType(RedactResponseException.class)
                         .authMethod(ApiKeyHeaderAuthMethod.class)
                         .pathGetter((de, req) -> de.getHttpWrapper().getHttpConfig()
-                                .getVersionedApiBaseUri("v1") + "/redact/transaction"
+                                .getApiBaseUri() + "/v1/redact/transaction"
                         )
                 );
             }

--- a/src/main/java/com/vonage/client/redact/RedactResponseException.java
+++ b/src/main/java/com/vonage/client/redact/RedactResponseException.java
@@ -1,0 +1,42 @@
+/*
+ *   Copyright 2024 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.redact;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.vonage.client.VonageApiResponseException;
+
+/**
+ * Response returned when an error is encountered (i.e. the API returns a non-2xx status code).
+ *
+ * @since 8.14.0
+ */
+public final class RedactResponseException extends VonageApiResponseException {
+
+	void setStatusCode(int statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	/**
+	 * Creates an instance of this class from a JSON payload.
+	 *
+	 * @param json The JSON string to parse.
+	 * @return An instance of this class with all known fields populated from the JSON payload, if present.
+	 */
+	@JsonCreator
+	public static RedactResponseException fromJson(String json) {
+		return fromJson(RedactResponseException.class, json);
+	}
+}

--- a/src/test/java/com/vonage/client/TestUtils.java
+++ b/src/test/java/com/vonage/client/TestUtils.java
@@ -23,8 +23,10 @@ import com.vonage.client.auth.hashutils.HashUtil;
 import org.apache.http.*;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import static org.junit.jupiter.api.Assertions.*;
@@ -159,15 +161,15 @@ public class TestUtils {
 
 
     // TODO make package-private after removing Meetings
-    public static HttpClient stubHttpClient(int statusCode) throws Exception {
+    public static CloseableHttpClient stubHttpClient(int statusCode) throws Exception {
         return stubHttpClient(statusCode, "");
     }
 
     // TODO make package-private after removing Meetings
-    public static HttpClient stubHttpClient(int statusCode, String content, String... additionalReturns) throws Exception {
-        HttpClient result = mock(HttpClient.class);
+    public static CloseableHttpClient stubHttpClient(int statusCode, String content, String... additionalReturns) throws Exception {
+        CloseableHttpClient result = mock(CloseableHttpClient.class);
 
-        HttpResponse response = mock(HttpResponse.class);
+        CloseableHttpResponse response = mock(CloseableHttpResponse.class);
         StatusLine sl = mock(StatusLine.class);
         HttpEntity entity = mock(HttpEntity.class);
 

--- a/src/test/java/com/vonage/client/VonageClientTest.java
+++ b/src/test/java/com/vonage/client/VonageClientTest.java
@@ -134,7 +134,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
     @Test
     public void testApiKeyWithSecret() throws VonageUnacceptableAuthException {
         VonageClient vonageClient = VonageClient.builder().apiKey("api-key").apiSecret("api-secret").build();
-        AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
+        AuthCollection authCollection = vonageClient.httpWrapper.getAuthCollection();
         assertTrue(authCollection.hasAuthMethod(ApiKeyHeaderAuthMethod.class));
     }
 
@@ -144,7 +144,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
             var vonageClient = VonageClient.builder()
                     .apiKey(API_KEY).signatureSecret(SIGNATURE_SECRET).hashType(hashType).build();
 
-            var sigAuthMethod = vonageClient.getHttpWrapper().getAuthCollection().getAuth(SignatureAuthMethod.class);
+            var sigAuthMethod = vonageClient.httpWrapper.getAuthCollection().getAuth(SignatureAuthMethod.class);
             var params = sigAuthMethod.getAuthParams(new RequestQueryParams());
 
             // This is messy but trying to generate a signature auth method and then comparing with
@@ -169,7 +169,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
                 .privateKeyContents(keyBytes)
                 .build();
 
-        AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
+        AuthCollection authCollection = vonageClient.httpWrapper.getAuthCollection();
         assertTrue(authCollection.hasAuthMethod(JWTAuthMethod.class));
     }
 
@@ -179,7 +179,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
         String key = new String(testUtils.loadKey("test/keys/application_key"));
 
         VonageClient vonageClient = VonageClient.builder().applicationId(APPLICATION_ID_STR).privateKeyContents(key).build();
-        AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
+        AuthCollection authCollection = vonageClient.httpWrapper.getAuthCollection();
         assertTrue(authCollection.hasAuthMethod(JWTAuthMethod.class));
     }
 
@@ -189,7 +189,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
                 .applicationId(APPLICATION_ID_STR)
                 .privateKeyPath(privateKeyPath)
                 .build();
-        AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
+        AuthCollection authCollection = vonageClient.httpWrapper.getAuthCollection();
         assertTrue(authCollection.hasAuthMethod(JWTAuthMethod.class));
     }
 
@@ -199,7 +199,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
                 .applicationId(APPLICATION_ID)
                 .privateKeyPath(privateKeyPath)
                 .build();
-        AuthCollection authCollection = vonageClient.getHttpWrapper().getAuthCollection();
+        AuthCollection authCollection = vonageClient.httpWrapper.getAuthCollection();
         assertTrue(authCollection.hasAuthMethod(JWTAuthMethod.class));
     }
 
@@ -215,8 +215,8 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
         HttpConfig config = HttpConfig.defaultConfig();
         VonageClient vonageClient = VonageClient.builder().build();
 
-        assertEquals(config.getApiBaseUri(), vonageClient.getHttpWrapper().getHttpConfig().getApiBaseUri());
-        assertEquals(config.getRestBaseUri(), vonageClient.getHttpWrapper().getHttpConfig().getRestBaseUri());
+        assertEquals(config.getApiBaseUri(), vonageClient.httpWrapper.getHttpConfig().getApiBaseUri());
+        assertEquals(config.getRestBaseUri(), vonageClient.httpWrapper.getHttpConfig().getRestBaseUri());
     }
 
     @Test
@@ -224,7 +224,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
         HttpConfig config = HttpConfig.builder().apiBaseUri("https://example.org").build();
         VonageClient vonageClient = VonageClient.builder().httpConfig(config).build();
 
-        assertEquals(config, vonageClient.getHttpWrapper().getHttpConfig());
+        assertEquals(config, vonageClient.httpWrapper.getHttpConfig());
     }
 
     @Test

--- a/src/test/java/com/vonage/client/VonageClientTest.java
+++ b/src/test/java/com/vonage/client/VonageClientTest.java
@@ -21,14 +21,12 @@ import com.vonage.client.auth.hashutils.HashUtil;
 import com.vonage.client.voice.Call;
 import com.vonage.client.voice.CallEvent;
 import com.vonage.client.voice.CallStatus;
-import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyFactory;
-import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 
 public class VonageClientTest extends AbstractClientTest<VonageClient> {
@@ -89,11 +87,11 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
         String constructedToken = client.generateJwt();
 
         byte[] publicKeyBytes = testUtils.loadKey("test/keys/application_public_key.der");
-        X509EncodedKeySpec spec = new X509EncodedKeySpec(publicKeyBytes);
-        KeyFactory kf = KeyFactory.getInstance("RSA");
-        PublicKey key = kf.generatePublic(spec);
+        var spec = new X509EncodedKeySpec(publicKeyBytes);
+        var keyFactory = KeyFactory.getInstance("RSA");
+        var key = keyFactory.generatePublic(spec);
 
-        Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(constructedToken).getPayload();
+        var claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(constructedToken).getPayload();
 
         assertEquals(APPLICATION_ID_STR, claims.get("application_id"));
     }

--- a/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
+++ b/src/test/java/com/vonage/client/auth/AuthCollectionTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import java.util.Collections;
 import java.util.Set;
-import java.util.UUID;
 
 public class AuthCollectionTest {
     private static final Set<Class<? extends AuthMethod>>

--- a/src/test/java/com/vonage/client/redact/RedactClientTest.java
+++ b/src/test/java/com/vonage/client/redact/RedactClientTest.java
@@ -18,14 +18,13 @@ package com.vonage.client.redact;
 import com.vonage.client.AbstractClientTest;
 import com.vonage.client.DynamicEndpointTestSpec;
 import com.vonage.client.RestEndpoint;
-import com.vonage.client.VonageBadRequestException;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.common.HttpMethod;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.*;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
 public class RedactClientTest extends AbstractClientTest<RedactClient> {
 
@@ -61,11 +60,11 @@ public class RedactClientTest extends AbstractClientTest<RedactClient> {
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         stubResponseAndAssertThrows(401, () ->
                 client.redactTransaction(redactRequest),
-                VonageBadRequestException.class
+                RedactResponseException.class
         );
         stubResponseAndAssertThrows(401, () ->
                 client.redactTransaction(redactRequest.getId(), redactRequest.getProduct()),
-                VonageBadRequestException.class
+                RedactResponseException.class
         );
     }
 
@@ -73,11 +72,11 @@ public class RedactClientTest extends AbstractClientTest<RedactClient> {
     public void testPrematureRedactionOrUnauthorized() throws Exception {
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         stubResponseAndAssertThrows(403, () ->
-                client.redactTransaction(redactRequest), VonageBadRequestException.class
+                client.redactTransaction(redactRequest), RedactResponseException.class
         );
         stubResponseAndAssertThrows(403, () ->
                 client.redactTransaction(redactRequest.getId(), redactRequest.getProduct()),
-                VonageBadRequestException.class
+                RedactResponseException.class
         );
     }
 
@@ -85,11 +84,11 @@ public class RedactClientTest extends AbstractClientTest<RedactClient> {
     public void testInvalidId() throws Exception {
         RedactRequest redactRequest = new RedactRequest("test-id", RedactRequest.Product.VOICE);
         stubResponseAndAssertThrows(404, () ->
-                client.redactTransaction(redactRequest), VonageBadRequestException.class
+                client.redactTransaction(redactRequest), RedactResponseException.class
         );
         stubResponseAndAssertThrows(404, () ->
                 client.redactTransaction(redactRequest.getId(), redactRequest.getProduct()),
-                VonageBadRequestException.class
+                RedactResponseException.class
         );
     }
 
@@ -109,12 +108,12 @@ public class RedactClientTest extends AbstractClientTest<RedactClient> {
 
             @Override
             protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-                return Arrays.asList(ApiKeyHeaderAuthMethod.class);
+                return List.of(ApiKeyHeaderAuthMethod.class);
             }
 
             @Override
             protected Class<? extends Exception> expectedResponseExceptionType() {
-                return VonageBadRequestException.class;
+                return RedactResponseException.class;
             }
 
             @Override


### PR DESCRIPTION
This PR refactors `HttpWrapper` to use `CloseableHttpClient` instead, so that when parsing responses in the `AbstractMethod#execute` method, the response can be tidied up using try-with-resources so that there are no potential resource leaks.
