### PR TITLE
docs: Improve SMS API javadocs

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,9 +12,9 @@ on:
   schedule:
     - cron: '16 23 * * 2'
   push:
-    branches: [ 'main' ]
+    branches:
+      - main
 
-# Declare default permissions as read only.
 permissions: read-all
 
 jobs:
@@ -22,13 +22,8 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
       security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
       id-token: write
-      # Uncomment the permissions below if installing in a private repository.
-      # contents: read
-      # actions: read
 
     steps:
       - name: Checkout code
@@ -47,13 +42,6 @@ jobs:
           # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action?tab=readme-ov-file#authentication-with-fine-grained-pat-optional.
           # repo_token: ${{ secrets.SCORECARD_TOKEN }}
 
-          # Public repositories:
-          #   - Publish results to OpenSSF REST API for easy access by consumers
-          #   - Allows the repository to include the Scorecard badge.
-          #   - See https://github.com/ossf/scorecard-action#publishing-results.
-          # For private repositories:
-          #   - `publish_results` will always be set to `false`, regardless
-          #     of the value entered here.
           publish_results: true
 
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF

--- a/pom.xml
+++ b/pom.xml
@@ -76,11 +76,6 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>
     </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.17.1</version>
-    </dependency>
 
     <!-- Tests -->
     <dependency>
