### PR TITLE
feat: Relaxed MMS caption length to 3000, can set RCS category, and new WhatsApp pricing info can be deserialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.6.0] - 2025-12-04
+- MMS caption length increased on 3000
+- Added new RCS param for messages to set the category
+- Added additional whatsapp information for deserializing incoming messages that contain pricing.
+
 # [9.5.0] - 2025-12-04
 - Added `trusted-number` to SMS
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.5.0")
+    implementation("com.vonage:server-sdk:9.6.0")
 }
 ```
 
@@ -85,7 +85,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.5.0</version>
+    <version>9.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.5.0</version>
+  <version>9.6.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.5.0",
+            CLIENT_VERSION = "9.6.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/messages/MessageStatus.java
+++ b/src/main/java/com/vonage/client/messages/MessageStatus.java
@@ -196,7 +196,47 @@ public class MessageStatus extends JsonableBaseObject {
 			@JsonProperty("id") String id;
 			@JsonProperty("origin") Origin origin;
 		}
+
+		/**
+		 * Represents WhatsApp pricing information in the status webhook.
+		 *
+		 * @since 9.5.0
+		 */
+		public static class Pricing extends JsonableBaseObject {
+			@JsonProperty("type") String type;
+			@JsonProperty("pricing_model") String pricingModel;
+			@JsonProperty("category") String category;
+
+			/**
+			 * The pricing type.
+			 *
+			 * @return The pricing type as a string. Possible values: {@code regular}, {@code free_customer_service}, {@code free_entry_point}.
+			 */
+			public String getType() {
+				return type;
+			}
+
+			/**
+			 * The pricing model.
+			 *
+			 * @return The pricing model as a string. Possible values: {@code PMP}, {@code CBP}.
+			 */
+			public String getPricingModel() {
+				return pricingModel;
+			}
+
+			/**
+			 * The message category.
+			 *
+			 * @return The category as a string. Possible values: {@code authentication}, {@code authentication_international}, {@code marketing}, {@code utility}, {@code service}, {@code referral_conversion}, {@code marketing_lite}.
+			 */
+			public String getCategory() {
+				return category;
+			}
+		}
+
 		@JsonProperty("conversation") Conversation conversation;
+		@JsonProperty("pricing") Pricing pricing;
 	}
 
 	protected MessageStatus() {
@@ -368,6 +408,19 @@ public class MessageStatus extends JsonableBaseObject {
 	public String getWhatsappConversationId() {
         return whatsapp != null && whatsapp.conversation != null ? whatsapp.conversation.id : null;
     }
+
+	/**
+	 * If the {@linkplain #getChannel()} is {@linkplain Channel#WHATSAPP}, returns the pricing information
+	 * for the message.
+	 *
+	 * @return The WhatsApp pricing information, {@code null} if absent or not applicable.
+	 *
+	 * @since 9.5.0
+	 */
+	@JsonIgnore
+	public Whatsapp.Pricing getWhatsappPricing() {
+		return whatsapp != null ? whatsapp.pricing : null;
+	}
 
 	/**
 	 * Catch-all for properties which are not mapped by this class during deserialization.

--- a/src/main/java/com/vonage/client/messages/mms/Content.java
+++ b/src/main/java/com/vonage/client/messages/mms/Content.java
@@ -50,7 +50,7 @@ public class Content extends JsonableBaseObject {
             default: throw new IllegalArgumentException("Unsupported media type: " + type);
         }
         MessagePayload payload = new MessagePayload(url, caption);
-        payload.validateCaptionLength(2000);
+        payload.validateCaptionLength(3000);
         this.url = payload.getUrl();
         this.caption = payload.getCaption();
     }

--- a/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsImageRequest.java
@@ -54,7 +54,7 @@ public final class MmsImageRequest extends MmsRequest implements CaptionMediaMes
 
 		/**
 		 * (OPTIONAL)
-		 * Additional text to accompany the image. Must be between 1 and 2000 characters.
+		 * Additional text to accompany the image. Must be between 1 and 3000 characters.
 		 *
 		 * @param caption The caption string.
 		 * @return This builder.

--- a/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
@@ -25,7 +25,7 @@ public abstract class MmsRequest extends MessageRequest {
 	protected MmsRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.MMS, messageType);
 		if (media != null) {
-			media.validateCaptionLength(2000);
+			media.validateCaptionLength(3000);
 		}
 		int min = 300, max = 259200;
 		if (ttl != null && (ttl < min || ttl > max)) {

--- a/src/main/java/com/vonage/client/messages/rcs/Rcs.java
+++ b/src/main/java/com/vonage/client/messages/rcs/Rcs.java
@@ -1,0 +1,49 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages.rcs;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * RCS-specific parameters.
+ *
+ * @since 9.6.0
+ */
+public final class Rcs extends JsonableBaseObject {
+	private String category;
+
+	Rcs() {}
+
+	/**
+	 * Creates an RCS options object with the specified category.
+	 *
+	 * @param category The RCS message category.
+	 */
+	public Rcs(String category) {
+		this.category = category;
+	}
+
+	/**
+	 * The RCS message category.
+	 *
+	 * @return The category as a string, or {@code null} if not set.
+	 */
+	@JsonProperty("category")
+	public String getCategory() {
+		return category;
+	}
+}

--- a/src/main/java/com/vonage/client/messages/rcs/RcsRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsRequest.java
@@ -26,9 +26,11 @@ import com.vonage.client.common.MessageType;
  * @since 8.11.0
  */
 public abstract class RcsRequest extends MessageRequest {
+	protected Rcs rcs;
 
 	protected RcsRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.RCS, messageType);
+		this.rcs = builder.rcs;
 	}
 
 	@JsonProperty("ttl")
@@ -36,7 +38,41 @@ public abstract class RcsRequest extends MessageRequest {
 		return ttl;
 	}
 
+	@JsonProperty("rcs")
+	public Rcs getRcs() {
+		return rcs;
+	}
+
+	@SuppressWarnings("unchecked")
 	protected abstract static class Builder<M extends RcsRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
+		protected Rcs rcs;
+
+		/**
+		 * (OPTIONAL)
+		 * Sets RCS-specific parameters.
+		 *
+		 * @param rcs The RCS options object.
+		 * @return This builder.
+		 *
+		 * @since 9.5.0
+		 */
+		public B rcs(Rcs rcs) {
+			this.rcs = rcs;
+			return (B) this;
+		}
+
+		/**
+		 * (OPTIONAL)
+		 * Sets the RCS message category.
+		 *
+		 * @param category The RCS category.
+		 * @return This builder.
+		 *
+		 * @since 9.5.0
+		 */
+		public B rcsCategory(String category) {
+			return rcs(new Rcs(category));
+		}
 
 		@Override
 		protected B ttl(int ttl) {

--- a/src/test/java/com/vonage/client/messages/mms/MmsAudioRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsAudioRequestTest.java
@@ -76,9 +76,11 @@ public class MmsAudioRequestTest {
 			assertEquals("V", builder.caption("V").build().getAudio().getCaption());
 		}
 
-		StringBuilder sb = new StringBuilder(2001);
-        sb.append("*".repeat(1999));
-		assertEquals(1999, sb.length());
+		StringBuilder sb = new StringBuilder(3001);
+		for (int i = 0; i < 2999; i++) {
+			sb.append('*');
+		}
+		assertEquals(2999, sb.length());
 
 		assertEquals(sb.toString(), builder.caption(sb.toString()).build().getAudio().getCaption());
 		try {
@@ -86,7 +88,7 @@ public class MmsAudioRequestTest {
 			fail("Expected exception for caption length");
 		}
 		catch (IllegalArgumentException ex) {
-			assertEquals(2001, sb.length());
+			assertEquals(3001, sb.length());
 		}
 	}
 }

--- a/src/test/java/com/vonage/client/messages/mms/MmsContentRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsContentRequestTest.java
@@ -124,9 +124,9 @@ public class MmsContentRequestTest {
 		assertEquals(caption, content.getCaption());
 		assertThrows(IllegalArgumentException.class, () -> new Content(MessageType.IMAGE, imageUrl, ""));
 
-		StringBuilder sb = new StringBuilder(2001);
-		sb.append("*".repeat(1999));
-		assertEquals(1999, sb.length());
+		StringBuilder sb = new StringBuilder(3001);
+		sb.append("*".repeat(2999));
+		assertEquals(2999, sb.length());
 
 		var sbStr = sb.toString();
 		assertEquals(sbStr, new Content(MessageType.IMAGE, imageUrl, sbStr).getCaption());
@@ -135,7 +135,7 @@ public class MmsContentRequestTest {
 			fail("Expected exception for caption length");
 		}
 		catch (IllegalArgumentException ex) {
-			assertEquals(2001, sb.length());
+			assertEquals(3001, sb.length());
 		}
 	}
 }

--- a/src/test/java/com/vonage/client/messages/mms/MmsFileRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsFileRequestTest.java
@@ -76,9 +76,11 @@ public class MmsFileRequestTest {
 			assertEquals("V", builder.caption("V").build().getFile().getCaption());
 		}
 
-		StringBuilder sb = new StringBuilder(2001);
-        sb.append("*".repeat(1999));
-		assertEquals(1999, sb.length());
+		StringBuilder sb = new StringBuilder(3001);
+		for (int i = 0; i < 2999; i++) {
+			sb.append('*');
+		}
+		assertEquals(2999, sb.length());
 
 		assertEquals(sb.toString(), builder.caption(sb.toString()).build().getFile().getCaption());
 		try {
@@ -86,7 +88,7 @@ public class MmsFileRequestTest {
 			fail("Expected exception for caption length");
 		}
 		catch (IllegalArgumentException ex) {
-			assertEquals(2001, sb.length());
+			assertEquals(3001, sb.length());
 		}
 	}
 }

--- a/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
@@ -94,11 +94,11 @@ public class MmsImageRequestTest {
 			assertEquals("V", builder.caption("V").build().getImage().getCaption());
 		}
 
-		StringBuilder sb = new StringBuilder(2001);
-		for (int i = 0; i < 1999; i++) {
+		StringBuilder sb = new StringBuilder(3001);
+		for (int i = 0; i < 2999; i++) {
 			sb.append('*');
 		}
-		assertEquals(1999, sb.length());
+		assertEquals(2999, sb.length());
 
 		assertEquals(sb.toString(), builder.caption(sb.toString()).build().getImage().getCaption());
 		try {
@@ -106,7 +106,7 @@ public class MmsImageRequestTest {
 			fail("Expected exception for caption length");
 		}
 		catch (IllegalArgumentException ex) {
-			assertEquals(2001, sb.length());
+			assertEquals(3001, sb.length());
 		}
 	}
 }

--- a/src/test/java/com/vonage/client/messages/mms/MmsVideoRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsVideoRequestTest.java
@@ -69,11 +69,11 @@ public class MmsVideoRequestTest {
 			assertEquals("V", builder.caption("V").build().getVideo().getCaption());
 		}
 
-		StringBuilder sb = new StringBuilder(2001);
-		for (int i = 0; i < 1999; i++) {
+		StringBuilder sb = new StringBuilder(3001);
+		for (int i = 0; i < 2999; i++) {
 			sb.append('*');
 		}
-		assertEquals(1999, sb.length());
+		assertEquals(2999, sb.length());
 
 		assertEquals(sb.toString(), builder.caption(sb.toString()).build().getVideo().getCaption());
 		try {
@@ -81,7 +81,7 @@ public class MmsVideoRequestTest {
 			fail("Expected exception for caption length");
 		}
 		catch (IllegalArgumentException ex) {
-			assertEquals(2001, sb.length());
+			assertEquals(3001, sb.length());
 		}
 	}
 }


### PR DESCRIPTION
- MMS caption length increased on 3000
- Added new RCS param for messages to set the category
- Added additional whatsapp information for deserializing incoming messages that contain pricing.

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
