### PR TITLE
fix: Conversation Event / Voice recording validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.16.1] -2025-02-04
+- Removed mandatory `from` parameter for event creation in Conversation API
+- Re-added URL domain validation in `VoiceClient.downloadRecordingRaw`
+- Bumped JWT library version to 2.0.1
+- Added `commons-codec` to runtime classpath to fix WS-2019-0379 warning
+
 # [8.16.0] - 2025-01-31
 - Added logging for requests & responses based on `java.util.logging`
 - Improved SMS API documentation

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.16.0</version>
+  <version>8.16.1</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>com.vonage</groupId>
       <artifactId>jwt</artifactId>
-      <version>2.0.0</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -76,6 +76,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.17.0</version>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.18.0</version>
+    </dependency>
 
     <!-- Tests -->
     <dependency>
@@ -94,12 +99,6 @@
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <version>6.1.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.16.0",
+            CLIENT_VERSION = "8.16.1",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/conversations/Event.java
+++ b/src/main/java/com/vonage/client/conversations/Event.java
@@ -72,7 +72,7 @@ public abstract class Event extends JsonableBaseObject {
 
 	Event(Builder<?, ?> builder) {
 		type = Objects.requireNonNull(builder.type, "Event type is required.");
-		from = ConversationsClient.validateMemberId(builder.from);
+		from = builder.from;
 	}
 
 	/**
@@ -154,12 +154,12 @@ public abstract class Event extends JsonableBaseObject {
 		/**
 		 * Member ID this event was sent from.
 		 *
-		 * @param from The member ID, or {@code null} if unspecified.
+		 * @param from The member ID.
 		 *
 		 * @return This builder.
 		 */
 		public B from(String from) {
-			this.from = from;
+			this.from = ConversationsClient.validateMemberId(from);
 			return (B) this;
 		}
 

--- a/src/main/java/com/vonage/client/voice/VoiceClient.java
+++ b/src/main/java/com/vonage/client/voice/VoiceClient.java
@@ -532,7 +532,13 @@ public class VoiceClient {
      * @since 7.11.0
      */
     public byte[] downloadRecordingRaw(String recordingUrl) {
-        return downloadRecording.execute(validateUrl(recordingUrl));
+        String validated = validateUrl(recordingUrl);
+        if (validated.contains(".nexmo.com/") || validated.contains(".vonage.com/")) {
+            return downloadRecording.execute(recordingUrl);
+        }
+        else {
+            throw new IllegalArgumentException("Recording URL must be from Vonage.");
+        }
     }
 
     /**

--- a/src/test/java/com/vonage/client/conversations/ConversationsClientTest.java
+++ b/src/test/java/com/vonage/client/conversations/ConversationsClientTest.java
@@ -1697,7 +1697,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 	@Test
 	public void testCreateEvent() throws Exception {
-		Event request = CustomEvent.builder().from(MEMBER_FROM).body(CONVERSATION_CUSTOM_DATA).build();
+		Event request = CustomEvent.builder().body(CONVERSATION_CUSTOM_DATA).build();
 		stubResponse(201, SAMPLE_EVENT_RESPONSE);
 		assertEqualsSampleEvent(client.createEvent(CONVERSATION_ID, request));
 

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -424,6 +424,17 @@ public class VoiceClientTest extends AbstractClientTest<VoiceClient> {
         assertTrue(Files.exists(recordingPath));
         assertArrayEquals(content.getBytes(), Files.readAllBytes(recordingPath));
 
+        stubResponse(200, content);
+        assertArrayEquals(content.getBytes(), client.downloadRecordingRaw(url.replace("vonage", "nexmo")));
+
+        stubResponseAndAssertThrows(content, () ->
+                client.downloadRecordingRaw(null),
+                IllegalArgumentException.class
+        );
+        stubResponseAndAssertThrows(content, () ->
+                client.downloadRecordingRaw("https://api.nexmo.vonage.commerce.io/v1/files/" + recordingId),
+                IllegalArgumentException.class
+        );
         stubResponseAndAssertThrows(content, () ->
                 client.saveRecording(url, null),
                 NullPointerException.class
@@ -433,7 +444,7 @@ public class VoiceClientTest extends AbstractClientTest<VoiceClient> {
                 IllegalArgumentException.class
         );
         stubResponseAndAssertThrows(content, () ->
-                        client.saveRecording(" \t", recordingPath),
+                client.saveRecording(" \t", recordingPath),
                 IllegalArgumentException.class
         );
     }


### PR DESCRIPTION
Removes `from` validation in Event creation and reintroduces URL domain host validation in Voice API downloadRecordingRaw method.