### PR TITLE
fix: Add logging to AbstractMethod.execute

### DIFF
--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -16,6 +16,7 @@
 package com.vonage.client;
 
 import com.vonage.client.auth.*;
+import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -81,11 +82,14 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
 
         if (shouldLog()) {
             LOGGER.info("Request " + httpRequest.getMethod() + " " + httpRequest.getURI());
-            StringBuilder headers = new StringBuilder("Request headers:\n");
-            for (org.apache.http.Header header : httpRequest.getAllHeaders()) {
-                headers.append('\n').append(header.getName()).append(": ").append(header.getValue());
+            Header[] headers = httpRequest.getAllHeaders();
+            if (headers != null && headers.length > 0) {
+                StringBuilder headersStr = new StringBuilder("--- REQUEST HEADERS ---\n");
+                for (Header header : headers) {
+                    headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
+                }
+                LOGGER.info(headersStr.toString());
             }
-            LOGGER.info(headers.toString());
             LOGGER.info("Request body: " + request);
         }
 
@@ -93,11 +97,14 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
             try {
                 if (shouldLog()) {
                     LOGGER.info("Response " + response.getStatusLine());
-                    StringBuilder headers = new StringBuilder("Response headers:\n");
-                    for (org.apache.http.Header header : response.getAllHeaders()) {
-                        headers.append('\n').append(header.getName()).append(": ").append(header.getValue());
+                    Header[] headers = response.getAllHeaders();
+                    if (headers != null && headers.length > 0) {
+                        StringBuilder headersStr = new StringBuilder("Response headers:\n");
+                        for (Header header : headers) {
+                            headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
+                        }
+                        LOGGER.info(headersStr.toString());
                     }
-                    LOGGER.info(headers.toString());
                 }
 
                 ResultT responseBody = parseResponse(response);

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -39,67 +39,91 @@ import java.util.stream.Collectors;
  * <p>
  * The REST call is executed by calling {@link #execute(Object)}.
  *
- * @param <RequestT> The request object type that will be used to construct the HTTP request body.
- * @param <ResultT>  The response object type which will be constructed from the returned HTTP response body.
+ * @param <REQ> The request object type that will be used to construct the HTTP request body.
+ * @param <RES>  The response object type which will be constructed from the returned HTTP response body.
  *
  * @see DynamicEndpoint for an abstract implementation which handles the most common use cases.
  */
-public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<RequestT, ResultT> {
+public abstract class AbstractMethod<REQ, RES> implements RestEndpoint<REQ, RES> {
     private static final Logger LOGGER = Logger.getLogger(AbstractMethod.class.getName());
 
     private static boolean shouldLog() {
         return LOGGER.isLoggable(Level.INFO);
     }
 
-    protected final HttpWrapper httpWrapper;
+    private final HttpWrapper httpWrapper;
 
-    public AbstractMethod(HttpWrapper httpWrapper) {
+    /**
+     * Construct a new AbstractMethod instance with the given HTTP client.
+     *
+     * @param httpWrapper The wrapper containing the HTTP client and configuration.
+     */
+    protected AbstractMethod(HttpWrapper httpWrapper) {
         this.httpWrapper = httpWrapper;
     }
 
+    /**
+     * Gets the underlying HTTP client wrapper.
+     *
+     * @return The {@link HttpWrapper} used by this endpoint.
+     */
     public HttpWrapper getHttpWrapper() {
         return httpWrapper;
     }
 
-    protected ResultT postProcessParsedResponse(ResultT response) {
+    /**
+     * Method which allows further modification of the response object after it has been parsed.
+     *
+     * @param response The unmarshalled response object.
+     *
+     * @return The final result object to return; usually the same object that was passed in.
+     */
+    protected RES postProcessParsedResponse(RES response) {
         return response;
     }
 
-    /**
-     * Execute the REST call represented by this method object.
-     *
-     * @param request A RequestT representing input to the REST call to be made
-     *
-     * @return A ResultT representing the response from the executed REST call
-     *
-     * @throws VonageClientException if there is a problem parsing the HTTP response
-     */
-    @Override
-    public ResultT execute(RequestT request) throws VonageResponseParseException, VonageClientException {
-        HttpUriRequest httpRequest = applyAuth(makeRequest(request))
+    private HttpUriRequest createFullHttpRequest(REQ request) throws VonageClientException {
+        return applyAuth(makeRequest(request))
                 .setHeader(HttpHeaders.USER_AGENT, httpWrapper.getUserAgent())
                 .setCharset(StandardCharsets.UTF_8).build();
+    }
+
+    /**
+     * Executes the REST call represented by this endpoint.
+     *
+     * @param request The request object representing input to the REST call to be made.
+     *
+     * @return The result object representing the response from the executed REST call.
+     *
+     * @throws VonageResponseParseException if there was a problem parsing the HTTP response.
+     * @throws VonageMethodFailedException if there was a problem executing the HTTP request.
+     */
+    @Override
+    public RES execute(REQ request) throws VonageMethodFailedException, VonageResponseParseException {
+        final HttpUriRequest httpRequest = createFullHttpRequest(request);
 
         if (shouldLog()) {
             LOGGER.info("Request " + httpRequest.getMethod() + " " + httpRequest.getURI());
             Header[] headers = httpRequest.getAllHeaders();
             if (headers != null && headers.length > 0) {
-                StringBuilder headersStr = new StringBuilder("--- REQUEST HEADERS ---\n");
+                StringBuilder headersStr = new StringBuilder("--- REQUEST HEADERS ---");
                 for (Header header : headers) {
                     headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
                 }
                 LOGGER.info(headersStr.toString());
             }
-            LOGGER.info("Request body: " + request);
+            if (request != null) {
+                LOGGER.info("--- REQUEST BODY ---\n" + request);
+            }
         }
 
-        try (CloseableHttpResponse response = httpWrapper.getHttpClient().execute(httpRequest)) {
+        try (final CloseableHttpResponse response = httpWrapper.getHttpClient().execute(httpRequest)) {
             try {
                 if (shouldLog()) {
                     LOGGER.info("Response " + response.getStatusLine());
                     Header[] headers = response.getAllHeaders();
                     if (headers != null && headers.length > 0) {
-                        StringBuilder headersStr = new StringBuilder("Response headers:\n");
+                        StringBuilder headersStr = new StringBuilder("--- RESPONSE HEADERS ---");
                         for (Header header : headers) {
                             headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
                         }
@@ -107,9 +131,9 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
                     }
                 }
 
-                ResultT responseBody = parseResponse(response);
-                if (shouldLog()) {
-                    LOGGER.info("Response body: " + responseBody);
+                final RES responseBody = parseResponse(response);
+                if (responseBody != null && shouldLog()) {
+                    LOGGER.info("--- RESPONSE BODY ---\n" + responseBody);
                 }
 
                 return postProcessParsedResponse(responseBody);
@@ -126,15 +150,15 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
     }
 
     /**
-     * Apply an appropriate authentication method (specified by {@link #getAcceptableAuthMethods()}) to the provided
-     * {@link RequestBuilder}, and return the result.
+     * Apply an appropriate authentication method (specified by {@link #getAcceptableAuthMethods()}) to the
+     * provided {@link RequestBuilder}, and return the result.
      *
-     * @param request A RequestBuilder which has not yet had authentication information applied
+     * @param request A RequestBuilder which has not yet had authentication information applied.
      *
-     * @return A RequestBuilder with appropriate authentication information applied (may or not be the same instance as
-     * <pre>request</pre>)
+     * @return A RequestBuilder with appropriate authentication information applied
+     * (may or not be the same instance as <pre>request</pre>).
      *
-     * @throws VonageClientException If no appropriate {@link AuthMethod} is available
+     * @throws VonageClientException If no appropriate {@link AuthMethod} is available.
      */
     final RequestBuilder applyAuth(RequestBuilder request) throws VonageClientException {
         AuthMethod am = getAuthMethod();
@@ -164,25 +188,30 @@ public abstract class AbstractMethod<RequestT, ResultT> implements RestEndpoint<
         return httpWrapper.getAuthCollection().getAcceptableAuthMethod(getAcceptableAuthMethods());
     }
 
+    /**
+     * Gets applicable authentication methods for this endpoint.
+     *
+     * @return The set of acceptable authentication method classes (at least one must be provided).
+     */
     protected abstract Set<Class<? extends AuthMethod>> getAcceptableAuthMethods();
 
     /**
      * Construct and return a RequestBuilder instance from the provided request.
      *
-     * @param request A RequestT representing input to the REST call to be made
+     * @param request A request object representing input to the REST call to be made.
      *
-     * @return A ResultT representing the response from the executed REST call
+     * @return A RequestBuilder instance representing the HTTP request to be made.
      */
-    protected abstract RequestBuilder makeRequest(RequestT request);
+    protected abstract RequestBuilder makeRequest(REQ request);
 
     /**
-     * Construct a ResultT representing the contents of the HTTP response returned from the Vonage Voice API.
+     * Construct a response object representing the contents of the HTTP response returned from the Vonage API.
      *
-     * @param response An HttpResponse returned from the Vonage Voice API
+     * @param response An HttpResponse returned from the Vonage API.
      *
-     * @return A ResultT type representing the result of the REST call
+     * @return The unmarshalled result of the REST call.
      *
-     * @throws IOException if a problem occurs parsing the response
+     * @throws IOException if a problem occurs parsing the response.
      */
-    protected abstract ResultT parseResponse(HttpResponse response) throws IOException;
+    protected abstract RES parseResponse(HttpResponse response) throws IOException;
 }

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  * @param <REQ> The request object type that will be used to construct the HTTP request body.
  * @param <RES>  The response object type which will be constructed from the returned HTTP response body.
  *
- * @see DynamicEndpoint for an abstract implementation which handles the most common use cases.
+ * @see DynamicEndpoint for a flexible implementation which handles the most common use cases.
  */
 public abstract class AbstractMethod<REQ, RES> implements RestEndpoint<REQ, RES> {
     private static final Logger LOGGER = Logger.getLogger(AbstractMethod.class.getName());
@@ -52,6 +52,9 @@ public abstract class AbstractMethod<REQ, RES> implements RestEndpoint<REQ, RES>
         return LOGGER.isLoggable(LOG_LEVEL);
     }
 
+    /**
+     * HTTP client and configuration used by this endpoint.
+     */
     private final HttpWrapper httpWrapper;
 
     /**

--- a/src/main/java/com/vonage/client/AbstractMethod.java
+++ b/src/main/java/com/vonage/client/AbstractMethod.java
@@ -46,9 +46,10 @@ import java.util.stream.Collectors;
  */
 public abstract class AbstractMethod<REQ, RES> implements RestEndpoint<REQ, RES> {
     private static final Logger LOGGER = Logger.getLogger(AbstractMethod.class.getName());
+    private static final Level LOG_LEVEL = Level.FINE;
 
     private static boolean shouldLog() {
-        return LOGGER.isLoggable(Level.INFO);
+        return LOGGER.isLoggable(LOG_LEVEL);
     }
 
     private final HttpWrapper httpWrapper;
@@ -103,37 +104,37 @@ public abstract class AbstractMethod<REQ, RES> implements RestEndpoint<REQ, RES>
         final HttpUriRequest httpRequest = createFullHttpRequest(request);
 
         if (shouldLog()) {
-            LOGGER.info("Request " + httpRequest.getMethod() + " " + httpRequest.getURI());
+            LOGGER.log(LOG_LEVEL, "Request " + httpRequest.getMethod() + " " + httpRequest.getURI());
             Header[] headers = httpRequest.getAllHeaders();
             if (headers != null && headers.length > 0) {
                 StringBuilder headersStr = new StringBuilder("--- REQUEST HEADERS ---");
                 for (Header header : headers) {
                     headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
                 }
-                LOGGER.info(headersStr.toString());
+                LOGGER.log(LOG_LEVEL, headersStr.toString());
             }
             if (request != null) {
-                LOGGER.info("--- REQUEST BODY ---\n" + request);
+                LOGGER.log(LOG_LEVEL, "--- REQUEST BODY ---\n" + request);
             }
         }
 
         try (final CloseableHttpResponse response = httpWrapper.getHttpClient().execute(httpRequest)) {
             try {
                 if (shouldLog()) {
-                    LOGGER.info("Response " + response.getStatusLine());
+                    LOGGER.log(LOG_LEVEL, "Response " + response.getStatusLine());
                     Header[] headers = response.getAllHeaders();
                     if (headers != null && headers.length > 0) {
                         StringBuilder headersStr = new StringBuilder("--- RESPONSE HEADERS ---");
                         for (Header header : headers) {
                             headersStr.append('\n').append(header.getName()).append(": ").append(header.getValue());
                         }
-                        LOGGER.info(headersStr.toString());
+                        LOGGER.log(LOG_LEVEL, headersStr.toString());
                     }
                 }
 
                 final RES responseBody = parseResponse(response);
                 if (responseBody != null && shouldLog()) {
-                    LOGGER.info("--- RESPONSE BODY ---\n" + responseBody);
+                    LOGGER.log(LOG_LEVEL, "--- RESPONSE BODY ---\n" + responseBody);
                 }
 
                 return postProcessParsedResponse(responseBody);

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -329,7 +329,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 				R customParsedResponse = parseResponseFromString(deser);
 				if (customParsedResponse == null) {
 					String errorMsg = "Unhandled return type: " + responseType;
-					logger.warning(errorMsg);
+					logger.severe(errorMsg);
 					throw new IllegalStateException(errorMsg);
 				}
 				else {
@@ -350,6 +350,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 					varex.title = response.getStatusLine().getReasonPhrase();
 				}
 				varex.statusCode = response.getStatusLine().getStatusCode();
+				logger.log(Level.WARNING, "Failed to parse response", varex);
 				throw varex;
 			}
 			else {
@@ -368,6 +369,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 		}
 		R customParsedResponse = parseResponseFromString(exMessage);
 		if (customParsedResponse == null) {
+			logger.warning(exMessage);
 			throw new VonageApiResponseException(exMessage);
 		}
 		else {

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -30,6 +30,8 @@ import java.net.URI;
 import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Enables convenient declaration of endpoints without directly implementing {@link AbstractMethod}.
@@ -42,6 +44,8 @@ import java.util.function.Consumer;
  */
 @SuppressWarnings("unchecked")
 public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
+	protected final Logger logger = Logger.getLogger(getClass().getName());
+
 	protected Set<Class<? extends AuthMethod>> authMethods;
 	protected String contentType, accept;
 	protected HttpMethod requestMethod;
@@ -242,6 +246,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 	@Override
 	protected final R parseResponse(HttpResponse response) throws IOException {
 		int statusCode = response.getStatusLine().getStatusCode();
+		logger.fine(() -> "Response status: " + statusCode);
 		try {
 			if (statusCode >= 200 && statusCode < 300) {
 				return parseResponseSuccess(response);
@@ -255,6 +260,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 		}
 		catch (InvocationTargetException ex) {
 			Throwable wrapped = ex.getTargetException();
+			logger.log(Level.SEVERE, "Internal SDK error", ex);
 			if (wrapped instanceof RuntimeException) {
 				throw (RuntimeException) wrapped;
 			}
@@ -263,6 +269,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 			}
 		}
 		catch (ReflectiveOperationException ex) {
+			logger.log(Level.SEVERE, "Internal SDK error", ex);
 			throw new VonageUnexpectedException(ex);
 		}
 		finally {
@@ -276,6 +283,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 
 	private R parseResponseRedirect(HttpResponse response) throws ReflectiveOperationException, IOException {
 		final String location = response.getFirstHeader("Location").getValue();
+		logger.fine(() -> "Redirect: " + location);
 
 		if (java.net.URI.class.equals(responseType)) {
 			return (R) URI.create(location);
@@ -290,13 +298,17 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 
 	private R parseResponseSuccess(HttpResponse response) throws IOException, ReflectiveOperationException {
 		if (Void.class.equals(responseType)) {
+			logger.fine(() -> "No response body.");
 			return null;
 		}
 		else if (byte[].class.equals(responseType)) {
-			return (R) EntityUtils.toByteArray(response.getEntity());
+			byte[] result = EntityUtils.toByteArray(response.getEntity());
+			logger.fine(() -> "Binary response body of length " + result.length);
+			return (R) result;
 		}
 		else {
 			String deser = EntityUtils.toString(response.getEntity());
+			logger.fine(() -> deser);
 
 			if (responseType.equals(String.class)) {
 				return (R) deser;
@@ -316,7 +328,9 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 			else {
 				R customParsedResponse = parseResponseFromString(deser);
 				if (customParsedResponse == null) {
-					throw new IllegalStateException("Unhandled return type: " + responseType);
+					String errorMsg = "Unhandled return type: " + responseType;
+					logger.warning(errorMsg);
+					throw new IllegalStateException(errorMsg);
 				}
 				else {
 					return customParsedResponse;
@@ -345,7 +359,9 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 						if (!constructor.isAccessible()) {
 							constructor.setAccessible(true);
 						}
-						throw (RuntimeException) constructor.newInstance(exMessage);
+						RuntimeException ex = (RuntimeException) constructor.newInstance(exMessage);
+						logger.log(Level.SEVERE, "Internal SDK error", ex);
+						throw ex;
 					}
 				}
 			}

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -32,8 +32,6 @@ import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.*;
 import java.io.*;
@@ -52,6 +50,11 @@ public class AbstractMethodTest {
     private static class ConcreteMethod extends AbstractMethod<String, String> {
         public ConcreteMethod(HttpWrapper httpWrapper) {
             super(httpWrapper);
+        }
+
+        static {
+            LogManager.getLogManager().getLogger(AbstractMethod.class.getName())
+                    .setLevel(java.util.logging.Level.FINE);
         }
 
         RequestBuilder makeRequest() throws UnsupportedEncodingException {
@@ -109,12 +112,6 @@ public class AbstractMethodTest {
     private CloseableHttpClient mockHttpClient;
     private AuthMethod mockAuthMethod;
     private final CloseableHttpResponse basicResponse = new CloseableBasicHttpResponse();
-
-    @BeforeAll
-    public static void setUpBeforeClass() {
-        LogManager.getLogManager().getLogger(AbstractMethod.class.getName())
-                .setLevel(java.util.logging.Level.FINE);
-    }
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -47,13 +47,7 @@ import java.util.concurrent.Executors;
 import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
-@Execution(ExecutionMode.SAME_THREAD)
 public class AbstractMethodTest {
-
-    static {
-        LogManager.getLogManager().getLogger(AbstractMethod.class.getName())
-                .setLevel(java.util.logging.Level.FINE);
-    }
 
     private static class ConcreteMethod extends AbstractMethod<String, String> {
         public ConcreteMethod(HttpWrapper httpWrapper) {
@@ -115,6 +109,12 @@ public class AbstractMethodTest {
     private CloseableHttpClient mockHttpClient;
     private AuthMethod mockAuthMethod;
     private final CloseableHttpResponse basicResponse = new CloseableBasicHttpResponse();
+
+    @BeforeAll
+    public static void setUpBeforeClass() {
+        LogManager.getLogManager().getLogger(AbstractMethod.class.getName())
+                .setLevel(java.util.logging.Level.FINE);
+    }
 
     @BeforeEach
     public void setUp() throws Exception {

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -42,9 +42,15 @@ import java.util.Arrays;
 import java.util.Scanner;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
 public class AbstractMethodTest {
+
+    static {
+        LogManager.getLogManager().getLogger(AbstractMethod.class.getName())
+                .setLevel(java.util.logging.Level.FINE);
+    }
 
     private static class ConcreteMethod extends AbstractMethod<String, String> {
         public ConcreteMethod(HttpWrapper httpWrapper) {

--- a/src/test/java/com/vonage/client/AbstractMethodTest.java
+++ b/src/test/java/com/vonage/client/AbstractMethodTest.java
@@ -32,6 +32,8 @@ import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.*;
 import java.io.*;
@@ -45,6 +47,7 @@ import java.util.concurrent.Executors;
 import java.util.logging.LogManager;
 import java.util.stream.Collectors;
 
+@Execution(ExecutionMode.SAME_THREAD)
 public class AbstractMethodTest {
 
     static {

--- a/src/test/java/com/vonage/client/DynamicEndpointTest.java
+++ b/src/test/java/com/vonage/client/DynamicEndpointTest.java
@@ -22,16 +22,20 @@ import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.net.URI;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class DynamicEndpointTest {
     private static final HttpWrapper WRAPPER = new HttpWrapper(new NoAuthMethod());
 
     @SuppressWarnings("unchecked")
     static <T, R> DynamicEndpoint<T, R> newEndpoint(R... responseType) {
-        return DynamicEndpoint.<T, R> builder(responseType)
+        var endpoint = DynamicEndpoint.<T, R> builder(responseType)
                 .wrapper(WRAPPER).authMethod(NoAuthMethod.class)
                 .pathGetter((de, req) -> TEST_BASE_URI)
                 .requestMethod(HttpMethod.GET).acceptHeader("text").build();
+        Logger.getLogger(endpoint.getClass().getName()).setLevel(Level.FINE);
+        return endpoint;
     }
 
     @Test

--- a/src/test/java/com/vonage/client/DynamicEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/DynamicEndpointTestSpec.java
@@ -194,16 +194,16 @@ public abstract class DynamicEndpointTestSpec<T, R> {
 		assertEquals(expectedUri, builder.build().getURI().toString().split("\\?")[0]);
 
 		AbstractMethod<T, R> endpoint = endpointAsAbstractMethod();
-		HttpConfig originalConfig = endpoint.httpWrapper.getHttpConfig();
+		HttpConfig originalConfig = endpoint.getHttpWrapper().getHttpConfig();
 		try {
 			String baseUri = customBaseUri();
-			endpoint.httpWrapper.setHttpConfig(HttpConfig.builder().baseUri(baseUri).build());
+			endpoint.getHttpWrapper().setHttpConfig(HttpConfig.builder().baseUri(baseUri).build());
 			builder = makeTestRequest(request);
 			expectedUri = expectedCustomBaseUri() + expectedEndpointUri(request);
 			assertEquals(expectedUri, builder.build().getURI().toString().split("\\?")[0]);
 		}
 		finally {
-			endpoint.httpWrapper.setHttpConfig(originalConfig);
+			endpoint.getHttpWrapper().setHttpConfig(originalConfig);
 		}
 	}
 

--- a/src/test/java/com/vonage/client/incoming/InputEventTest.java
+++ b/src/test/java/com/vonage/client/incoming/InputEventTest.java
@@ -18,24 +18,23 @@ package com.vonage.client.incoming;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.*;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
+import java.util.logging.Logger;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class InputEventTest {
 
-    private static final Log LOG = LogFactory.getLog(InputEventTest.class);
+    private static final Logger LOG = Logger.getLogger(InputEventTest.class.getName());
 
     @Test
     public void testDeserializeInputEvent() {
         String inputJsonStr = getInputEventJsonString().toString();
-        LOG.debug(inputJsonStr);
+        LOG.info(inputJsonStr);
 
-        InputEvent inputEvent = InputEvent.fromJson(inputJsonStr);
+        var inputEvent = InputEvent.fromJson(inputJsonStr);
         assertEquals("aaaaaaaa-bbbb-cccc-dddd-0123456789ab", inputEvent.getUuid());
         assertEquals("bbbbbbbb-cccc-dddd-eeee-0123456789ab", inputEvent.getConversationUuid());
         assertTrue(inputEvent.getDtmf().isTimedOut());
@@ -65,11 +64,10 @@ public class InputEventTest {
         speechNode.put("error", expectedMessage);
         jsonNode.set("speech", speechNode);
 
-        InputEvent inputEvent = InputEvent.fromJson(jsonNode.toString());
+        var inputEvent = InputEvent.fromJson(jsonNode.toString());
         String actualMessage = inputEvent.getSpeech().getError();
 
         assertEquals(expectedMessage, actualMessage);
-
     }
 
 


### PR DESCRIPTION
This PR removes declarations of Apache Commons loggers and adds log statements for requests and responses made using the SDK, using `java.util.logging` with INFO level. This is all centralised in `AbstractMethod#execute(T)` for simplicity.

EDIT: Also added non-static logging to DynamicEndpoint so each individual endpoint implementation can have its own logging of raw request and responses prior to (de-)serialisation.