### PR TITLE
feat: Add support for custom HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.1.0] - 2025-04-22
+- Added custom HTTP requests support via `CustomClient` (see [README](README.md#custom-requests) for details)
+
 # [9.0.0] - 2025-04-08
 - Removed deprecations (classes, methods, constructors, packages etc.)
   - Removed Meetings, Proactive Connect and Number Insight v2 APIs

--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ You can mix and match between `java.util.Map` and `com.vonage.client.Jsonable` i
 For example, to create an application, you can use any of the following (all are equivalent):
 
 #### Map request, Map response
-
 ```java
 Map<String, ?> response = client.getCustomClient().post(
         "https://api.nexmo.com/v2/applications",
@@ -143,7 +142,6 @@ Map<String, ?> response = client.getCustomClient().post(
 ```
 
 #### Map request, Jsonable response
-
 ```java
 Application response = client.getCustomClient().post(
         "https://api.nexmo.com/v2/applications",
@@ -152,7 +150,6 @@ Application response = client.getCustomClient().post(
 ```
 
 #### Jsonable request, Map response
-
 ```java
 Map<String, ?> response = client.getCustomClient().post(
         "https://api.nexmo.com/v2/applications",
@@ -161,7 +158,6 @@ Map<String, ?> response = client.getCustomClient().post(
 ```
 
 #### Jsonable request, Jsonable response
-
 ```java
 Application response = client.getCustomClient().post(
         "https://api.nexmo.com/v2/applications",
@@ -169,6 +165,13 @@ Application response = client.getCustomClient().post(
 );
 ```
 
+#### Supported response types
+The `<R>` parameter in the response type methods does not have to be a `Map<String, ?>` or `Jsonable`; it can also
+be a `String`, `byte[]` (for binary types) or `Collection` (for JSON arrays). The following will work, for example:
+
+```java
+String response = client.getCustomClient().get("https://example.com");
+```
 
 #### Advanced Usage
 The `CustomClient` provides preset methods for the supported HTTP request types and JSON-based request bodies.
@@ -182,7 +185,7 @@ which the SDK provides for Vonage APIs. Furthermore, you may notice your IDE giv
 varargs parameter for the response type as a way to infer the response type without you having to explicitly provide
 the `Class<R>` parameter. This is a known limitation of Java generics and is not a problem with the SDK itself, it is
 implemented this way for your convenience. As per the documentation, it is important to not pass any value for this
-varargs parameter - just omit it. If you do pass a value, the SDK will not be able to infer the response type.
+varargs parameter — just omit it. If you do pass a value, the SDK will not be able to infer the response type.
 You should also always use explicit assignment for the `CustomClient` methods, as the SDK will not be able to infer the return type if you use `var` or `Object`.
 If you do not assign the response to a typed variable explicitly, `Void` will be inferred and the method will return `null`.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ the dependency co-ordinates and add `mavenLocal()` to the `repositories` block i
 * For a searchable list of code snippets examples, see [**SNIPPETS.md**](https://github.com/Vonage/vonage-java-code-snippets/blob/main/SNIPPETS.md).
 * For Video API usage instructions, see [the guide on our developer portal](https://developer.vonage.com/en/video/server-sdks/java).
 
+### Custom Requests
+Beginning with v9.1.0, you can now make customisable requests to any Vonage API endpoint using the `CustomClient` class,
+obtained from the `VonageClient#getCustomClient()` method. This will take care of auth and serialisation for you.
+You can use existing data models from the SDK or create your own by extending `com.vonage.client.JsonableBaseObject`
+or implementing the `com.vonage.client.Jsonable` interface. For example, you can check your account balance using
+the following code, which will send a `get` request to the specified URL and return a `BalanceResponse` object:
+
+```java
+BalanceResponse response = client.getCustomClient().get("https://rest.nexmo.com/account/get-balance");
+```
+
+You can also parse the response into a `Map<String, ?>` which represents the JSON response body as a tree like so:
+
+```java
+Map<String, ?> response = client.getCustomClient().getJson("https://api-eu.vonage.com/v3/media?order=ascending&page_size=50");
+```
+
+The same applies for POST, PUT and PATCH requests when sending data.
+
 ## Configuration
 
 ## Typical Instantiation

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ BalanceResponse response = client.getCustomClient().get("https://rest.nexmo.com/
 You can also parse the response into a `Map<String, ?>` which represents the JSON response body as a tree like so:
 
 ```java
-Map<String, ?> response = client.getCustomClient().getJson("https://api-eu.vonage.com/v3/media?order=ascending&page_size=50");
+Map<String, ?> response = client.getCustomClient().get("https://api-eu.vonage.com/v3/media?order=ascending&page_size=50");
 ```
 
 The same applies for POST, PUT and PATCH requests when sending data.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.0.0")
+    implementation("com.vonage:server-sdk:9.1.0")
 }
 ```
 
@@ -85,7 +85,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.0.0</version>
+    <version>9.1.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,62 @@ You can also parse the response into a `Map<String, ?>` which represents the JSO
 Map<String, ?> response = client.getCustomClient().get("https://api-eu.vonage.com/v3/media?order=ascending&page_size=50");
 ```
 
-The same applies for POST, PUT and PATCH requests when sending data.
+The same applies for `POST`, `PUT` and `PATCH` requests when sending data.
+You can mix and match between `java.util.Map` and `com.vonage.client.Jsonable` interfaces for request and response bodies.
+For example, to create an application, you can use any of the following (all are equivalent):
+
+#### Map request, Map response
+
+```java
+Map<String, ?> response = client.getCustomClient().post(
+        "https://api.nexmo.com/v2/applications",
+        Map.of("name", "Demo Application")
+);
+```
+
+#### Map request, Jsonable response
+
+```java
+Application response = client.getCustomClient().post(
+        "https://api.nexmo.com/v2/applications",
+        Map.of("name", "Demo Application")
+);
+```
+
+#### Jsonable request, Map response
+
+```java
+Map<String, ?> response = client.getCustomClient().post(
+        "https://api.nexmo.com/v2/applications",
+        Application.builder().name("Demo Application").build()
+);
+```
+
+#### Jsonable request, Jsonable response
+
+```java
+Application response = client.getCustomClient().post(
+        "https://api.nexmo.com/v2/applications",
+        Application.builder().name("Demo Application").build()
+);
+```
+
+
+#### Advanced Usage
+The `CustomClient` provides preset methods for the supported HTTP request types and JSON-based request bodies.
+However, if you would like to make a request with non-JSON body (e.g. binary data), you can use the `makeRequest` method.
+This is a more convenient way of using `com.vonage.client.DynamicEndpoint` which takes care of most of the setup for you.
+
+#### Caveats
+Whilst the `CustomClient` class is a powerful tool, it is not intended to be a replacement for dedicated support
+which the SDK provides for Vonage APIs. Furthermore, you may notice your IDE giving warnings like
+"Unchecked generics array creation for varargs parameter". This is because all methods in `CustomClient` use a 
+varargs parameter for the response type as a way to infer the response type without you having to explicitly provide
+the `Class<R>` parameter. This is a known limitation of Java generics and is not a problem with the SDK itself, it is
+implemented this way for your convenience. As per the documentation, it is important to not pass any value for this
+varargs parameter - just omit it. If you do pass a value, the SDK will not be able to infer the response type.
+You should also always use explicit assignment for the `CustomClient` methods, as the SDK will not be able to infer the return type if you use `var` or `Object`.
+If you do not assign the response to a typed variable explicitly, `Void` will be inferred and the method will return `null`.
 
 ## Configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.0.0</version>
+  <version>9.1.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.12.1</version>
+      <version>5.12.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -1,0 +1,176 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.vonage.client.auth.ApiKeyAuthMethod;
+import com.vonage.client.auth.JWTAuthMethod;
+import com.vonage.client.common.HttpMethod;
+import org.apache.http.HttpResponse;
+import java.util.Map;
+
+/**
+ * Client for making custom requests to Vonage APIs unsupported by this SDK.
+ * This is useful for testing out beta APIs or making custom requests where the SDK falls short.
+ * You can specify the HTTP method, endpoint URL, request body parameters and response object to parse.
+ * The implementation is based on {@link DynamicEndpoint}.
+ * <p>
+ * The supported request and response types (i.e. the {@code <T>} and {@code <R>} generics)
+ * should be instances of {@link Jsonable}. See the {@linkplain DynamicEndpoint#parseResponse(HttpResponse)}
+ * method for how deserialisation is handled.
+ *
+ * @since 9.1.0
+ */
+@SuppressWarnings("unchecked")
+public class CustomClient {
+    private final HttpWrapper httpWrapper;
+
+    /**
+     * Wrapper for converting Map to JSON and vice versa.
+     */
+    static final class JsonableMap implements Jsonable {
+        private Map<String, ?> body;
+
+        @JsonAnyGetter
+        Map<String, ?> getBody() {
+            return body;
+        }
+
+        @JsonAnySetter
+        public void setBody(Map<String, ?> body) {
+            this.body = body;
+        }
+    }
+
+    /**
+     * Constructor for creating a custom client.
+     *
+     * @param httpWrapper Shared HTTP wrapper object and configuration used for making REST calls.
+     */
+    public CustomClient(HttpWrapper httpWrapper) {
+        this.httpWrapper = httpWrapper;
+    }
+
+    /**
+     * Most flexible method for making custom requests. This advanced option should only be used
+     * if you are familiar with the underlying {@linkplain DynamicEndpoint} implementation.
+     *
+     * @param requestMethod The HTTP method to use for the request.
+     * @param url Absolute URL to send the request to as a string.
+     * @param requestBody The payload to send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <T> The request body type.
+     * @param <R> The response body type.
+     */
+    public <T, R> R makeRequest(HttpMethod requestMethod, String url, T requestBody, R... responseType) {
+        return DynamicEndpoint.<T, R> builder(responseType)
+                .wrapper(httpWrapper)
+                .authMethod(JWTAuthMethod.class, ApiKeyAuthMethod.class)
+                .requestMethod(requestMethod)
+                .pathGetter((de, req) -> url)
+                .build().execute(requestBody);
+    }
+
+    /**
+     * Convenience method for making DELETE requests.
+     *
+     * @param url Absolute URL to send the request to as a string.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     *
+     * @param <R> The response body type. Most likely {@code Void} for most DELETE calls.
+     */
+    public <R> R delete(String url, R... responseType) {
+        return makeRequest(HttpMethod.DELETE, url, null, responseType);
+    }
+
+    public <R> R delete(String url, QueryParamsRequest queryParams, R... responseType) {
+        return makeRequest(HttpMethod.DELETE, url, queryParams, responseType);
+    }
+
+    public void delete(String url) {
+        delete(url, new Void[0]);
+    }
+
+    public void delete(String url, QueryParamsRequest queryParams) {
+        delete(url, queryParams, new Void[0]);
+    }
+
+
+
+    public <R> R get(String url, R... responseType) {
+        return makeRequest(HttpMethod.GET, url, null, responseType);
+    }
+
+    public <R> R get(String url, QueryParamsRequest queryParams, R... responseType) {
+        return makeRequest(HttpMethod.GET, url, queryParams, responseType);
+    }
+
+    public <R> R post(String url, Jsonable requestBody, R... responseType) {
+        return makeRequest(HttpMethod.POST, url, requestBody, responseType);
+    }
+
+    public <R> R post(String url, QueryParamsRequest queryParams, R... responseType) {
+        return makeRequest(HttpMethod.POST, url, queryParams, responseType);
+    }
+
+    public <R> R put(String url, Jsonable requestBody, R... responseType) {
+        return makeRequest(HttpMethod.PUT, url, requestBody, responseType);
+    }
+
+    public <R> R put(String url, QueryParamsRequest queryParams, R... responseType) {
+        return makeRequest(HttpMethod.PUT, url, queryParams, responseType);
+    }
+
+    public <R> R patch(String url, Jsonable requestBody, R... responseType) {
+        return makeRequest(HttpMethod.PATCH, url, requestBody, responseType);
+    }
+
+    public <R> R patch(String url, QueryParamsRequest queryParams, R... responseType) {
+        return makeRequest(HttpMethod.PATCH, url, queryParams, responseType);
+    }
+
+    public Map<String, ?> postJson(String url, Map<String, ?> requestBody) {
+        JsonableMap map = new JsonableMap();
+        map.setBody(requestBody);
+        map = post(url, map);
+        return map.getBody();
+    }
+
+    public Map<String, ?> getJson(String url) {
+        JsonableMap map = get(url);
+        return map.getBody();
+    }
+
+    public Map<String, ?> putJson(String url, Map<String, ?> requestBody) {
+        JsonableMap map = new JsonableMap();
+        map.setBody(requestBody);
+        map = put(url, map);
+        return map.getBody();
+    }
+
+    public Map<String, ?> patchJson(String url, Map<String, ?> requestBody) {
+        JsonableMap map = new JsonableMap();
+        map.setBody(requestBody);
+        map = patch(url, map);
+        return map.getBody();
+    }
+}

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -22,6 +22,7 @@ import com.vonage.client.auth.JWTAuthMethod;
 import com.vonage.client.auth.NoAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import org.apache.http.HttpResponse;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -33,6 +34,16 @@ import java.util.Map;
  * The supported request and response types (i.e. the {@code <T>} and {@code <R>} generics)
  * should be instances of {@link Jsonable}. See the {@linkplain DynamicEndpoint#parseResponse(HttpResponse)}
  * method for how deserialisation is handled.
+ * <p>
+ * The valid types for the return type parameter {@code <R>} are generally:
+ * <ul>
+ *     <li>{@link Jsonable} - for parsing the response body into a JSON object</li>
+ *     <li>{@link Map} - for parsing the response body as JSON into a tree structure</li>
+ *     <li>{@link Collection} - for parsing the response body as JSON into a list of objects</li>
+ *     <li>{@link Void} - for ignoring the response body</li>
+ *     <li>{@code byte[]} - for parsing the response body as binary</li>
+ *     <li>{@link String} - for returning the response body directly as a string</li>
+ * </ul>
  *
  * @since 9.1.0
  */
@@ -45,6 +56,10 @@ public class CustomClient {
      */
     static final class JsonableMap extends JsonableBaseObject {
         @JsonAnyGetter @JsonAnySetter Map<String, Object> body;
+
+        JsonableMap(Map<String, ?> body) {
+            this.body = (Map<String, Object>) body;
+        }
     }
 
     /**
@@ -132,16 +147,51 @@ public class CustomClient {
     }
 
     /**
+     * Convenience method for making JSON-based POST requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to convert to JSON and send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
+     */
+    public <R> R post(String url, Map<String, ?> requestBody, R... responseType) {
+        return post(url, new JsonableMap(requestBody), responseType);
+    }
+
+    /**
      * Convenience method for making PUT requests.
      *
      * @param url URL to send the request to as a string.
      * @param requestBody The payload to send in the request body.
      * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
      *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
      * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
      */
     public <R> R put(String url, Jsonable requestBody, R... responseType) {
         return makeRequest(HttpMethod.PUT, url, requestBody, responseType);
+    }
+
+    /**
+     * Convenience method for making JSON-based PUT requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to convert to JSON and send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
+     */
+    public <R> R put(String url, Map<String, ?> requestBody, R... responseType) {
+        return put(url, new JsonableMap(requestBody), responseType);
     }
 
     /**
@@ -161,63 +211,18 @@ public class CustomClient {
     }
 
     /**
-     * Convenience method for making JSON-based GET requests.
-     *
-     * @param url URL to send the request to as a string.
-     *
-     * @return The response body converted from JSON into a Map.
-     * @throws VonageApiResponseException If the HTTP response code is >= 400.
-     */
-    public Map<String, ?> getJson(String url) {
-        JsonableMap map = get(url);
-        return map.body;
-    }
-
-    /**
-     * Convenience method for making JSON-based POST requests.
-     *
-     * @param url URL to send the request to as a string.
-     * @param requestBody The payload to convert to JSON and send in the request body.
-     *
-     * @return The response body converted from JSON into a Map.
-     * @throws VonageApiResponseException If the HTTP response code is >= 400.
-     */
-    public Map<String, ?> postJson(String url, Map<String, ?> requestBody) {
-        JsonableMap map = new JsonableMap();
-        map.body = (Map<String, Object>) requestBody;
-        map = post(url, map);
-        return map.body;
-    }
-
-    /**
-     * Convenience method for making JSON-based PUT requests.
-     *
-     * @param url URL to send the request to as a string.
-     * @param requestBody The payload to convert to JSON and send in the request body.
-     *
-     * @return The response body converted from JSON into a Map.
-     * @throws VonageApiResponseException If the HTTP response code is >= 400.
-     */
-    public Map<String, ?> putJson(String url, Map<String, ?> requestBody) {
-        JsonableMap map = new JsonableMap();
-        map.body = (Map<String, Object>) requestBody;
-        map = put(url, map);
-        return map.body;
-    }
-
-    /**
      * Convenience method for making JSON-based PATCH requests.
      *
      * @param url URL to send the request to as a string.
      * @param requestBody The payload to convert to JSON and send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
      *
-     * @return The response body converted from JSON into a Map.
+     * @return The parsed response object, or {@code null} if absent / not applicable.
      * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
      */
-    public Map<String, ?> patchJson(String url, Map<String, ?> requestBody) {
-        JsonableMap map = new JsonableMap();
-        map.body = (Map<String, Object>) requestBody;
-        map = patch(url, map);
-        return map.body;
+    public <R> R patch(String url, Map<String, ?> requestBody, R... responseType) {
+        return patch(url, new JsonableMap(requestBody), responseType);
     }
 }

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -17,9 +17,7 @@ package com.vonage.client;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.vonage.client.auth.ApiKeyAuthMethod;
-import com.vonage.client.auth.JWTAuthMethod;
-import com.vonage.client.auth.NoAuthMethod;
+import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.common.HttpMethod;
 import org.apache.http.HttpResponse;
 import java.util.Collection;
@@ -89,7 +87,7 @@ public class CustomClient {
     public <T, R> R makeRequest(HttpMethod requestMethod, String url, T requestBody, R... responseType) {
         return DynamicEndpoint.<T, R> builder(fixResponseType(responseType))
                 .wrapper(httpWrapper).requestMethod(requestMethod)
-                .authMethod(JWTAuthMethod.class, ApiKeyAuthMethod.class, NoAuthMethod.class)
+                .authMethod(AuthMethod.class)   // All available methods are acceptable
                 .pathGetter((de, req) -> url)
                 .build().execute(requestBody);
     }

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -44,28 +44,8 @@ public class CustomClient {
     /**
      * Wrapper for converting Map to JSON and vice versa.
      */
-    static final class JsonableMap implements Jsonable {
-        private Map<String, ?> body;
-
-        /**
-         * Gets the body of the request.
-         *
-         * @return The request body as a Map.
-         */
-        @JsonAnyGetter
-        Map<String, ?> getBody() {
-            return body;
-        }
-
-        /**
-         * Sets the body of the request.
-         *
-         * @param body The request body as a Map.
-         */
-        @JsonAnySetter
-        public void setBody(Map<String, ?> body) {
-            this.body = body;
-        }
+    static final class JsonableMap extends JsonableBaseObject {
+        @JsonAnyGetter @JsonAnySetter Map<String, Object> body;
     }
 
     /**
@@ -196,11 +176,11 @@ public class CustomClient {
      * @return The response body converted from JSON into a Map.
      * @throws VonageApiResponseException If the HTTP response code is >= 400.
      */
-    public Map<String, ?> postJson(String url, Map<String, ?> requestBody) {
+    public Map<String, ?> postJson(String url, Map<String, Object> requestBody) {
         JsonableMap map = new JsonableMap();
-        map.setBody(requestBody);
+        map.body = requestBody;
         map = post(url, map);
-        return map.getBody();
+        return map.body;
     }
 
     /**
@@ -213,7 +193,7 @@ public class CustomClient {
      */
     public Map<String, ?> getJson(String url) {
         JsonableMap map = get(url);
-        return map.getBody();
+        return map.body;
     }
 
     /**
@@ -225,11 +205,11 @@ public class CustomClient {
      * @return The response body converted from JSON into a Map.
      * @throws VonageApiResponseException If the HTTP response code is >= 400.
      */
-    public Map<String, ?> putJson(String url, Map<String, ?> requestBody) {
+    public Map<String, ?> putJson(String url, Map<String, Object> requestBody) {
         JsonableMap map = new JsonableMap();
-        map.setBody(requestBody);
+        map.body = requestBody;
         map = put(url, map);
-        return map.getBody();
+        return map.body;
     }
 
     /**
@@ -241,10 +221,10 @@ public class CustomClient {
      * @return The response body converted from JSON into a Map.
      * @throws VonageApiResponseException If the HTTP response code is >= 400.
      */
-    public Map<String, ?> patchJson(String url, Map<String, ?> requestBody) {
+    public Map<String, ?> patchJson(String url, Map<String, Object> requestBody) {
         JsonableMap map = new JsonableMap();
-        map.setBody(requestBody);
+        map.body = requestBody;
         map = patch(url, map);
-        return map.getBody();
+        return map.body;
     }
 }

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -19,9 +19,11 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.vonage.client.auth.ApiKeyAuthMethod;
 import com.vonage.client.auth.JWTAuthMethod;
+import com.vonage.client.auth.NoAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import org.apache.http.HttpResponse;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Client for making custom requests to Vonage APIs unsupported by this SDK.
@@ -45,11 +47,21 @@ public class CustomClient {
     static final class JsonableMap implements Jsonable {
         private Map<String, ?> body;
 
+        /**
+         * Gets the body of the request.
+         *
+         * @return The request body as a Map.
+         */
         @JsonAnyGetter
         Map<String, ?> getBody() {
             return body;
         }
 
+        /**
+         * Sets the body of the request.
+         *
+         * @param body The request body as a Map.
+         */
         @JsonAnySetter
         public void setBody(Map<String, ?> body) {
             this.body = body;
@@ -81,10 +93,10 @@ public class CustomClient {
      * @param <R> The response body type.
      */
     public <T, R> R makeRequest(HttpMethod requestMethod, String url, T requestBody, R... responseType) {
-        return DynamicEndpoint.<T, R> builder(responseType)
-                .wrapper(httpWrapper)
-                .authMethod(JWTAuthMethod.class, ApiKeyAuthMethod.class)
-                .requestMethod(requestMethod)
+        return DynamicEndpoint.<T, R> builder(
+                    Objects.requireNonNull(responseType, "Do not pass anything for responseType, omit it instead.")
+                ).wrapper(httpWrapper).requestMethod(requestMethod)
+                .authMethod(JWTAuthMethod.class, ApiKeyAuthMethod.class, NoAuthMethod.class)
                 .pathGetter((de, req) -> url)
                 .build().execute(requestBody);
     }
@@ -92,62 +104,98 @@ public class CustomClient {
     /**
      * Convenience method for making DELETE requests.
      *
-     * @param url Absolute URL to send the request to as a string.
+     * @param url URL to send the request to as a string.
      * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
-     * @return The parsed response object, or {@code null} if absent / not applicable.
      *
-     * @param <R> The response body type. Most likely {@code Void} for most DELETE calls.
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
      */
     public <R> R delete(String url, R... responseType) {
         return makeRequest(HttpMethod.DELETE, url, null, responseType);
     }
 
-    public <R> R delete(String url, QueryParamsRequest queryParams, R... responseType) {
-        return makeRequest(HttpMethod.DELETE, url, queryParams, responseType);
-    }
-
+    /**
+     * Convenience method for making DELETE requests.
+     *
+     * @param url URL to send the request to as a string.
+     *
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public void delete(String url) {
         delete(url, new Void[0]);
     }
 
-    public void delete(String url, QueryParamsRequest queryParams) {
-        delete(url, queryParams, new Void[0]);
-    }
-
-
-
+    /**
+     * Convenience method for making GET requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
+     */
     public <R> R get(String url, R... responseType) {
         return makeRequest(HttpMethod.GET, url, null, responseType);
     }
 
-    public <R> R get(String url, QueryParamsRequest queryParams, R... responseType) {
-        return makeRequest(HttpMethod.GET, url, queryParams, responseType);
-    }
-
+    /**
+     * Convenience method for making POST requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
+     */
     public <R> R post(String url, Jsonable requestBody, R... responseType) {
         return makeRequest(HttpMethod.POST, url, requestBody, responseType);
     }
 
-    public <R> R post(String url, QueryParamsRequest queryParams, R... responseType) {
-        return makeRequest(HttpMethod.POST, url, queryParams, responseType);
-    }
-
+    /**
+     * Convenience method for making PUT requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public <R> R put(String url, Jsonable requestBody, R... responseType) {
         return makeRequest(HttpMethod.PUT, url, requestBody, responseType);
     }
 
-    public <R> R put(String url, QueryParamsRequest queryParams, R... responseType) {
-        return makeRequest(HttpMethod.PUT, url, queryParams, responseType);
-    }
-
+    /**
+     * Convenience method for making PATCH requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to send in the request body.
+     * @param responseType Hack for type inference. Do not provide this field (especially, DO NOT pass {@code null}).
+     *
+     * @return The parsed response object, or {@code null} if absent / not applicable.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     *
+     * @param <R> The response body type.
+     */
     public <R> R patch(String url, Jsonable requestBody, R... responseType) {
         return makeRequest(HttpMethod.PATCH, url, requestBody, responseType);
     }
 
-    public <R> R patch(String url, QueryParamsRequest queryParams, R... responseType) {
-        return makeRequest(HttpMethod.PATCH, url, queryParams, responseType);
-    }
-
+    /**
+     * Convenience method for making JSON-based POST requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to convert to JSON and send in the request body.
+     *
+     * @return The response body converted from JSON into a Map.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public Map<String, ?> postJson(String url, Map<String, ?> requestBody) {
         JsonableMap map = new JsonableMap();
         map.setBody(requestBody);
@@ -155,11 +203,28 @@ public class CustomClient {
         return map.getBody();
     }
 
+    /**
+     * Convenience method for making JSON-based GET requests.
+     *
+     * @param url URL to send the request to as a string.
+     *
+     * @return The response body converted from JSON into a Map.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public Map<String, ?> getJson(String url) {
         JsonableMap map = get(url);
         return map.getBody();
     }
 
+    /**
+     * Convenience method for making JSON-based PUT requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to convert to JSON and send in the request body.
+     *
+     * @return The response body converted from JSON into a Map.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public Map<String, ?> putJson(String url, Map<String, ?> requestBody) {
         JsonableMap map = new JsonableMap();
         map.setBody(requestBody);
@@ -167,6 +232,15 @@ public class CustomClient {
         return map.getBody();
     }
 
+    /**
+     * Convenience method for making JSON-based PATCH requests.
+     *
+     * @param url URL to send the request to as a string.
+     * @param requestBody The payload to convert to JSON and send in the request body.
+     *
+     * @return The response body converted from JSON into a Map.
+     * @throws VonageApiResponseException If the HTTP response code is >= 400.
+     */
     public Map<String, ?> patchJson(String url, Map<String, ?> requestBody) {
         JsonableMap map = new JsonableMap();
         map.setBody(requestBody);

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -58,7 +58,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 		authMethods = Objects.requireNonNull(builder.authMethods, "At least one auth method must be defined.");
 		requestMethod = Objects.requireNonNull(builder.requestMethod, "HTTP request method is required.");
 		pathGetter = Objects.requireNonNull(builder.pathGetter, "Path function is required.");
-		if ((responseType = builder.responseType) == null || responseType == Object.class) {
+		if ((responseType = builder.responseType) == Object.class) {
 			throw new IllegalStateException(
 					"Could not infer the response type." +
 					"Please provide it explicitly, or do not use var when assigning the result."
@@ -101,7 +101,7 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 		private Class<? extends VonageApiResponseException> responseExceptionType;
 
 		Builder(Class<R> responseType) {
-			this.responseType = responseType;
+			this.responseType = Objects.requireNonNull(responseType, "Response type class cannot be null.");
 		}
 
 		public Builder<T, R> wrapper(HttpWrapper wrapper) {

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -58,7 +58,12 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 		authMethods = Objects.requireNonNull(builder.authMethods, "At least one auth method must be defined.");
 		requestMethod = Objects.requireNonNull(builder.requestMethod, "HTTP request method is required.");
 		pathGetter = Objects.requireNonNull(builder.pathGetter, "Path function is required.");
-		responseType = Objects.requireNonNull(builder.responseType, "Response type is required.");
+		if ((responseType = builder.responseType) == null || responseType == Object.class) {
+			throw new IllegalStateException(
+					"Could not infer the response type." +
+					"Please provide it explicitly, or do not use var when assigning the result."
+			);
+		}
 		responseExceptionType = builder.responseExceptionType;
 		contentType = builder.contentType;
         accept = builder.accept == null &&

--- a/src/main/java/com/vonage/client/DynamicEndpoint.java
+++ b/src/main/java/com/vonage/client/DynamicEndpoint.java
@@ -314,7 +314,11 @@ public class DynamicEndpoint<T, R> extends AbstractMethod<T, R> {
 			if (Jsonable.class.isAssignableFrom(responseType)) {
 				return (R) Jsonable.fromJson(deser, (Class<? extends Jsonable>) responseType);
 			}
-			else if (Collection.class.isAssignableFrom(responseType) || isJsonableArrayResponse()) {
+			else if (
+					Map.class.isAssignableFrom(responseType) ||
+					Collection.class.isAssignableFrom(responseType) ||
+					isJsonableArrayResponse()
+			) {
 				return Jsonable.createDefaultObjectMapper().readValue(deser, responseType);
 			}
 			else {

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.0.0",
+            CLIENT_VERSION = "9.1.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -56,7 +56,7 @@ public class VonageClient {
      * The HTTP wrapper for this client and its sub-clients.
      */
     final HttpWrapper httpWrapper;
-
+    private final CustomClient custom;
     private final AccountClient account;
     private final ApplicationClient application;
     private final InsightClient insight;
@@ -83,6 +83,7 @@ public class VonageClient {
     private VonageClient(Builder builder) {
         httpWrapper = new HttpWrapper(builder.httpConfig, builder.authCollection, builder.httpClient);
 
+        custom = new CustomClient(httpWrapper);
         account = new AccountClient(httpWrapper);
         application = new ApplicationClient(httpWrapper);
         insight = new InsightClient(httpWrapper);
@@ -100,6 +101,16 @@ public class VonageClient {
         conversations = new ConversationsClient(httpWrapper);
         simSwap = new SimSwapClient(httpWrapper);
         numberVerification = new NumberVerificationClient(httpWrapper);
+    }
+
+    /**
+     * Returns a client for making custom HTTP requests.
+     *
+     * @return The {@linkplain CustomClient}.
+     * @since 9.1.0
+     */
+    public CustomClient getCustomClient() {
+        return custom;
     }
 
     /**

--- a/src/test/java/com/vonage/client/CustomClientTest.java
+++ b/src/test/java/com/vonage/client/CustomClientTest.java
@@ -1,0 +1,146 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unchecked")
+public class CustomClientTest extends AbstractClientTest<CustomClient> {
+    private static final String URL = "https://api.example.com/endpoint";
+    private static final Map<String, ?> PAYLOAD_MAP = Map.of(
+            "Key 1", "value1",
+            "K2", 2,
+            "Key3", true,
+            "4th_Key", Map.of(
+                    "Nested Key 1", "nestedValue1",
+                    "Nested Key 2", List.of("nestedLevel2Val1", 3.1459),
+                    "NK3", false,
+                    "Nested Key 4", Map.of(
+                            "Deeply Nested Key 1", "deeplyNestedValue1",
+                            "Deeply Nested Key 2", Map.of("singleton", List.of()),
+                            "Deeply Nested Key 3", 0.000000001
+                    )
+            ),
+            "k5", List.of(Map.of("k5l1", List.of(7, 8, 9)))
+    );
+    private static final String PAYLOAD_STR = new OrderedMap(PAYLOAD_MAP.entrySet().toArray(Map.Entry[]::new)).toJson();
+    private static final TestResponse TEST_JSONABLE = Jsonable.fromJson(PAYLOAD_STR);
+
+    static class TestResponse extends JsonableBaseObject {
+        private String key1;
+        private Integer k2;
+        private Boolean key3;
+        private Map<String, Object> nestedKey4;
+
+        @JsonProperty("Key 1")
+        public String getKey1() {
+            return key1;
+        }
+
+        @JsonProperty("K2")
+        public Integer getK2() {
+            return k2;
+        }
+
+        @JsonProperty("Key3")
+        public Boolean isKey3() {
+            return key3;
+        }
+
+        @JsonProperty("4th_Key")
+        public Map<String, ?> getNestedKey4() {
+            return nestedKey4;
+        }
+    }
+
+    public CustomClientTest() {
+        client = new CustomClient(wrapper);
+    }
+
+    @Test
+    public void testJsonMethods() throws Exception {
+        stubResponse(PAYLOAD_STR);
+        assertEquals(PAYLOAD_MAP, client.getJson(URL));
+        assertEquals(PAYLOAD_MAP, client.postJson(URL, PAYLOAD_MAP));
+        assertEquals(PAYLOAD_MAP, client.putJson(URL, PAYLOAD_MAP));
+        assertEquals(PAYLOAD_MAP, client.patchJson(URL, PAYLOAD_MAP));
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        stubResponse(204);
+        client.delete(URL);
+        assertNull(client.delete(URL, (Object) null));
+        assertNull(client.delete(URL, (Object[]) null));
+        stubResponse(204, PAYLOAD_STR);
+        TestResponse responseBody = client.delete(URL);
+        assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(401);
+        assertThrows(VonageApiResponseException.class, () -> client.delete(URL));
+    }
+
+    @Test
+    public void testGet() throws Exception {
+        stubResponse(PAYLOAD_STR);
+        TestResponse responseBody = client.get(URL);
+        assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(404);
+        assertThrows(VonageApiResponseException.class, () -> client.get(URL));
+    }
+
+    @Test
+    public void testPost() throws Exception {
+        stubResponse(PAYLOAD_STR);
+        TestResponse responseBody = client.post(URL, new OrderedMap());
+        assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(201);
+        client.post(URL, TEST_JSONABLE);
+        assertNull(client.post(URL, TEST_JSONABLE, (Object) null));
+        assertNull(client.post(URL, TEST_JSONABLE, (Object[]) null));
+        stubResponse(400);
+        assertThrows(VonageApiResponseException.class, () -> client.post(URL, TEST_JSONABLE));
+    }
+
+    @Test
+    public void testPut() throws Exception {
+        stubResponse(PAYLOAD_STR);
+        TestResponse responseBody = client.put(URL, new OrderedMap());
+        assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(202);
+        client.put(URL, TEST_JSONABLE);
+        assertNull(client.put(URL, TEST_JSONABLE, (Object) null));
+        assertNull(client.put(URL, TEST_JSONABLE, (Object[]) null));
+        stubResponse(409);
+        assertThrows(VonageApiResponseException.class, () -> client.put(URL, TEST_JSONABLE));
+    }
+
+    @Test
+    public void testPatch() throws Exception {
+        stubResponse(PAYLOAD_STR);
+        TestResponse responseBody = client.patch(URL, new OrderedMap());
+        assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(204);
+        client.patch(URL, TEST_JSONABLE);
+        assertNull(client.patch(URL, TEST_JSONABLE, (Object) null));
+        assertNull(client.patch(URL, TEST_JSONABLE, (Object[]) null));
+        stubResponse(406);
+        assertThrows(VonageApiResponseException.class, () -> client.patch(URL, TEST_JSONABLE));
+    }
+}

--- a/src/test/java/com/vonage/client/CustomClientTest.java
+++ b/src/test/java/com/vonage/client/CustomClientTest.java
@@ -111,6 +111,9 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
         client.post(URL, TEST_JSONABLE);
         assertNull(client.post(URL, TEST_JSONABLE, (Object) null));
         assertNull(client.post(URL, TEST_JSONABLE, (Object[]) null));
+        stubResponse(PAYLOAD_STR);
+        responseBody = client.post(URL, (Jsonable) null);
+        assertEquals(TEST_JSONABLE, responseBody);
         stubResponse(400);
         assertThrows(VonageApiResponseException.class, () -> client.post(URL, TEST_JSONABLE));
     }

--- a/src/test/java/com/vonage/client/CustomClientTest.java
+++ b/src/test/java/com/vonage/client/CustomClientTest.java
@@ -75,15 +75,6 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
     }
 
     @Test
-    public void testJsonMethods() throws Exception {
-        stubResponse(PAYLOAD_STR);
-        assertEquals(PAYLOAD_MAP, client.getJson(URL));
-        assertEquals(PAYLOAD_MAP, client.postJson(URL, PAYLOAD_MAP));
-        assertEquals(PAYLOAD_MAP, client.putJson(URL, PAYLOAD_MAP));
-        assertEquals(PAYLOAD_MAP, client.patchJson(URL, PAYLOAD_MAP));
-    }
-
-    @Test
     public void testDelete() throws Exception {
         stubResponse(204);
         client.delete(URL);
@@ -101,6 +92,9 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
         stubResponse(PAYLOAD_STR);
         TestResponse responseBody = client.get(URL);
         assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(PAYLOAD_STR);
+        Map<String, ?> responseBodyMap = client.get(URL);
+        assertEquals(PAYLOAD_MAP, responseBodyMap);
         stubResponse(404);
         assertThrows(VonageApiResponseException.class, () -> client.get(URL));
     }
@@ -108,8 +102,11 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
     @Test
     public void testPost() throws Exception {
         stubResponse(PAYLOAD_STR);
-        TestResponse responseBody = client.post(URL, new OrderedMap());
+        TestResponse responseBody = client.post(URL, (Jsonable) new OrderedMap());
         assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(PAYLOAD_STR);
+        Map<String, ?> responseBodyMap = client.post(URL, (Map<String, ?>) new OrderedMap());
+        assertEquals(PAYLOAD_MAP, responseBodyMap);
         stubResponse(201);
         client.post(URL, TEST_JSONABLE);
         assertNull(client.post(URL, TEST_JSONABLE, (Object) null));
@@ -121,8 +118,11 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
     @Test
     public void testPut() throws Exception {
         stubResponse(PAYLOAD_STR);
-        TestResponse responseBody = client.put(URL, new OrderedMap());
+        TestResponse responseBody = client.put(URL, (Map<String, ?>) new OrderedMap());
         assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(PAYLOAD_STR);
+        Map<String, ?> responseBodyMap = client.put(URL, (Jsonable) new OrderedMap());
+        assertEquals(PAYLOAD_MAP, responseBodyMap);
         stubResponse(202);
         client.put(URL, TEST_JSONABLE);
         assertNull(client.put(URL, TEST_JSONABLE, (Object) null));
@@ -134,8 +134,11 @@ public class CustomClientTest extends AbstractClientTest<CustomClient> {
     @Test
     public void testPatch() throws Exception {
         stubResponse(PAYLOAD_STR);
-        TestResponse responseBody = client.patch(URL, new OrderedMap());
+        TestResponse responseBody = client.patch(URL, (Jsonable) new OrderedMap());
         assertEquals(TEST_JSONABLE, responseBody);
+        stubResponse(PAYLOAD_STR);
+        Map<String, ?> responseBodyMap = client.patch(URL, (Map<String, ?>) new OrderedMap());
+        assertEquals(PAYLOAD_MAP, responseBodyMap);
         stubResponse(204);
         client.patch(URL, TEST_JSONABLE);
         assertNull(client.patch(URL, TEST_JSONABLE, (Object) null));

--- a/src/test/java/com/vonage/client/DynamicEndpointTest.java
+++ b/src/test/java/com/vonage/client/DynamicEndpointTest.java
@@ -46,6 +46,14 @@ public class DynamicEndpointTest {
         return endpoint;
     }
 
+
+    @Test
+    public void testUntypedEndpoint() {
+        assertThrows(IllegalStateException.class, DynamicEndpointTest::newEndpoint);
+        assertThrows(IllegalStateException.class, () -> newEndpoint((Object) null));
+        assertThrows(NullPointerException.class, () -> newEndpoint((Object[]) null));
+    }
+
     @Test
     public void testRedirectHandling() throws Exception {
         DynamicEndpoint<byte[], URI> uriEndpoint = newEndpoint();
@@ -56,14 +64,14 @@ public class DynamicEndpointTest {
         stubResponse(WRAPPER, 302, TEST_REDIRECT_URI);
         assertEquals(TEST_REDIRECT_URI, stringEndpoint.execute("bar"));
 
-        DynamicEndpoint<String, Object> objectEndpoint = newEndpoint();
+        DynamicEndpoint<String, DynamicEndpointTest> unsupportedReturnEndpoint = newEndpoint();
         stubResponse(WRAPPER, 302, TEST_REDIRECT_URI);
-        assertThrows(IllegalStateException.class, () -> objectEndpoint.execute("foo"));
+        assertThrows(IllegalStateException.class, () -> unsupportedReturnEndpoint.execute("foo"));
     }
 
     @Test
     public void testInformationalResponse() throws Exception {
-        var endpoint = newEndpoint();
+        DynamicEndpoint<byte[], Void> endpoint = newEndpoint();
         stubResponse(WRAPPER, 100, "Continue");
         assertNull(endpoint.execute(new byte[0]));
     }

--- a/src/test/java/com/vonage/client/OrderedMap.java
+++ b/src/test/java/com/vonage/client/OrderedMap.java
@@ -20,7 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-public class OrderedMap extends LinkedHashMap<String, Object> {
+public class OrderedMap extends LinkedHashMap<String, Object> implements Jsonable {
 
     public OrderedMap() {
         super();

--- a/src/test/java/com/vonage/client/VonageClientTest.java
+++ b/src/test/java/com/vonage/client/VonageClientTest.java
@@ -242,6 +242,7 @@ public class VonageClientTest extends AbstractClientTest<VonageClient> {
         assertNotNull(client.getApplicationClient());
         assertNotNull(client.getConversationsClient());
         assertNotNull(client.getConversionClient());
+        assertNotNull(client.getCustomClient());
         assertNotNull(client.getVoiceClient());
         assertNotNull(client.getInsightClient());
         assertNotNull(client.getMessagesClient());


### PR DESCRIPTION
This PR allows users of the SDK to declaratively make custom requests with their own JSON-based request and response types and to specify the URL and HTTP method, whilst automatically handling the authentication, serialisation and deserialisation. This is implemented as methods on the new `CustomClient` class, accessible from `VonageClient#getCustomClient()`.