### PR TITLE
fix: Remove VerificationRequest brand length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [8.20.1] - 2025-03-20
+- Removed `brand` length limit in Verify v2 request
+
 # [8.20.0] - 2025-03-19
 - Added `quantizationParameter` to Video Archive
 - Fixed custom event type parsing and creation in Conversation API

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>8.20.0</version>
+  <version>8.20.1</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "8.20.0",
+            CLIENT_VERSION = "8.20.1",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/verify2/VerificationRequest.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationRequest.java
@@ -50,9 +50,6 @@ public class VerificationRequest implements Jsonable {
 		if ((brand = builder.brand) == null || brand.trim().isEmpty()) {
 			throw new IllegalArgumentException("Brand name is required.");
 		}
-		if (brand.length() > 16) {
-			throw new IllegalArgumentException("Brand cannot exceed 16 characters in length.");
-		}
 		if ((channelTimeout = builder.timeout) != null && (channelTimeout < 15 || channelTimeout > 900)) {
 			throw new IllegalArgumentException("Delivery wait timeout must be between 15 and 900 seconds.");
 		}

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -169,9 +169,7 @@ public class VerificationRequestTest {
 			assertThrows(IllegalArgumentException.class, builder::build);
 			builder.brand("  ");
 			assertThrows(IllegalArgumentException.class, builder::build);
-			assertEquals(16, builder.brand("ABCDEFGHIJKLMNOP").build().getBrand().length());
-			assertEquals(17, builder.brand(builder.brand + 'Q').brand.length());
-			assertThrows(IllegalArgumentException.class, builder::build);
+			assertEquals(17, builder.brand("ABCDEFGHIJKLMNOPQ").build().getBrand().length());
 		}
 	}
 


### PR DESCRIPTION
Removes length validation on Verify v2 `VerificationRequest` `brand` property.