### PR TITLE
fix: Relax downloadRecording validation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 src/test/resources/com/vonage/client/test/keys/application_key binary
 src/test/resources/com/vonage/client/test/keys/application_key2 binary
+*.sh linguist-vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.15.1] - 2024-12-19
+- Removed hardcoded domain validation from `VoiceClient.downloadRecordingRaw`
+
 # [8.15.0] - 2024-12-03
 - Added proxy support to `HttpConfig.Builder`
 - Basic auth in header instead of query params in SMS API

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.15.0</version>
+  <version>8.15.1</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.11.3</version>
+      <version>5.11.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -228,7 +228,7 @@
 
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.1</version>
+        <version>3.11.2</version>
         <configuration>
           <linksource>true</linksource>
         </configuration>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.15.0",
+            CLIENT_VERSION = "8.15.1",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/voice/VoiceClient.java
+++ b/src/main/java/com/vonage/client/voice/VoiceClient.java
@@ -532,12 +532,7 @@ public class VoiceClient {
      * @since 7.11.0
      */
     public byte[] downloadRecordingRaw(String recordingUrl) {
-        if (validateUrl(recordingUrl).contains(".nexmo.com/v1/files")) {
-            return downloadRecording.execute(recordingUrl);
-        }
-        else {
-            throw new IllegalArgumentException("Invalid recording URL");
-        }
+        return downloadRecording.execute(validateUrl(recordingUrl));
     }
 
     /**

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -408,7 +408,7 @@ public class VoiceClientTest extends AbstractClientTest<VoiceClient> {
         String recordingId = UUID.randomUUID().toString();
         String content = "<BINARY>";
         stubResponse(200, content);
-        String url = "https://api.nexmo.com/v1/files/" + recordingId;
+        String url = "https://api-eu.vonage.com/v1/files/" + recordingId;
         Path temp = Files.createTempFile(null, null);
         Files.delete(temp);
 
@@ -422,23 +422,11 @@ public class VoiceClientTest extends AbstractClientTest<VoiceClient> {
         assertArrayEquals(content.getBytes(), Files.readAllBytes(recordingPath));
 
         stubResponseAndAssertThrows(content, () ->
-                client.saveRecording("ftp:///myserver.co.uk/rec.mp3", recordingPath),
-                IllegalArgumentException.class
-        );
-        stubResponseAndAssertThrows(content, () ->
-                client.saveRecording("http://example.org/recording.wav", recordingPath),
-                IllegalArgumentException.class
-        );
-        stubResponseAndAssertThrows(content, () ->
-                client.saveRecording("https://example.org/recording.wav", recordingPath),
-                IllegalArgumentException.class
-        );
-        stubResponseAndAssertThrows(content, () ->
                 client.saveRecording(url, null),
                 NullPointerException.class
         );
         stubResponseAndAssertThrows(content, () ->
-                client.saveRecording("not-a-url", recordingPath),
+                client.saveRecording(";not_a url£", recordingPath),
                 IllegalArgumentException.class
         );
     }


### PR DESCRIPTION
Removes unnecessary validation of the URL domain in the `downloadRecording` method of Voice API implementation.