### PR TITLE
feat: Add support for proxies in HttpConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.15.0] - 2024-12-03
+- Added proxy support to `HttpConfig.Builder`
+- Basic auth in header instead of query params in SMS API
+
 # [8.14.0] - 2024-11-14
 - Close HTTP responses to prevent resource leaks
 - Added `RedactResponseException` and deprecated `VonageBadRequestException`

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.14.0</version>
+  <version>8.15.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -17,6 +17,7 @@ package com.vonage.client;
 
 import com.vonage.client.auth.*;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -71,7 +72,7 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
     @Override
     public ResultT execute(RequestT request) throws VonageResponseParseException, VonageClientException {
         HttpUriRequest httpRequest = applyAuth(makeRequest(request))
-                .setHeader("User-Agent", httpWrapper.getUserAgent())
+                .setHeader(HttpHeaders.USER_AGENT, httpWrapper.getUserAgent())
                 .setCharset(StandardCharsets.UTF_8).build();
 
         try (CloseableHttpResponse response = httpWrapper.getHttpClient().execute(httpRequest)) {

--- a/src/main/java/com/vonage/client/HttpConfig.java
+++ b/src/main/java/com/vonage/client/HttpConfig.java
@@ -210,7 +210,7 @@ public class HttpConfig {
         }
 
         /**
-         * Sets the proxy to use for requests.
+         * Sets the proxy to use for requests. This will route requests through the specified URL.
          *
          * @param proxy The proxy URI to use as a string.
          * @return This builder.
@@ -222,7 +222,7 @@ public class HttpConfig {
         }
 
         /**
-         * Sets the proxy to use for requests.
+         * Sets the proxy to use for requests. This will route requests through the specified URL.
          *
          * @param proxy The proxy URI to use.
          * @return This builder.

--- a/src/main/java/com/vonage/client/HttpConfig.java
+++ b/src/main/java/com/vonage/client/HttpConfig.java
@@ -29,11 +29,13 @@ public class HttpConfig {
     private final int timeoutMillis;
     private final String customUserAgent, apiBaseUri, restBaseUri, apiEuBaseUri, videoBaseUri;
     private final Function<ApiRegion, String> regionalUriGetter;
+    private final URI proxy;
 
     private HttpConfig(Builder builder) {
         if ((timeoutMillis = builder.timeoutMillis) < 10) {
             throw new IllegalArgumentException("Timeout must be greater than 10ms.");
         }
+        proxy = builder.proxy;
         apiBaseUri = builder.apiBaseUri;
         restBaseUri = builder.restBaseUri;
         videoBaseUri = builder.videoBaseUri;
@@ -87,6 +89,16 @@ public class HttpConfig {
      */
     public String getCustomUserAgent() {
         return customUserAgent;
+    }
+
+    /**
+     * Returns the proxy URL to use for the underlying HTTP client configuration.
+     *
+     * @return The proxy URI, or {@code null} if not set.
+     * @since 8.15.0
+     */
+    public URI getProxy() {
+        return proxy;
     }
 
     @Deprecated
@@ -156,6 +168,7 @@ public class HttpConfig {
      */
     public static class Builder {
         private int timeoutMillis = 60_000;
+        private URI proxy;
         private Function<ApiRegion, String> regionalUriGetter = region -> "https://"+region+".vonage.com";
         private String customUserAgent,
                 apiBaseUri = DEFAULT_API_BASE_URI,
@@ -193,6 +206,30 @@ public class HttpConfig {
          */
         public Builder timeoutMillis(int timeoutMillis) {
             this.timeoutMillis = timeoutMillis;
+            return this;
+        }
+
+        /**
+         * Sets the proxy to use for requests.
+         *
+         * @param proxy The proxy URI to use as a string.
+         * @return This builder.
+         * @since 8.15.0
+         * @throws IllegalArgumentException If the proxy URI is invalid.
+         */
+        public Builder proxy(String proxy) {
+            return proxy(URI.create(proxy));
+        }
+
+        /**
+         * Sets the proxy to use for requests.
+         *
+         * @param proxy The proxy URI to use.
+         * @return This builder.
+         * @since 8.15.0
+         */
+        public Builder proxy(URI proxy) {
+            this.proxy = proxy;
             return this;
         }
 

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.14.0",
+            CLIENT_VERSION = "8.15.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 


### PR DESCRIPTION
This PR allows users to set a proxy URL without needing to use the deprecated `VonageClient.Builder#httpClient` method. This can instead be configured directly in `HttpConfig` without exposing details of the underlying HTTP client implementation.