### PR TITLE
fix: CustomClient return type validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [9.3.1] - 2025-0?-??
+# [9.3.1] - 2025-05-08
+- Fixed `CustomClient` return type validation (normalise to `Void` if unknown)
 - Deprecated Verify v1, SIM Swap and Number Verification APIs
 
 # [9.3.0] - 2025-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.3.1] - 2025-0?-??
+- Deprecated Verify v1, SIM Swap and Number Verification APIs
+
 # [9.3.0] - 2025-05-07
 - Added support for native failover in Messages API
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.3.0")
+    implementation("com.vonage:server-sdk:9.3.1")
 }
 ```
 
@@ -85,7 +85,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.3.0</version>
+    <version>9.3.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.3.0</version>
+  <version>9.3.1</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/CustomClient.java
+++ b/src/main/java/com/vonage/client/CustomClient.java
@@ -92,9 +92,28 @@ public class CustomClient {
                 .build().execute(requestBody);
     }
 
+    /**
+     * Normalises the response type to {@linkplain Void} if unknown.
+     *
+     * @param responseType Response type parameter (not provided directly).
+     *
+     * @return The updated response type parameter (to be provided downstream as varargs).
+     * @param <R> The type parameter.
+     */
     private <R> R[] fixResponseType(R... responseType) {
-        return responseType == null || Object.class.equals(responseType.getClass().getComponentType()) ?
-                (R[]) new Void[0] : responseType;
+        Class<R> componentType = (Class<R>) responseType.getClass().getComponentType();
+        if (
+            String.class.equals(componentType) ||
+            byte[].class.equals(componentType) ||
+            Jsonable.class.isAssignableFrom(componentType) ||
+            Map.class.isAssignableFrom(componentType) ||
+            Collection.class.isAssignableFrom(componentType)
+        ) {
+            return responseType;
+        }
+        else {
+            return (R[]) new Void[0];
+        }
     }
 
     /**

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.3.0",
+            CLIENT_VERSION = "9.3.1",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -162,7 +162,10 @@ public class VonageClient {
      * Returns the Verify v1 API client.
      *
      * @return The {@linkplain VerifyClient}.
+     *
+     * @deprecated Please migrate to using {@linkplain #getVerify2Client()} instead.
      */
+    @Deprecated
     public VerifyClient getVerifyClient() {
         return verify;
     }
@@ -259,7 +262,10 @@ public class VonageClient {
      *
      * @return The {@linkplain SimSwapClient}.
      * @since 8.8.0
+     *
+     * @deprecated This API will be removed in the next major release.
      */
+    @Deprecated
     public SimSwapClient getSimSwapClient() {
         return simSwap;
     }
@@ -269,7 +275,10 @@ public class VonageClient {
      *
      * @return The {@linkplain NumberVerificationClient}.
      * @since 8.9.0
+     *
+     * @deprecated This API will be removed in the next major release.
      */
+    @Deprecated
     public NumberVerificationClient getNumberVerificationClient() {
         return numberVerification;
     }

--- a/src/main/java/com/vonage/client/camara/numberverification/NumberVerificationClient.java
+++ b/src/main/java/com/vonage/client/camara/numberverification/NumberVerificationClient.java
@@ -31,7 +31,10 @@ import java.util.UUID;
 /**
  * A client for communicating with the Vonage Number Verification API. The standard way to obtain an instance
  * of this class is to use {@link VonageClient#getNumberVerificationClient()}.
+ *
+ * @deprecated This API will be removed in the next major release.
  */
+@Deprecated
 public class NumberVerificationClient extends NetworkApiClient {
     final RestEndpoint<VerifyNumberRequest, VerifyNumberResponse> verifyNumber;
     private final UUID appId;

--- a/src/main/java/com/vonage/client/camara/numberverification/package-info.java
+++ b/src/main/java/com/vonage/client/camara/numberverification/package-info.java
@@ -22,4 +22,5 @@
  *
  * @since 8.9.0
  */
+@Deprecated
 package com.vonage.client.camara.numberverification;

--- a/src/main/java/com/vonage/client/camara/package-info.java
+++ b/src/main/java/com/vonage/client/camara/package-info.java
@@ -20,4 +20,5 @@
  *
  * @since 8.8.0
  */
+@Deprecated
 package com.vonage.client.camara;

--- a/src/main/java/com/vonage/client/camara/simswap/SimSwapClient.java
+++ b/src/main/java/com/vonage/client/camara/simswap/SimSwapClient.java
@@ -32,7 +32,10 @@ import java.time.Instant;
 /**
  * A client for communicating with the Vonage SIM Swap API. The standard way to obtain an instance
  * of this class is to use {@link VonageClient#getSimSwapClient()}.
+ *
+ * @deprecated This API will be removed in the next major release.
  */
+@Deprecated
 public class SimSwapClient extends NetworkApiClient {
     final RestEndpoint<SimSwapRequest, CheckSimSwapResponse> check;
     final RestEndpoint<SimSwapRequest, SimSwapDateResponse> retrieveDate;

--- a/src/main/java/com/vonage/client/camara/simswap/package-info.java
+++ b/src/main/java/com/vonage/client/camara/simswap/package-info.java
@@ -22,4 +22,5 @@
  *
  * @since 8.8.0
  */
+@Deprecated
 package com.vonage.client.camara.simswap;

--- a/src/main/java/com/vonage/client/conversations/package-info.java
+++ b/src/main/java/com/vonage/client/conversations/package-info.java
@@ -13,8 +13,11 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+
 /**
- * Implementation of the <a href=https://developer.vonage.com/en/conversation/overview>Conversation API</a>.
+ * Implementation of the <a href=https://developer.vonage.com/en/api/conversation>Conversation API</a>.
+ * See the <a href=https://developer.vonage.com/en/conversation/overview>Vonage developer portal</a>
+ * for an overview and documentation.
  *
  * @since 8.4.0
  */

--- a/src/main/java/com/vonage/client/verify/VerifyClient.java
+++ b/src/main/java/com/vonage/client/verify/VerifyClient.java
@@ -29,7 +29,10 @@ import java.util.Locale;
  * <p>
  * More information on method parameters can be found on the
  * <a href="https://developer.vonage.com/verify/overview">Vonage developer portal</a>.
+ *
+ * @deprecated Please migrate to {@link com.vonage.client.verify2}.
  */
+@Deprecated
 public class VerifyClient {
     final RestEndpoint<CheckRequest, CheckResponse> check;
     final RestEndpoint<VerifyRequest, VerifyResponse> verify;

--- a/src/main/java/com/vonage/client/verify/package-info.java
+++ b/src/main/java/com/vonage/client/verify/package-info.java
@@ -19,4 +19,5 @@
  * See the <a href=https://developer.vonage.com/en/verify/verify-v1/overview>Vonage developer portal</a>
  * for an overview and documentation.
  */
+@Deprecated
 package com.vonage.client.verify;


### PR DESCRIPTION
Fixes the `CustomClient#fixResponseType` method to ensure only known types are accepted.