### PR TITLE
fix: Use Basic header auth in InsightClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Deprecated `java.util.Date`-based methods
   - `getOrder()` returns a `com.vonage.client.common.SortOrder` instead of `CallOrder`
 - Made constructors for response objects in Voice API package-private
+- Basic auth header in Number Insight v1 requests instead of query parameters
 
 # [8.16.2] - 2025-02-05
 - Added `disconnected_by` enum to `com.vonage.client.voice.EventWebhook`

--- a/src/main/java/com/vonage/client/insight/InsightClient.java
+++ b/src/main/java/com/vonage/client/insight/InsightClient.java
@@ -17,8 +17,6 @@ package com.vonage.client.insight;
 
 import com.vonage.client.*;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
-import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.function.Function;
@@ -40,10 +38,10 @@ public class InsightClient {
     public InsightClient(HttpWrapper wrapper) {
         @SuppressWarnings("unchecked")
         final class Endpoint<T, R> extends DynamicEndpoint<T, R> {
-            Endpoint(Function<T, String> pathGetter, Class<? extends AuthMethod> auth, R... type) {
+            Endpoint(Function<T, String> pathGetter, R... type) {
                 super(DynamicEndpoint.<T, R> builder(type)
                         .wrapper(wrapper).requestMethod(HttpMethod.POST)
-                        .authMethod(SignatureAuthMethod.class, auth)
+                        .authMethod(SignatureAuthMethod.class, ApiKeyHeaderAuthMethod.class)
                         .pathGetter((de, req) -> {
                             String base = de.getHttpWrapper().getHttpConfig().getApiBaseUri();
                             return base + "/ni/" + pathGetter.apply(req) + "/json";
@@ -52,9 +50,9 @@ public class InsightClient {
             }
         }
 
-        basic = new Endpoint<>(req -> "basic", ApiKeyHeaderAuthMethod.class);
-        standard = new Endpoint<>(req -> "standard", ApiKeyQueryParamsAuthMethod.class);
-        advanced = new Endpoint<>(req -> "advanced" + (req.isAsync() ? "/async" : ""), ApiKeyQueryParamsAuthMethod.class);
+        basic = new Endpoint<>(req -> "basic");
+        standard = new Endpoint<>(req -> "standard");
+        advanced = new Endpoint<>(req -> "advanced" + (req.isAsync() ? "/async" : ""));
     }
 
     /**

--- a/src/test/java/com/vonage/client/insight/InsightClientTest.java
+++ b/src/test/java/com/vonage/client/insight/InsightClientTest.java
@@ -17,16 +17,10 @@ package com.vonage.client.insight;
 
 import com.vonage.client.AbstractClientTest;
 import com.vonage.client.RestEndpoint;
-import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
-import com.vonage.client.auth.AuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
-import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 import java.math.BigDecimal;
-import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 public class InsightClientTest extends AbstractClientTest<InsightClient> {
@@ -229,11 +223,6 @@ public class InsightClientTest extends AbstractClientTest<InsightClient> {
             }
 
             @Override
-            protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-                return List.of(SignatureAuthMethod.class, ApiKeyHeaderAuthMethod.class);
-            }
-
-            @Override
             protected String expectedEndpointUri(BasicInsightRequest request) {
                 return "/ni/basic/json";
             }
@@ -263,11 +252,6 @@ public class InsightClientTest extends AbstractClientTest<InsightClient> {
             @Override
             protected RestEndpoint<StandardInsightRequest, StandardInsightResponse> endpoint() {
                 return client.standard;
-            }
-
-            @Override
-            protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-                return List.of(SignatureAuthMethod.class, ApiKeyQueryParamsAuthMethod.class);
             }
 
             @Override
@@ -302,11 +286,6 @@ public class InsightClientTest extends AbstractClientTest<InsightClient> {
             @Override
             protected RestEndpoint<AdvancedInsightRequest, AdvancedInsightResponse> endpoint() {
                 return client.advanced;
-            }
-
-            @Override
-            protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-                return List.of(SignatureAuthMethod.class, ApiKeyQueryParamsAuthMethod.class);
             }
 
             @Override

--- a/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
@@ -17,7 +17,12 @@ package com.vonage.client.insight;
 
 import com.vonage.client.DynamicEndpointTestSpec;
 import com.vonage.client.VonageApiResponseException;
+import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
+import com.vonage.client.auth.AuthMethod;
+import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 abstract class InsightEndpointTestSpec<T, R> extends DynamicEndpointTestSpec<T, R> {
@@ -25,6 +30,11 @@ abstract class InsightEndpointTestSpec<T, R> extends DynamicEndpointTestSpec<T, 
 	@Override
 	protected Class<? extends VonageApiResponseException> expectedResponseExceptionType() {
 		return VonageApiResponseException.class;
+	}
+
+	@Override
+	protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
+		return List.of(SignatureAuthMethod.class, ApiKeyHeaderAuthMethod.class);
 	}
 
 	@Override


### PR DESCRIPTION
Changes Number Insight v1 implementation to use Basic header auth instead of query parameters. Signature auth will still work and use query parameters as before.
