### PR TITLE
Add Lithuanian and Marathi to TextToSpeechLanguage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.4.2] - 2025-10-23
+- Added missing supported languages (Lithuanian and Marathi) to `TextToSpeechLanguage` enum
+
 # [9.4.1] - 2025-08-22
 - Fixed typo for verify to correct the call to next workflow
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.4.1")
+    implementation("com.vonage:server-sdk:9.4.2")
 }
 ```
 
@@ -85,7 +85,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.4.1</version>
+    <version>9.4.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.4.1</version>
+  <version>9.4.2</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.4.1",
+            CLIENT_VERSION = "9.4.2",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
+++ b/src/main/java/com/vonage/client/voice/TextToSpeechLanguage.java
@@ -90,6 +90,8 @@ public enum TextToSpeechLanguage {
     UKRAINIAN("uk-UA"),
     VIETNAMESE("vi-VN"),
     CHINESE_YUE("yue-CN"),
+    LITHUANIAN("lt-LT"),
+    MARATHI("mr-IN"),
 
     @JsonEnumDefaultValue
     UNKNOWN("Unknown");

--- a/src/test/java/com/vonage/client/voice/TextToSpeechLanguageTest.java
+++ b/src/test/java/com/vonage/client/voice/TextToSpeechLanguageTest.java
@@ -90,6 +90,8 @@ public class TextToSpeechLanguageTest {
         assertEquals(UKRAINIAN, fromString("uk-UA"));
         assertEquals(VIETNAMESE, fromString("vi-VN"));
         assertEquals(CHINESE_YUE, fromString("yue-CN"));
+        assertEquals(LITHUANIAN, fromString("lt-LT"));
+        assertEquals(MARATHI, fromString("mr-IN"));
         assertEquals(UNKNOWN, fromString("Klingon"));
     }
 


### PR DESCRIPTION
Lithuanian and Marathi are supported per https://developer.vonage.com/en/voice/voice-api/concepts/text-to-speech#voice-names but are not present in the TextToSpeechLanguage enum. Add them.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
