### PR TITLE
feat: SIP connect NCCO domain/user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.17.0] - 2025-02-2?
+- Added user/domain name support to `com.vonage.client.voice.ncco.SipEndpoint`
+
 # [8.16.2] - 2025-02-05
 - Added `disconnected_by` enum to `com.vonage.client.voice.EventWebhook`
 - Changed `AnswerWebhook#getUuid()` return type to String

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.16.2</version>
+  <version>8.17.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.16.2",
+            CLIENT_VERSION = "8.17.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/SipEndpointTest.java
@@ -39,4 +39,57 @@ public class SipEndpointTest {
                 "\"type\":\"sip\"}],\"action\":\"connect\"}]";
         assertEquals(expectedJson, new Ncco(connect).toJson());
     }
+
+    @Test
+    public void testUriOnly() {
+        String uri = "sip:vonage.com";
+        SipEndpoint endpoint = SipEndpoint.builder().uri(uri).build();
+
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\"" + uri + "\",\"type\":\"sip\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void testDomainOnly() {
+        String domain = "example";
+        SipEndpoint endpoint = SipEndpoint.builder().domain(domain).build();
+
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"domain\":\""+domain+"\",\"type\":\"sip\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void testDomainAndUserOnly() {
+        String domain = "Nexmo";
+        String user = "My_user";
+        SipEndpoint endpoint = SipEndpoint.builder().domain(domain).user(user).build();
+
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"domain\":\""+domain+"\",\"user\":\""+user+"\",\"type\":\"sip\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void testDomainAndUri() {
+        assertThrows(IllegalStateException.class, () -> SipEndpoint.builder()
+                .domain("example").uri("sip:test@example.com").build()
+        );
+    }
+
+    @Test
+    public void testUserOnly() {
+        assertThrows(IllegalStateException.class, () -> SipEndpoint.builder().user("my_user").build());
+    }
+
+    @Test
+    public void testUserAndUri() {
+        assertThrows(IllegalStateException.class, () -> SipEndpoint.builder()
+                .user("my_user").uri(URI.create("sip:my_user@example.com")).build()
+        );
+    }
 }


### PR DESCRIPTION
Adds user and domain properties to the `SipEndpoint` action, as per [the NCCO reference](https://b883d430.preview.developer.vonage.com/en/voice/voice-api/ncco-reference#sip---the-sip-endpoint-to-connect-to).