### PR TITLE
feat: Add template_id support to VerificationRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [Unreleased]
+- Added `templateId` support to `VerificationRequest` for Verify v2 API to allow using custom templates
+
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type
 

--- a/src/main/java/com/vonage/client/verify2/VerificationRequest.java
+++ b/src/main/java/com/vonage/client/verify2/VerificationRequest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -41,11 +42,13 @@ public class VerificationRequest implements Jsonable {
 	protected final Integer channelTimeout, codeLength;
 	protected final Boolean fraudCheck;
 	protected final String brand, code, clientRef;
+	protected final UUID templateId;
 	protected final List<Workflow> workflows;
 
 	VerificationRequest(Builder builder) {
 		locale = builder.locale;
 		clientRef = builder.clientRef;
+		templateId = builder.templateId;
 		fraudCheck = builder.fraudCheck != null && !builder.fraudCheck ? false : null;
 		if ((brand = builder.brand) == null || brand.trim().isEmpty()) {
 			throw new IllegalArgumentException("Brand name is required.");
@@ -180,6 +183,17 @@ public class VerificationRequest implements Jsonable {
 	}
 
 	/**
+	 * A custom template ID to use for the verification request.
+	 * This allows you to use a pre-configured template instead of the default verification message.
+	 *
+	 * @return The template ID, or {@code null} if not set.
+	 */
+	@JsonProperty("template_id")
+	public UUID getTemplateId() {
+		return templateId;
+	}
+
+	/**
 	 * Entry point for constructing an instance of this class.
 	 *
 	 * @return A new Builder.
@@ -193,6 +207,7 @@ public class VerificationRequest implements Jsonable {
 		String brand, code, clientRef;
 		Integer timeout, codeLength;
 		Locale locale;
+		UUID templateId;
 		final List<Workflow> workflows = new ArrayList<>(1);
 
 		private Builder() {}
@@ -362,6 +377,20 @@ public class VerificationRequest implements Jsonable {
 		 */
 		public Builder fraudCheck() {
 			return fraudCheck(false);
+		}
+
+		/**
+		 * (OPTIONAL)
+		 * A custom template ID to use for the verification request.
+		 * This allows you to use a pre-configured template instead of the default verification message.
+		 *
+		 * @param templateId The UUID of the template to use.
+		 *
+		 * @return This builder.
+		 */
+		public Builder templateId(UUID templateId) {
+			this.templateId = templateId;
+			return this;
 		}
 
 		/**

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.UUID;
 
 public class VerificationRequestTest {
 	static final boolean SANDBOX = true;
@@ -39,6 +40,7 @@ public class VerificationRequestTest {
 			CONTENT_ID = "1107158078772563946",
 			ENTITY_ID = "1101407360000017170",
 			REDIRECT_URL = "https://acme-app.com/sa/redirect";
+	static final UUID TEMPLATE_ID = UUID.fromString("8f35a1a7-eb2f-4552-8fdf-fffdaee41bc9");
 
 	Builder newBuilder() {
 		return VerificationRequest.builder().brand(BRAND);
@@ -370,5 +372,42 @@ public class VerificationRequestTest {
 		assertThrows(VonageUnexpectedException.class, () -> new SelfRefrencing(VerificationRequest.builder()
 				.addWorkflow(new SmsWorkflow(TO_NUMBER)).brand("Test")).toJson()
 		);
+	}
+
+	@Test
+	public void testTemplateId() {
+		Builder builder = getBuilderRequiredParamsSingleWorkflow(Channel.SMS);
+		VerificationRequest request = builder.build();
+		assertNull(request.getTemplateId());
+		
+		builder.templateId(TEMPLATE_ID);
+		request = builder.build();
+		assertEquals(TEMPLATE_ID, request.getTemplateId());
+		
+		String json = request.toJson();
+		assertTrue(json.contains("\"template_id\":\"" + TEMPLATE_ID + "\""));
+	}
+
+	@Test
+	public void testTemplateIdInJson() {
+		for (Channel channel : Channel.values()) {
+			Builder builder = getBuilderRequiredParamsSingleWorkflow(channel);
+			builder.templateId(TEMPLATE_ID);
+			VerificationRequest request = builder.build();
+			String json = request.toJson();
+			assertTrue(json.contains("\"template_id\":\"" + TEMPLATE_ID + "\""),
+					"template_id should be included in JSON for " + channel);
+		}
+	}
+
+	@Test
+	public void testTemplateIdNotIncludedWhenNull() {
+		for (Channel channel : Channel.values()) {
+			Builder builder = getBuilderRequiredParamsSingleWorkflow(channel);
+			VerificationRequest request = builder.build();
+			String json = request.toJson();
+			assertFalse(json.contains("\"template_id\""),
+					"template_id should not be included in JSON when null for " + channel);
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Adds support for `template_id` parameter in `VerificationRequest` to allow using custom templates for verification requests in the Verify v2 API.

## Changes
- Added `templateId` field to `VerificationRequest` class
- Added `templateId(UUID)` method to `VerificationRequest.Builder`
- Added `getTemplateId()` getter method with proper JSON serialization
- Added comprehensive unit tests for the new functionality

## Testing
- Added unit tests to verify template_id serialization in JSON
- Verified that template_id is omitted when null (optional field)
- Tested across all verification channels (SMS, Voice, Email, WhatsApp, Silent Auth)

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [ ] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
