### PR TITLE
docs: Deprecate NI RealTimeData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added logging for requests & responses based on `java.util.logging`
 - Improved SMS API documentation
 - Deprecated Number Insight v2 / Fraud Score API
+- Deprecated `real_time_data` in Number Insight API
 - Minor internal refactoring based on code coverage improvements
 
 # [8.15.1] - 2024-12-19

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightRequest.java
@@ -58,6 +58,7 @@ public class AdvancedInsightRequest extends BaseInsightRequest {
         return new Builder();
     }
 
+    @Deprecated
     public Boolean getRealTimeData() {
         return realTimeData;
     }
@@ -180,7 +181,10 @@ public class AdvancedInsightRequest extends BaseInsightRequest {
          *                     This only applies when {@link #async(boolean)} is {@code false}.
          *
          * @return This builder.
+         *
+         * @deprecated This feature will be removed in the next major release.
          */
+        @Deprecated
         public Builder realTimeData(boolean realTimeData) {
             this.realTimeData = realTimeData;
             return this;

--- a/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
+++ b/src/main/java/com/vonage/client/insight/AdvancedInsightResponse.java
@@ -77,7 +77,10 @@ public class AdvancedInsightResponse extends StandardInsightResponse {
 
     /**
      * @return Real-time data about the number if it was requested, {@code null} otherwise.
+     *
+     * @deprecated This feature will be removed in the next major release.
      */
+    @Deprecated
     @JsonProperty("real_time_data")
     public RealTimeData getRealTimeData() {
         return realTimeData;


### PR DESCRIPTION
Deprecates the `real_time_data` in the Number Insight API.