@@ -99,6 +94,12 @@
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <version>4.0.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.17.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/vonage/client/sms/MessageStatus.java
+++ b/src/main/java/com/vonage/client/sms/MessageStatus.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
  * <a href=https://developer.vonage.com/api-errors/sms>the documentation</a> for more details.
  */
 public enum MessageStatus {
+
     /**
      * A status of zero does not indicate that Vonage delivered your message. Instead, this
      * status indicates the absence of an error - i.e. the REST call succeeded.
@@ -193,6 +194,11 @@ public enum MessageStatus {
         this.messageStatus = messageStatus;
     }
 
+    /**
+     * Gets the message status as an int.
+     *
+     * @return The message status code.
+     */
     @JsonValue
     public int getMessageStatus() {
         return messageStatus;

--- a/src/main/java/com/vonage/client/sms/MessageType.java
+++ b/src/main/java/com/vonage/client/sms/MessageType.java
@@ -26,6 +26,13 @@ import com.fasterxml.jackson.annotation.JsonValue;
 public enum MessageType {
     TEXT, UNICODE, BINARY, UNKNOWN;
 
+    /**
+     * Convert a string value to a MessageType enum.
+     *
+     * @param name The string value to convert.
+     *
+     * @return The message type as an enum.
+     */
     @JsonCreator
     public static MessageType fromString(String name) {
         try {

--- a/src/main/java/com/vonage/client/sms/SmsClient.java
+++ b/src/main/java/com/vonage/client/sms/SmsClient.java
@@ -17,7 +17,6 @@ package com.vonage.client.sms;
 
 import com.vonage.client.*;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
 import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import com.vonage.client.sms.messages.Message;

--- a/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
+++ b/src/main/java/com/vonage/client/sms/SmsSubmissionResponse.java
@@ -20,11 +20,19 @@ import com.vonage.client.Jsonable;
 import com.vonage.client.JsonableBaseObject;
 import java.util.List;
 
+/**
+ * Represents the response from the SMS API when a request is made to submit a message.
+ * Since a message may be split into multiple parts, the response metadata for each individual SMS
+ * can be retrieved from the {@link #getMessages()} method, which returns a list of
+ * {@link SmsSubmissionResponseMessage} for each corresponding message that was submitted.
+ */
 public class SmsSubmissionResponse extends JsonableBaseObject {
     private int messageCount;
     private List<SmsSubmissionResponseMessage> messages;
 
     /**
+     * Default constructor.
+     *
      * @deprecated This will be made private in the next major release.
      */
     @Deprecated

--- a/src/main/java/com/vonage/client/sms/SmsSubmissionResponseMessage.java
+++ b/src/main/java/com/vonage/client/sms/SmsSubmissionResponseMessage.java
@@ -19,13 +19,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.JsonableBaseObject;
 import java.math.BigDecimal;
 
+/**
+ * Represents the API response for a single SMS submission.
+ */
 public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     private MessageStatus status;
     private String to, id, network, errorText, clientRef, accountRef;
     private BigDecimal remainingBalance, messagePrice;
 
     /**
-     * @return The number the message was sent to. Numbers are specified in E.164 format.
+     * The number the message was sent to.
+     *
+     * @return The receiving number in E.164 format.
      */
     @JsonProperty("to")
     public String getTo() {
@@ -33,7 +38,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return The ID of the message.
+     * ID of the message.
+     *
+     * @return The message ID as a string.
      */
     @JsonProperty("message-id")
     public String getId() {
@@ -41,9 +48,11 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return The status of the message. A non-zero code (i.e. anything that isn't
-     * {@link MessageStatus#OK} indicates an error. See
-     * <a href=https://developer.vonage.com/messaging/sms/guides/troubleshooting-sms>Troubleshooting Failed SMS</a>.
+     * Status of the message. A non-zero code (i.e. anything that isn't {@link MessageStatus#OK}) indicates an
+     * error. See <a href=https://developer.vonage.com/messaging/sms/guides/troubleshooting-sms>
+     * Troubleshooting Failed SMS</a> for more details.
+     *
+     * @return The message status as an enum.
      */
     @JsonProperty("status")
     public MessageStatus getStatus() {
@@ -51,7 +60,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return The description of the error, if present.
+     * Error description, if present.
+     *
+     * @return The description of the error, or {@code null} if not applicable.
      */
     @JsonProperty("error-text")
     public String getErrorText() {
@@ -59,7 +70,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return Your estimated remaining balance.
+     * Estimated account remaining balance.
+     *
+     * @return The remaining balance as a {@link BigDecimal}.
      */
     @JsonProperty("remaining-balance")
     public BigDecimal getRemainingBalance() {
@@ -67,7 +80,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return The estimated cost of the message.
+     * Estimated cost of the message.
+     *
+     * @return The message price as a {@link BigDecimal}.
      */
     @JsonProperty("message-price")
     public BigDecimal getMessagePrice() {
@@ -75,7 +90,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return The estimated ID of the network of the recipient.
+     * Estimated ID of the network of the recipient.
+     *
+     * @return The recipient's network ID as a string, or {@code null} if unknown.
      */
     @JsonProperty("network")
     public String getNetwork() {
@@ -83,8 +100,9 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * @return If a client-ref was included when sending the SMS,
-     * this field will be included and hold the value that was sent.
+     * If a client-ref was included when sending the SMS, this field will be the value that was sent.
+     *
+     * @return The reference associated with the message as a string, or {@code null} if there wasn't one set.
      */
     @JsonProperty("client-ref")
     public String getClientRef() {
@@ -92,15 +110,21 @@ public class SmsSubmissionResponseMessage extends JsonableBaseObject {
     }
 
     /**
-     * This is an advanced feature and requires activation via a support request before it can be used.
+     * Account reference. An optional string used to identify separate accounts using the SMS endpoint for billing
+     * purposes. This is an advanced feature and requires activation via a support request before it can be used.
      *
-     * @return An optional string used to identify separate accounts using the SMS endpoint for billing purposes.
+     * @return The account reference, or {@code null} if not applicable.
      */
     @JsonProperty("account-ref")
     public String getAccountRef() {
         return accountRef;
     }
 
+    /**
+     * Convenience method for checking if the message status indicates a temporary error.
+     *
+     * @return {@code true} if the status is a temporary error, {@code false} otherwise.
+     */
     public boolean isTemporaryError() {
         return status == MessageStatus.INTERNAL_ERROR || status == MessageStatus.TOO_MANY_BINDS
                 || status == MessageStatus.THROTTLED;

--- a/src/main/java/com/vonage/client/sms/messages/BinaryMessage.java
+++ b/src/main/java/com/vonage/client/sms/messages/BinaryMessage.java
@@ -15,7 +15,7 @@
  */
 package com.vonage.client.sms.messages;
 
-import org.apache.commons.codec.binary.Hex;
+import java.util.Formatter;
 import java.util.Map;
 
 /**
@@ -26,7 +26,7 @@ public class BinaryMessage extends Message {
     private int protocolId = 0;
 
     /**
-     * Instantiate a new binary sms message request.
+     * Instantiate a new binary SMS message request.
      *
      * @param from              the 'from' address that will be seen on the handset when this message arrives,
      *                          typically either a valid short-code / long code that can be replied to, or a short text description of the application sending the message (Max 11 chars)
@@ -51,32 +51,44 @@ public class BinaryMessage extends Message {
     }
 
     /**
-     * @return byte[] The raw binary message data to be sent to a handset.
-     * This api, and the Vonage sms service will send this data 'as-is' (in conjunction with the binary UDH) and will not make any corrections.
-     * so you should ensure that it is a correctly constructed message
+     * The raw binary message data to be sent to a handset. The Vonage SMS service will send this data 'as-is'
+     * (in conjunction with the binary UDH) and will not make any corrections, so you should ensure that it is correct.
+     *
+     * @return The message body as a byte array.
      */
     public byte[] getMessageBody() {
         return messageBody == null ? null : messageBody.clone();
     }
 
     /**
-     * @return byte[] Most binary content will require a UserDataHeader portion of the message containing commands to enable the handset to interpret the binary data
-     * (for example, a binary ringtone, a wap-push, OverTheAir configuration, etc.).
-     * Additionally, if you are sending a long text message as multiple concatenated messages and are performing this operation manually rather than
-     * using the automated long sms handling in the Vonage sms service, then you will need to construct and include here an appropriate
-     * UserDataHeader field that describes the segmentation/re-assembly fields required to successfully concatenate multiple short messages.
+     * Most binary content will require a UserDataHeader portion of the message containing commands to enable the
+     * handset to interpret the binary data (for example, a binary ringtone, a WAP-push, OverTheAir configuration, etc.).
+     * Additionally, if you are sending a long text message as multiple concatenated messages and are performing this
+     * operation manually rather than using the automated long sms handling in the Vonage SMS service, then you will
+     * need to construct and include here an appropriate UserDataHeader field that describes the segmentation /
+     * re-assembly fields required to successfully concatenate multiple short messages.
+     *
+     * @return The User Data Header as a byte array.
      */
     public byte[] getUdh() {
         return udh == null ? null : udh.clone();
     }
 
     /**
-     * @return Integer The value of the GSM Protocol ID field to be submitted with this message. Ordinarily this should be left as the default value of 0
+     * The value of the GSM Protocol ID field to be submitted with this message.
+     * Ordinarily this should be left as the default value of 0.
+     *
+     * @return The protocol ID.
      */
     public int getProtocolId() {
         return protocolId;
     }
 
+    /**
+     * Sets the protocol ID for this message.
+     *
+     * @param protocolId The protocol ID.
+     */
     public void setProtocolId(int protocolId) {
         this.protocolId = protocolId;
     }
@@ -84,9 +96,18 @@ public class BinaryMessage extends Message {
     @Override
     public Map<String, String> makeParams() {
         Map<String, String> params = super.makeParams();
-        params.put("udh", Hex.encodeHexString(getUdh()));
-        params.put("body", Hex.encodeHexString(getMessageBody()));
+        params.put("udh", toHexString(getUdh()));
+        params.put("body", toHexString(getMessageBody()));
         params.put("protocol-id", Integer.toString(getProtocolId()));
         return params;
+    }
+
+    private static String toHexString(byte[] data) {
+        StringBuilder sb = new StringBuilder(data.length * 2);
+        Formatter formatter = new Formatter(sb);
+        for (byte b : data) {
+            formatter.format("%02x", b);
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/com/vonage/client/sms/messages/Message.java
+++ b/src/main/java/com/vonage/client/sms/messages/Message.java
@@ -24,23 +24,29 @@ import java.util.Map;
  * Represents the details common to any message that is to be submitted to the Vonage SMS API.
  */
 public abstract class Message implements QueryParamsRequest {
+
+    /**
+     * Represents the type of message.
+     */
     public enum MessageType {
         /**
-         * Message is a regular TEXT SMS message
+         * Regular text SMS message.
          */
         TEXT,
+
         /**
-         * Message is a binary SMS message with a custom UDH and binary payload
+         * Binary SMS message with a custom UDH and binary payload.
          */
         BINARY,
+
         /**
-         * Message is a unicode message, for sending messages in non-latin script to a supported handset
+         * Unicode message, for sending messages in non-latin script to a supported handset.
          */
         UNICODE;
 
         @Override
         public String toString() {
-            return super.toString().toLowerCase();
+            return name().toLowerCase();
         }
     }
 
@@ -60,15 +66,15 @@ public abstract class Message implements QueryParamsRequest {
     /**
      * Abstract type for more specific SMS message types.<br>
      * This constructor exposes the full range of possible parameters and is not for general use
-     * Instead, it is accessed via super() in the constructors of various sub-classes that expose a relevant
-     * sub-set of the available parameters
+     * Instead, it is accessed via super() in the constructors of various subclasses that expose a relevant
+     * sub-set of the available parameters.
      *
-     * @param type the type of SMS message to be sent
+     * @param type the type of SMS message to be sent.
      * @param from the 'from' address that will be seen on the handset when this message arrives, typically either a
      *             valid short-code / long code that can be replied to, or a short text description of the application
-     *             sending the message (Max 15 chars)
-     * @param to   the phone number of the handset you wish to send the message to
-     * @param statusReportRequired flag to enable status updates about the delivery of this message
+     *             sending the message (Max 15 chars).
+     * @param to   the phone number of the handset you wish to send the message to.
+     * @param statusReportRequired flag to enable status updates about the delivery of this message.
      */
     protected Message(final MessageType type,
                       final String from,
@@ -81,35 +87,51 @@ public abstract class Message implements QueryParamsRequest {
     }
 
     /**
-     * @return int the type of message will influence the makeup of the request we post to the Vonage server, and also the action taken by the Vonage server in response to this message
+     * The type of message will influence the makeup of the request we post to the Vonage server, and also the
+     * action taken by the Vonage server in response to this message.
+     *
+     * @return The message type as an enum.
      */
     public MessageType getType() {
         return type;
     }
 
     /**
-     * @return String the 'from' address that will be seen on the handset when this message arrives,
-     * typically either a valid short-code / long code that can be replied to, or a short text description of the application sending the message (Max 11 chars)
+     * The 'from' address that will be seen on the handset when this message arrives, typically either
+     * valid short-code / long code that can be replied to, or a short text description of the application
+     * sending the message (maximum 11 characters).
+     *
+     * @return The message sender ID or number as a string.
      */
     public String getFrom() {
         return from;
     }
 
     /**
-     * @return String the phone number of the handset that you wish to send the message to
+     * The phone number of the handset that you wish to send the message to.
+     *
+     * @return The recipient phone number as a string, in E.164 format.
      */
     public String getTo() {
         return to;
     }
 
     /**
-     * @return String A user definable value that will be stored in the Vonage sms records. It will
-     * be available in detailed reporting and analytics in order to help with reconciliation of messages
+     * An optional user definable value that will be stored in the Vonage SMS records. It will be available
+     * in detailed reporting and analytics in order to help with reconciliation of messages.
+     *
+     * @return The client reference as a string, or {@code null} if unspecified.
      */
     public String getClientReference() {
         return clientReference;
     }
 
+    /**
+     * Sets the client reference for this message.
+     *
+     * @param clientReference The custom message reference, maximum 40 characters.
+     * @throws IllegalArgumentException if the client reference is longer than 40 characters.
+     */
     public void setClientReference(String clientReference) {
         if (clientReference.length() > 40) {
             throw new IllegalArgumentException("Client reference must be 40 characters or less.");
@@ -118,63 +140,116 @@ public abstract class Message implements QueryParamsRequest {
     }
 
     /**
-     * @return {@link MessageClass} The message class that is to be applied to this message.
+     * The message class that is to be applied to this message.
+     *
+     * @return The message class as an enum.
      */
     public MessageClass getMessageClass() {
         return messageClass;
     }
 
+    /**
+     * Set the message class for this message.
+     *
+     * @param messageClass The message class as an enum.
+     */
     public void setMessageClass(MessageClass messageClass) {
         this.messageClass = messageClass;
     }
 
+    /**
+     * The duration in milliseconds the delivery of an SMS will be attempted. By default, Vonage attempts
+     * delivery for 72 hours, however the maximum effective value depends on the operator and is typically 24 - 48
+     * hours. We recommend this value should be kept at its default or at least 30 minutes.
+     *
+     * @return The message TTL in milliseconds, or {@code null} if unspecified (the default).
+     */
     public Long getTimeToLive() {
         return timeToLive;
     }
 
+    /**
+     * The duration in milliseconds the delivery of an SMS will be attempted. By default, Vonage attempts
+     * delivery for 72 hours, however the maximum effective value depends on the operator and is typically 24 - 48
+     * hours. We recommend this value should be kept at its default or at least 30 minutes.
+     *
+     * @param timeToLive The message TTL in milliseconds.
+     */
     public void setTimeToLive(Long timeToLive) {
         this.timeToLive = timeToLive;
     }
 
+    /**
+     * The webhook endpoint the delivery receipt for this SMS is sent to. This parameter overrides the webhook
+     * endpoint you set in the Dashboard. Maximum 100 characters.
+     *
+     * @return The callback URL as a string, or {@code null} if unspecified (the default).
+     */
     public String getCallbackUrl() {
         return callbackUrl;
     }
 
+    /**
+     * The webhook endpoint the delivery receipt for this SMS is sent to. This parameter overrides the webhook
+     * endpoint you set in the Dashboard. Maximum 100 characters.
+     *
+     * @param callbackUrl The callback URL to send the delivery receipt to for this message.
+     */
     public void setCallbackUrl(String callbackUrl) {
         this.callbackUrl = callbackUrl;
     }
 
+    /**
+     * A parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+     *
+     * @return The entity ID as a string, or {@code null} if unspecified.
+     */
     public String getEntityId() {
         return entityId;
     }
 
+    /**
+     * Sets a parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+     *
+     * @param entityId The entity ID as a string.
+     */
     public void setEntityId(String entityId) {
         this.entityId = entityId;
     }
 
+    /**
+     * A parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+     *
+     * @return The content ID as a string, or {@code null} if unspecified.
+     */
     public String getContentId() {
         return contentId;
     }
 
+    /**
+     * Sets a parameter that satisfies regulatory requirements when sending an SMS to specific countries.
+     *
+     * @param contentId The content ID as a string.
+     */
     public void setContentId(String contentId) {
         this.contentId = contentId;
     }
 
     /**
-     * @return get the value of the 'status-report-req' parameter.
+     * Boolean indicating if you'd like to receive a Delivery Receipt.
+     *
+     * @return {@code true} if a delivery receipt should be requested, {@code false} otherwise.
      */
     public boolean getStatusReportRequired() {
         return statusReportRequired;
     }
 
     /**
-     * Set the value of the 'status-report-req' parameter.
-     * <p>
-     * If set to 'true', Vonage will call 'callbackUrl' with status updates about the delivery of this message. If this
-     * value is set to 'true', then 'callbackUrl' should also be set to a URL that is configured to receive these
-     * status updates.
+     * Boolean indicating if you like to receive a Delivery Receipt.
+     * If set to {@code true}, Vonage will call 'callbackUrl' with status updates about the delivery of this message.
+     * Thus, the {@linkplain #setCallbackUrl(String)} should be configured if a global one isn't set already.
      *
-     * @param statusReportRequired 'true' if status reports are desired, 'false' otherwise.
+     * @param statusReportRequired {@code true} if status reports are desired, {@code false} otherwise.
      */
     public void setStatusReportRequired(boolean statusReportRequired) {
         this.statusReportRequired = statusReportRequired;
@@ -240,6 +315,11 @@ public abstract class Message implements QueryParamsRequest {
             this.messageClass = messageClass;
         }
 
+        /**
+         * Gets the message class as an integer.
+         *
+         * @return The message class number.
+         */
         @JsonValue
         public int getMessageClass() {
             return messageClass;

--- a/src/main/java/com/vonage/client/sms/messages/TextMessage.java
+++ b/src/main/java/com/vonage/client/sms/messages/TextMessage.java
@@ -59,16 +59,20 @@ public class TextMessage extends Message {
     }
 
     /**
-     * @return String The text of the message to be sent to the handset
+     * The text of the message to be sent to the handset.
+     *
+     * @return String The message body as a string.
      */
     public String getMessageBody() {
         return messageBody;
     }
 
     /**
-     * @return boolean This flag is set to true if the message needs to be submitted as a unicode message. This would
-     * be for scenario's where the message contains text that does not fit within the Latin GSM alphabet. Examples
+     * This flag is set to true if the message needs to be submitted as a Unicode message. This would
+     * be for scenarios where the message contains text that does not fit within the Latin GSM alphabet. Examples
      * would be messages to be sent in non-western scripts, such as Arabic, Kanji, Chinese, etc.
+     *
+     * @return {@code true} if the message is to be submitted as a Unicode message, {@code false} otherwise.
      */
     public boolean isUnicode() {
         return getType() == MessageType.UNICODE;


### PR DESCRIPTION
As well as tidying up the documentation for classes in the `com.vonage.client.sms` package, this PR refactors `BinaryMessage` to use a Formatter for converting the message into a hexadecimal string, thus removing the dependency on commons-codec and reducing the SDK's footprint. This is still used in tests to verify correctness.
