### PR TITLE
9.8.0 Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Messages: Added support for Typing Indicators in WhatsApp
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
+- Voice: Add support for `shaken` signing on calls
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Voice: Add support for `shaken` signing on calls
 - Voice: Added support for `sip_code` on incoming event webhooks
 - Voice: Added support for Transfer NCCO action
+- Voice: Added support for Wait NCCO action
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Verify: Deprecates the `sandbox` parameter
+- Number Insights: Internally switched to supporting only Basic Authorization header authentication
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [9.8.0] - 2025-01-29
 - Added `trusted_recipient` to SMS, MMS, and MMS
+- Added support for Typing Indicators in WhatsApp
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,21 +4,21 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [9.8.0] - 2025-01-29
 - Added deprecation notice for Java 8/1.8 users. Version 9.x will be the final version to support Java 8.
+- Accounts: Internally switched to supporting only Basic Authorization header authentication
+- Conversion: Internally switched to supporting only Basic Authorization header authentication
+- Identity Insights: Added new API, covers Formatting, SimSwap, Original and Current Carrier checks
 - Messages: Added `trusted_recipient` to SMS, MMS, and MMS
 - Messages: Added support for Typing Indicators in WhatsApp
 - Messages: Added `pool_id` support
+- Number Insights: Internally switched to supporting only Basic Authorization header authentication
+- Verify v1: Internally switched to supporting only Basic Authorization header authenticatio
+- Verify: Deprecates the `sandbox` parameter
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Voice: Add support for `shaken` signing on calls
 - Voice: Added support for `sip_code` on incoming event webhooks
 - Voice: Added support for Transfer NCCO action
 - Voice: Added support for Wait NCCO action
-- Verify: Deprecates the `sandbox` parameter
-- Number Insights: Internally switched to supporting only Basic Authorization header authentication
-- Accounts: Internally switched to supporting only Basic Authorization header authentication
-- Verify v1: Internally switched to supporting only Basic Authorization header authentication
-- Conversion: Internally switched to supporting only Basic Authorization header authentication
-- Identity Insights: Added new API, covers Formatting, SimSwap, Original and Current Carrier checks
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Messages: Added `trusted_recipient` to SMS, MMS, and MMS
 - Messages: Added support for Typing Indicators in WhatsApp
 - Voice: Websocket Connections can now include custom authorization headers
+- Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Accounts: Internally switched to supporting only Basic Authorization header authentication
 - Verify v1: Internally switched to supporting only Basic Authorization header authentication
 - Conversion: Internally switched to supporting only Basic Authorization header authentication
+- Identity Insights: Added new API, covers Formatting, SimSwap, Original and Current Carrier checks
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
+- Accounts: Internally switched to supporting only Basic Authorization header authentication
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication
 - Verify v1: Internally switched to supporting only Basic Authorization header authentication
+- Conversion: Internally switched to supporting only Basic Authorization header authentication
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Accounts: Internally switched to supporting only Basic Authorization header authentication
 - Conversion: Internally switched to supporting only Basic Authorization header authentication
 - Identity Insights: Added new API, covers Formatting, SimSwap, Original and Current Carrier checks
-- Messages: Added `trusted_recipient` to SMS, MMS, and MMS
+- Messages: Added `trusted_recipient` to SMS, MMS, and RCS
 - Messages: Added support for Typing Indicators in WhatsApp
 - Messages: Added `pool_id` support
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Voice: Add support for `shaken` signing on calls
+- Voice: Added support for `sip_code` on incoming event webhooks
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [9.8.0] - 2025-01-29
+- Added deprecation notice for Java 8/1.8 users. Version 9.x will be the final version to support Java 8.
 - Messages: Added `trusted_recipient` to SMS, MMS, and MMS
 - Messages: Added support for Typing Indicators in WhatsApp
 - Voice: Websocket Connections can now include custom authorization headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.8.0] - 2025-01-29
+- Added `trusted_recipient` to SMS, MMS, and MMS
+
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Voice: Add support for `shaken` signing on calls
 - Voice: Added support for `sip_code` on incoming event webhooks
+- Voice: Added support for Transfer NCCO action
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Messages: Added support for Typing Indicators in WhatsApp
 - Messages: Added `pool_id` support
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
-- Verify v1: Internally switched to supporting only Basic Authorization header authenticatio
+- Verify v1: Internally switched to supporting only Basic Authorization header authentication
 - Verify: Deprecates the `sandbox` parameter
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 # [9.8.0] - 2025-01-29
-- Added `trusted_recipient` to SMS, MMS, and MMS
-- Added support for Typing Indicators in WhatsApp
+- Messages: Added `trusted_recipient` to SMS, MMS, and MMS
+- Messages: Added support for Typing Indicators in WhatsApp
+- Voice: Websocket Connections can now include custom authorization headers
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Verify: Deprecates the `sandbox` parameter
 - Number Insights: Internally switched to supporting only Basic Authorization header authentication
 - Accounts: Internally switched to supporting only Basic Authorization header authentication
+- Verify v1: Internally switched to supporting only Basic Authorization header authentication
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Messages: Added support for Typing Indicators in WhatsApp
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
+- Verify: Deprecates the `sandbox` parameter
 
 # [9.7.0] - 2025-12-04
 - Added native RCS message types (card, carousel) and suggestions support to eliminate need for custom message type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Added deprecation notice for Java 8/1.8 users. Version 9.x will be the final version to support Java 8.
 - Messages: Added `trusted_recipient` to SMS, MMS, and MMS
 - Messages: Added support for Typing Indicators in WhatsApp
+- Messages: Added `pool_id` support
 - Voice: Websocket Connections can now include custom authorization headers
 - Voice: Answer Webhook adds support for SIP User-To-User incoming headers
 - Voice: Add support for `shaken` signing on calls

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.7.0")
+    implementation("com.vonage:server-sdk:9.8.0")
 }
 ```
 
@@ -85,7 +85,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.7.0</version>
+    <version>9.8.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ such as [Maven](https://maven.apache.org/), [Gradle](https://gradle.org/) or [Iv
 
 Release notes for each version can be found in the [changelog](CHANGELOG.md).
 
+> [!WARNING]
+> **Java 8 Deprecation Notice**
+> 
+> Version 9.x is the last major version to support Java 8. Support ends on **June 30, 2026**.
+> Future versions (10.0+) will require **Java 11 or later**.
+> 
+> If you are running Java 8, you will see a warning message in your logs when initializing the SDK.
+> Please plan to upgrade your Java runtime, or pin your SDK version to 9.x.
+
 Here are the instructions for including the SDK in your project:
 
 ### Gradle
@@ -300,6 +309,14 @@ This will also activate the logger on `AbstractMethod` if you haven't already sp
 that class, so you don't need to set it separately.
 
 ## Frequently Asked Questions
+
+**Q: I'm seeing a warning about Java 8. What should I do?**
+
+**A:** Version 9.x is the last major version to support Java 8. Support ends on June 30, 2026. Future versions (10.0+) will require Java 11 or later. If you are running Java 8, you have two options:
+1. **Recommended**: Upgrade your Java runtime to Java 11 or later
+2. Pin your SDK version to 9.x in your dependency configuration (though you will miss out on future updates and bug fixes)
+
+The warning appears once per application lifecycle and does not affect functionality.
 
 **Q: What happened to [`com.vonage:client`](https://search.maven.org/artifact/com.vonage/client)?**
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.7.0</version>
+  <version>9.8.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>
@@ -306,6 +306,8 @@
                 <arg>--pinentry-mode</arg>
                 <arg>loopback</arg>
               </gpgArguments>
+              <keyname>${gpg.keyname}</keyname>
+              <homedir>${gpg.homedir}</homedir>
             </configuration>
           </plugin>
           <plugin>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -37,7 +37,7 @@ import java.util.UUID;
 public class HttpWrapper {
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.7.0",
+            CLIENT_VERSION = "9.8.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -25,6 +25,7 @@ import com.vonage.client.auth.hashutils.HashType;
 import com.vonage.client.camara.numberverification.NumberVerificationClient;
 import com.vonage.client.camara.simswap.SimSwapClient;
 import com.vonage.client.conversations.ConversationsClient;
+import com.vonage.client.identityinsights.IdentityInsightsClient;
 import com.vonage.client.conversion.ConversionClient;
 import com.vonage.client.insight.InsightClient;
 import com.vonage.client.messages.MessagesClient;
@@ -83,6 +84,7 @@ public class VonageClient {
     private final ConversationsClient conversations;
     private final SimSwapClient simSwap;
     private final NumberVerificationClient numberVerification;
+    private final IdentityInsightsClient identityInsights;
 
     /**
      * Constructor which uses the builder pattern for instantiation.
@@ -111,6 +113,7 @@ public class VonageClient {
         conversations = new ConversationsClient(httpWrapper);
         simSwap = new SimSwapClient(httpWrapper);
         numberVerification = new NumberVerificationClient(httpWrapper);
+        identityInsights = new IdentityInsightsClient(httpWrapper);
     }
 
     /**
@@ -314,6 +317,16 @@ public class VonageClient {
     @Deprecated
     public NumberVerificationClient getNumberVerificationClient() {
         return numberVerification;
+    }
+
+    /**
+     * Returns the Identity Insights API client.
+     *
+     * @return The {@linkplain IdentityInsightsClient}.
+     * @since 9.1.0
+     */
+    public IdentityInsightsClient getIdentityInsightsClient() {
+        return identityInsights;
     }
 
     /**

--- a/src/main/java/com/vonage/client/VonageClient.java
+++ b/src/main/java/com/vonage/client/VonageClient.java
@@ -49,9 +49,18 @@ import java.util.UUID;
  * <p>
  * Construct an instance of this object with one or more {@link AuthMethod}s (providing all the authentication methods
  * for the APIs you wish to use), and then call {@link #getVoiceClient()} to obtain a client for the Vonage Voice API.
- * <p>.
+ * <p>
+ * <p><strong>DEPRECATION NOTICE:</strong></p>
+ * <p>This SDK version (9.x) is the last major version to support Java 8.</p>
+ * <p>Starting with version 10.0, Java 11 or later will be required.</p>
+ * <p>Java 8 support will end on June 30, 2026. Please upgrade your Java runtime or pin your SDK version to 9.x.</p>
  */
 public class VonageClient {
+    /**
+     * Flag to ensure the Java 8 deprecation warning is only printed once.
+     */
+    private static volatile boolean java8WarningShown = false;
+
     /**
      * The HTTP wrapper for this client and its sub-clients.
      */
@@ -81,6 +90,7 @@ public class VonageClient {
      * @param builder The builder object to use for configuration.
      */
     private VonageClient(Builder builder) {
+        warnOnLegacyJava();
         httpWrapper = new HttpWrapper(builder.httpConfig, builder.authCollection, builder.httpClient);
 
         custom = new CustomClient(httpWrapper);
@@ -101,6 +111,29 @@ public class VonageClient {
         conversations = new ConversationsClient(httpWrapper);
         simSwap = new SimSwapClient(httpWrapper);
         numberVerification = new NumberVerificationClient(httpWrapper);
+    }
+
+    /**
+     * Checks if the current Java version is Java 8 and prints a deprecation warning to stderr if it is.
+     * This warning is only shown once per JVM process to avoid log spam.
+     */
+    private static void warnOnLegacyJava() {
+        if (java8WarningShown) {
+            return;
+        }
+
+        String version = System.getProperty("java.specification.version");
+        if ("1.8".equals(version)) {
+            synchronized (VonageClient.class) {
+                // Double-check after acquiring lock to prevent race conditions
+                if (!java8WarningShown) {
+                    System.err.println("⚠️  [VONAGE SDK WARNING] You are using Java 8. Support ends on June 30, 2026.");
+                    System.err.println("   Future versions of this SDK (v10.0+) will require Java 11 or later.");
+                    System.err.println("   Please upgrade your runtime or pin your SDK version to 9.x.");
+                    java8WarningShown = true;
+                }
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/vonage/client/account/AccountClient.java
+++ b/src/main/java/com/vonage/client/account/AccountClient.java
@@ -17,7 +17,6 @@ package com.vonage.client.account;
 
 import com.vonage.client.*;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.List;
 import java.util.Objects;
@@ -58,15 +57,15 @@ public class AccountClient {
                 this(pathGetter, method, false, method == HttpMethod.POST, type);
             }
             Endpoint(Function<T, String> pathGetter, HttpMethod method,
-                     boolean signatureAuth, boolean formEncoded, R... type
+                     boolean useApiBaseUri, boolean formEncoded, R... type
             ) {
                 super(DynamicEndpoint.<T, R> builder(type)
                         .wrapper(wrapper).requestMethod(method)
-                        .authMethod(ApiKeyHeaderAuthMethod.class, signatureAuth ? SignatureAuthMethod.class : null)
+                        .authMethod(ApiKeyHeaderAuthMethod.class)
                         .responseExceptionType(AccountResponseException.class)
                         .urlFormEncodedContentType(formEncoded).pathGetter((de, req) -> {
                                 HttpConfig config = de.getHttpWrapper().getHttpConfig();
-                                String base = signatureAuth ? config.getApiBaseUri() : config.getRestBaseUri();
+                                String base = useApiBaseUri ? config.getApiBaseUri() : config.getRestBaseUri();
                                 return base + "/account" + pathGetter.apply(req);
                         })
                 );

--- a/src/main/java/com/vonage/client/conversion/ConversionClient.java
+++ b/src/main/java/com/vonage/client/conversion/ConversionClient.java
@@ -16,8 +16,7 @@
 package com.vonage.client.conversion;
 
 import com.vonage.client.*;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
+import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.Date;
 
@@ -38,7 +37,7 @@ public class ConversionClient {
                 .pathGetter((de, req) -> de.getHttpWrapper().getHttpConfig().getApiBaseUri() +
                         "/conversions/" + req.getType().name().toLowerCase()
                 )
-                .authMethod(SignatureAuthMethod.class, ApiKeyQueryParamsAuthMethod.class)
+                .authMethod(ApiKeyHeaderAuthMethod.class)
                 .requestMethod(HttpMethod.POST).wrapper(wrapper).build();
     }
 

--- a/src/main/java/com/vonage/client/identityinsights/CurrentCarrierInsightResponse.java
+++ b/src/main/java/com/vonage/client/identityinsights/CurrentCarrierInsightResponse.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Response containing information about the current carrier assigned to a phone number.
+ * 
+ * @since 9.1.0
+ */
+public class CurrentCarrierInsightResponse extends JsonableBaseObject {
+    private String name, countryCode, networkCode;
+    private NetworkType networkType;
+    private InsightStatus status;
+    
+    protected CurrentCarrierInsightResponse() {}
+    
+    /**
+     * Gets the full name of the current carrier.
+     * 
+     * @return The carrier name, or {@code null} if unavailable.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+    
+    /**
+     * Gets the type of network.
+     * 
+     * @return The network type, or {@code null} if unavailable.
+     */
+    @JsonProperty("network_type")
+    public NetworkType getNetworkType() {
+        return networkType;
+    }
+    
+    /**
+     * Gets the country code (ISO 3166-1 alpha-2).
+     * 
+     * @return The country code, or {@code null} if unavailable.
+     */
+    @JsonProperty("country_code")
+    public String getCountryCode() {
+        return countryCode;
+    }
+    
+    /**
+     * Gets the network code (MCC + MNC).
+     * 
+     * @return The network code, or {@code null} if unavailable.
+     */
+    @JsonProperty("network_code")
+    public String getNetworkCode() {
+        return networkCode;
+    }
+    
+    /**
+     * Gets the status of this insight.
+     * 
+     * @return The insight status.
+     */
+    @JsonProperty("status")
+    public InsightStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/FormatInsightResponse.java
+++ b/src/main/java/com/vonage/client/identityinsights/FormatInsightResponse.java
@@ -1,0 +1,125 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+import java.util.List;
+
+/**
+ * Response containing format validation and metadata for a phone number.
+ * 
+ * @since 9.1.0
+ */
+public class FormatInsightResponse extends JsonableBaseObject {
+    private String countryCode, countryName, countryPrefix, offlineLocation;
+    private List<String> timeZones;
+    private String numberInternational, numberNational;
+    private Boolean isFormatValid;
+    private InsightStatus status;
+    
+    protected FormatInsightResponse() {}
+    
+    /**
+     * Gets the two-character country code (ISO 3166-1 alpha-2).
+     * 
+     * @return The country code, or {@code null} if unavailable.
+     */
+    @JsonProperty("country_code")
+    public String getCountryCode() {
+        return countryCode;
+    }
+    
+    /**
+     * Gets the full name of the country.
+     * 
+     * @return The country name, or {@code null} if unavailable.
+     */
+    @JsonProperty("country_name")
+    public String getCountryName() {
+        return countryName;
+    }
+    
+    /**
+     * Gets the numeric prefix for the country.
+     * 
+     * @return The country prefix, or {@code null} if unavailable.
+     */
+    @JsonProperty("country_prefix")
+    public String getCountryPrefix() {
+        return countryPrefix;
+    }
+    
+    /**
+     * Gets the offline location based on the number's prefix.
+     * 
+     * @return The offline location, or {@code null} if unavailable.
+     */
+    @JsonProperty("offline_location")
+    public String getOfflineLocation() {
+        return offlineLocation;
+    }
+    
+    /**
+     * Gets the time zones for the location.
+     * 
+     * @return List of time zone identifiers, or {@code null} if unavailable.
+     */
+    @JsonProperty("time_zones")
+    public List<String> getTimeZones() {
+        return timeZones;
+    }
+    
+    /**
+     * Gets the phone number in international E.164 format.
+     * 
+     * @return The international number format, or {@code null} if unavailable.
+     */
+    @JsonProperty("number_international")
+    public String getNumberInternational() {
+        return numberInternational;
+    }
+    
+    /**
+     * Gets the phone number in national format.
+     * 
+     * @return The national number format, or {@code null} if unavailable.
+     */
+    @JsonProperty("number_national")
+    public String getNumberNational() {
+        return numberNational;
+    }
+    
+    /**
+     * Indicates if the phone number format is valid.
+     * 
+     * @return {@code true} if format is valid, {@code false} otherwise, or {@code null} if unknown.
+     */
+    @JsonProperty("is_format_valid")
+    public Boolean getIsFormatValid() {
+        return isFormatValid;
+    }
+    
+    /**
+     * Gets the status of this insight.
+     * 
+     * @return The insight status.
+     */
+    @JsonProperty("status")
+    public InsightStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/IdentityInsightsClient.java
+++ b/src/main/java/com/vonage/client/identityinsights/IdentityInsightsClient.java
@@ -1,0 +1,124 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.vonage.client.DynamicEndpoint;
+import com.vonage.client.HttpWrapper;
+import com.vonage.client.RestEndpoint;
+import com.vonage.client.VonageClient;
+import com.vonage.client.auth.JWTAuthMethod;
+import com.vonage.client.camara.CamaraResponseException;
+import com.vonage.client.common.HttpMethod;
+
+/**
+ * A client for communicating with the Vonage Identity Insights API.
+ * The standard way to obtain an instance of this class is to use 
+ * {@link VonageClient#getIdentityInsightsClient()}.
+ * <p>
+ * The Identity Insights API allows clients to request real-time information related to a phone number.
+ * Users can retrieve any combination of different datasets, known as insights (e.g., number formatting,
+ * SIM swap information), in a single API call.
+ * </p>
+ * <p>
+ * Each insight is processed independently, and the response includes a structured result for each
+ * insight along with a status code indicating success or the type of error encountered.
+ * </p>
+ *
+ * @since 9.1.0
+ */
+public class IdentityInsightsClient {
+    final RestEndpoint<IdentityInsightsRequest, IdentityInsightsResponse> getInsights;
+    
+    /**
+     * Create a new IdentityInsightsClient.
+     *
+     * @param wrapper Http Wrapper used to create requests.
+     */
+    public IdentityInsightsClient(HttpWrapper wrapper) {
+        @SuppressWarnings("unchecked")
+        class Endpoint extends DynamicEndpoint<IdentityInsightsRequest, IdentityInsightsResponse> {
+            Endpoint(IdentityInsightsResponse... type) {
+                super(DynamicEndpoint.<IdentityInsightsRequest, IdentityInsightsResponse>builder(type)
+                        .authMethod(JWTAuthMethod.class)
+                        .responseExceptionType(CamaraResponseException.class)
+                        .requestMethod(HttpMethod.POST)
+                        .wrapper(wrapper)
+                        .pathGetter((de, req) -> 
+                            wrapper.getHttpConfig().getApiEuBaseUri() + "/identity-insights/v1/requests"
+                        )
+                );
+            }
+        }
+        
+        getInsights = new Endpoint();
+    }
+    
+    /**
+     * Retrieve multiple insights for a phone number in a single request.
+     * <p>
+     * Each insight is processed independently. The response will include a status code for each
+     * requested insight, which can be:
+     * </p>
+     * <ul>
+     *   <li><b>OK</b> - The insight was processed successfully.</li>
+     *   <li><b>INVALID_NUMBER_FORMAT</b> - The phone number format is not valid.</li>
+     *   <li><b>NO_COVERAGE</b> - The country or mobile network is not supported.</li>
+     *   <li><b>NOT_FOUND</b> - The phone number could not be found for this insight.</li>
+     *   <li><b>UNAUTHORIZED</b> - The request could not be authorized.</li>
+     *   <li><b>INVALID_PURPOSE</b> - The purpose used is not valid or allowed.</li>
+     *   <li><b>SUPPLIER_ERROR</b> - The supplier returned an error.</li>
+     *   <li><b>INTERNAL_ERROR</b> - An internal error occurred.</li>
+     * </ul>
+     * <p>
+     * Example usage:
+     * </p>
+     * <pre>{@code
+     * IdentityInsightsRequest request = new IdentityInsightsRequest("+14155552671")
+     *     .purpose("FraudPreventionAndDetection")
+     *     .format()
+     *     .simSwap(240)
+     *     .currentCarrier();
+     * 
+     * IdentityInsightsResponse response = client.getInsights(request);
+     * 
+     * if (response.getInsights().getFormat() != null) {
+     *     FormatInsightResponse format = response.getInsights().getFormat();
+     *     if (format.getStatus().getCode() == InsightStatusCode.OK) {
+     *         System.out.println("Country: " + format.getCountryName());
+     *         System.out.println("Valid format: " + format.getIsFormatValid());
+     *     }
+     * }
+     * }</pre>
+     *
+     * @param request The insights request specifying the phone number and desired insights.
+     * @return The insights response containing results for each requested insight.
+     * 
+     * @throws CamaraResponseException If the request was unsuccessful. This could be for the following reasons:
+     * <ul>
+     *     <li><b>400</b> - Bad Request: Invalid request arguments or malformed JSON.</li>
+     *     <li><b>401</b> - Unauthorized: Authentication credentials are missing, invalid, or expired.</li>
+     *     <li><b>405</b> - Method Not Allowed: Request method not supported.</li>
+     *     <li><b>415</b> - Unsupported Media Type: Invalid Content-Type header.</li>
+     *     <li><b>422</b> - Unprocessable Entity: The request failed due to validation errors.</li>
+     *     <li><b>429</b> - Too Many Requests: Rate limit exceeded.</li>
+     *     <li><b>500</b> - Internal Server Error: An unexpected error occurred on the server.</li>
+     *     <li><b>503</b> - Service Unavailable: Failed to invoke upstream service.</li>
+     * </ul>
+     */
+    public IdentityInsightsResponse getInsights(IdentityInsightsRequest request) {
+        return getInsights.execute(request);
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/IdentityInsightsRequest.java
+++ b/src/main/java/com/vonage/client/identityinsights/IdentityInsightsRequest.java
@@ -1,0 +1,139 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+import com.vonage.client.common.E164;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Request to retrieve multiple insights for a phone number.
+ * 
+ * @since 9.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdentityInsightsRequest extends JsonableBaseObject {
+    private String phoneNumber, purpose;
+    private Map<String, Object> insights;
+    
+    /**
+     * Creates a new identity insights request.
+     * 
+     * @param phoneNumber Phone number in E.164 format.
+     */
+    public IdentityInsightsRequest(String phoneNumber) {
+        this.phoneNumber = new E164(Objects.requireNonNull(phoneNumber, "Phone number is required")).toString();
+        this.insights = new HashMap<String, Object>();
+    }
+    
+    /**
+     * Gets the phone number.
+     * 
+     * @return The phone number in E.164 format.
+     */
+    @JsonProperty("phone_number")
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+    
+    /**
+     * Gets the purpose for the request.
+     * 
+     * @return The purpose.
+     */
+    @JsonProperty("purpose")
+    public String getPurpose() {
+        return purpose;
+    }
+    
+    /**
+     * Sets the purpose for the request.
+     * Required for Network Registry insights.
+     * 
+     * @param purpose The purpose (e.g., "FraudPreventionAndDetection").
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest purpose(String purpose) {
+        this.purpose = purpose;
+        return this;
+    }
+    
+    /**
+     * Gets the requested insights.
+     * 
+     * @return Map of insight names to their request objects.
+     */
+    @JsonProperty("insights")
+    public Map<String, Object> getInsights() {
+        return insights;
+    }
+    
+    /**
+     * Requests the format insight.
+     * 
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest format() {
+        insights.put("format", new HashMap<String, Object>());
+        return this;
+    }
+    
+    /**
+     * Requests the SIM swap insight with default period (240 hours).
+     * 
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest simSwap() {
+        return simSwap(null);
+    }
+    
+    /**
+     * Requests the SIM swap insight with specified period.
+     * 
+     * @param period Period in hours (1-2400), or {@code null} for default (240).
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest simSwap(Integer period) {
+        insights.put("sim_swap", period != null ? new SimSwapInsightRequest(period) : new HashMap<String, Object>());
+        return this;
+    }
+    
+    /**
+     * Requests the original carrier insight.
+     * 
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest originalCarrier() {
+        insights.put("original_carrier", new HashMap<String, Object>());
+        return this;
+    }
+    
+    /**
+     * Requests the current carrier insight.
+     * 
+     * @return This request for method chaining.
+     */
+    public IdentityInsightsRequest currentCarrier() {
+        insights.put("current_carrier", new HashMap<String, Object>());
+        return this;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/IdentityInsightsResponse.java
+++ b/src/main/java/com/vonage/client/identityinsights/IdentityInsightsResponse.java
@@ -1,0 +1,109 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Response containing multiple insights for a phone number.
+ * 
+ * @since 9.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdentityInsightsResponse extends JsonableBaseObject {
+    private String requestId;
+    private Insights insights;
+    
+    protected IdentityInsightsResponse() {}
+    
+    /**
+     * Gets the unique request identifier.
+     * 
+     * @return The request ID.
+     */
+    @JsonProperty("request_id")
+    public String getRequestId() {
+        return requestId;
+    }
+    
+    /**
+     * Gets the insights object containing all requested insights.
+     * 
+     * @return The insights.
+     */
+    @JsonProperty("insights")
+    public Insights getInsights() {
+        return insights;
+    }
+    
+    /**
+     * Container for all insight responses.
+     */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Insights extends JsonableBaseObject {
+        private FormatInsightResponse format;
+        private SimSwapInsightResponse simSwap;
+        private OriginalCarrierInsightResponse originalCarrier;
+        private CurrentCarrierInsightResponse currentCarrier;
+        
+        protected Insights() {}
+        
+        /**
+         * Gets the format insight response.
+         * 
+         * @return The format insight, or {@code null} if not requested.
+         */
+        @JsonProperty("format")
+        public FormatInsightResponse getFormat() {
+            return format;
+        }
+        
+        /**
+         * Gets the SIM swap insight response.
+         * 
+         * @return The SIM swap insight, or {@code null} if not requested.
+         */
+        @JsonProperty("sim_swap")
+        public SimSwapInsightResponse getSimSwap() {
+            return simSwap;
+        }
+        
+        /**
+         * Gets the original carrier insight response.
+         * 
+         * @return The original carrier insight, or {@code null} if not requested.
+         */
+        @JsonProperty("original_carrier")
+        public OriginalCarrierInsightResponse getOriginalCarrier() {
+            return originalCarrier;
+        }
+        
+        /**
+         * Gets the current carrier insight response.
+         * 
+         * @return The current carrier insight, or {@code null} if not requested.
+         */
+        @JsonProperty("current_carrier")
+        public CurrentCarrierInsightResponse getCurrentCarrier() {
+            return currentCarrier;
+        }
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/InsightStatus.java
+++ b/src/main/java/com/vonage/client/identityinsights/InsightStatus.java
@@ -1,0 +1,54 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Base status class for insight responses.
+ * 
+ * @since 9.1.0
+ */
+public class InsightStatus extends JsonableBaseObject {
+    private InsightStatusCode code;
+    private String message;
+    
+    /**
+     * Default constructor for JSON deserialization.
+     */
+    protected InsightStatus() {}
+    
+    /**
+     * Gets the status code.
+     * 
+     * @return The status code.
+     */
+    @JsonProperty("code")
+    public InsightStatusCode getCode() {
+        return code;
+    }
+    
+    /**
+     * Gets the status message.
+     * 
+     * @return The status message.
+     */
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/InsightStatusCode.java
+++ b/src/main/java/com/vonage/client/identityinsights/InsightStatusCode.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+/**
+ * Enum representing the status codes for Identity Insights requests.
+ * 
+ * @since 9.1.0
+ */
+public enum InsightStatusCode {
+    /**
+     * The insight was processed successfully.
+     */
+    OK,
+    
+    /**
+     * The phone number format is not valid for assignment by carriers to users.
+     */
+    INVALID_NUMBER_FORMAT,
+    
+    /**
+     * The country or mobile network is not supported by available suppliers.
+     */
+    NO_COVERAGE,
+    
+    /**
+     * The phone number could not be found for this Insight.
+     */
+    NOT_FOUND,
+    
+    /**
+     * The request could not be authorized for the combination of application, supplier, and phone number.
+     */
+    UNAUTHORIZED,
+    
+    /**
+     * The purpose used is not valid or allowed for this Insight.
+     */
+    INVALID_PURPOSE,
+    
+    /**
+     * The supplier returned an error while processing the request.
+     */
+    SUPPLIER_ERROR,
+    
+    /**
+     * An internal error occurred while processing the request.
+     */
+    INTERNAL_ERROR
+}

--- a/src/main/java/com/vonage/client/identityinsights/NetworkType.java
+++ b/src/main/java/com/vonage/client/identityinsights/NetworkType.java
@@ -1,0 +1,48 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+/**
+ * Enum representing the network type for carrier insights.
+ * 
+ * @since 9.1.0
+ */
+public enum NetworkType {
+    /**
+     * Mobile network.
+     */
+    MOBILE,
+    
+    /**
+     * Landline network.
+     */
+    LANDLINE,
+    
+    /**
+     * Toll-free number.
+     */
+    TOLLFREE,
+    
+    /**
+     * Premium rate number.
+     */
+    PREMIUM,
+    
+    /**
+     * Virtual number.
+     */
+    VIRTUAL
+}

--- a/src/main/java/com/vonage/client/identityinsights/OriginalCarrierInsightResponse.java
+++ b/src/main/java/com/vonage/client/identityinsights/OriginalCarrierInsightResponse.java
@@ -1,0 +1,82 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Response containing information about the original carrier assigned to a phone number.
+ * 
+ * @since 9.1.0
+ */
+public class OriginalCarrierInsightResponse extends JsonableBaseObject {
+    private String name, countryCode, networkCode;
+    private NetworkType networkType;
+    private InsightStatus status;
+    
+    protected OriginalCarrierInsightResponse() {}
+    
+    /**
+     * Gets the full name of the original carrier.
+     * 
+     * @return The carrier name, or {@code null} if unavailable.
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+    
+    /**
+     * Gets the type of network.
+     * 
+     * @return The network type, or {@code null} if unavailable.
+     */
+    @JsonProperty("network_type")
+    public NetworkType getNetworkType() {
+        return networkType;
+    }
+    
+    /**
+     * Gets the country code (ISO 3166-1 alpha-2).
+     * 
+     * @return The country code, or {@code null} if unavailable.
+     */
+    @JsonProperty("country_code")
+    public String getCountryCode() {
+        return countryCode;
+    }
+    
+    /**
+     * Gets the network code (MCC + MNC).
+     * 
+     * @return The network code, or {@code null} if unavailable.
+     */
+    @JsonProperty("network_code")
+    public String getNetworkCode() {
+        return networkCode;
+    }
+    
+    /**
+     * Gets the status of this insight.
+     * 
+     * @return The insight status.
+     */
+    @JsonProperty("status")
+    public InsightStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/SimSwapInsightRequest.java
+++ b/src/main/java/com/vonage/client/identityinsights/SimSwapInsightRequest.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Request for SIM swap insight.
+ * 
+ * @since 9.1.0
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SimSwapInsightRequest extends JsonableBaseObject {
+    private Integer period;
+    
+    /**
+     * Creates a new SIM swap insight request with default period (240 hours).
+     */
+    public SimSwapInsightRequest() {}
+    
+    /**
+     * Creates a new SIM swap insight request with specified period.
+     * 
+     * @param period Period in hours to check for SIM swap (1-2400).
+     */
+    public SimSwapInsightRequest(Integer period) {
+        if (period != null && (period < 1 || period > 2400)) {
+            throw new IllegalArgumentException("Period must be between 1 and 2400 hours.");
+        }
+        this.period = period;
+    }
+    
+    /**
+     * Gets the period to check for SIM swap.
+     * 
+     * @return The period in hours, or {@code null} for default (240).
+     */
+    @JsonProperty("period")
+    public Integer getPeriod() {
+        return period;
+    }
+    
+    /**
+     * Sets the period to check for SIM swap.
+     * 
+     * @param period Period in hours (1-2400).
+     * @return This request for method chaining.
+     */
+    public SimSwapInsightRequest period(Integer period) {
+        if (period != null && (period < 1 || period > 2400)) {
+            throw new IllegalArgumentException("Period must be between 1 and 2400 hours.");
+        }
+        this.period = period;
+        return this;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/SimSwapInsightResponse.java
+++ b/src/main/java/com/vonage/client/identityinsights/SimSwapInsightResponse.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+import java.time.Instant;
+
+/**
+ * Response containing SIM swap information for a phone number.
+ * 
+ * @since 9.1.0
+ */
+public class SimSwapInsightResponse extends JsonableBaseObject {
+    private Instant latestSimSwapAt;
+    private Boolean isSwapped;
+    private InsightStatus status;
+    
+    protected SimSwapInsightResponse() {}
+    
+    /**
+     * Gets the date and time of the latest SIM swap.
+     * 
+     * @return The latest SIM swap timestamp, or {@code null} if unavailable.
+     */
+    @JsonProperty("latest_sim_swap_at")
+    public Instant getLatestSimSwapAt() {
+        return latestSimSwapAt;
+    }
+    
+    /**
+     * Indicates whether the SIM card was swapped during the specified period.
+     * 
+     * @return {@code true} if swapped, {@code false} otherwise, or {@code null} if unknown.
+     */
+    @JsonProperty("is_swapped")
+    public Boolean getIsSwapped() {
+        return isSwapped;
+    }
+    
+    /**
+     * Gets the status of this insight.
+     * 
+     * @return The insight status.
+     */
+    @JsonProperty("status")
+    public InsightStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/com/vonage/client/identityinsights/package-info.java
+++ b/src/main/java/com/vonage/client/identityinsights/package-info.java
@@ -1,0 +1,41 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+/**
+ * This package contains classes to support usage of the
+ * <a href="https://developer.vonage.com/en/api/identity-insights">Identity Insights API</a>.
+ * Please refer to the
+ * <a href="https://developer.vonage.com/en/identity-insights/overview">developer documentation</a>
+ * for an overview of the concepts.
+ * <p>
+ * The Identity Insights API allows clients to request real-time information related to a phone number.
+ * Users can retrieve any combination of different datasets, known as insights (e.g., number formatting,
+ * SIM swap information), in a single API call.
+ * </p>
+ * <p>
+ * Each insight is processed independently, and the response includes a structured result for each insight
+ * along with a status code. The API supports the following insights:
+ * </p>
+ * <ul>
+ *   <li><b>Format</b> - Validates phone number format and provides metadata.</li>
+ *   <li><b>SIM Swap</b> - Information about recent SIM card swaps.</li>
+ *   <li><b>Original Carrier</b> - Information about the originally assigned carrier.</li>
+ *   <li><b>Current Carrier</b> - Information about the currently assigned carrier.</li>
+ * </ul>
+ *
+ * @since 9.1.0
+ */
+package com.vonage.client.identityinsights;

--- a/src/main/java/com/vonage/client/insight/InsightClient.java
+++ b/src/main/java/com/vonage/client/insight/InsightClient.java
@@ -17,7 +17,6 @@ package com.vonage.client.insight;
 
 import com.vonage.client.*;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.function.Function;
 
@@ -42,7 +41,7 @@ public class InsightClient {
             Endpoint(Function<T, String> pathGetter, R... type) {
                 super(DynamicEndpoint.<T, R> builder(type)
                         .wrapper(wrapper).requestMethod(HttpMethod.POST)
-                        .authMethod(SignatureAuthMethod.class, ApiKeyHeaderAuthMethod.class)
+                        .authMethod(ApiKeyHeaderAuthMethod.class)
                         .pathGetter((de, req) -> {
                             String base = de.getHttpWrapper().getHttpConfig().getApiBaseUri();
                             return base + "/ni/" + pathGetter.apply(req) + "/json";

--- a/src/main/java/com/vonage/client/messages/MessagesClient.java
+++ b/src/main/java/com/vonage/client/messages/MessagesClient.java
@@ -19,6 +19,7 @@ import com.vonage.client.*;
 import com.vonage.client.auth.JWTAuthMethod;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.common.HttpMethod;
+import com.vonage.client.messages.whatsapp.ReplyingIndicator;
 import com.vonage.jwt.Jwt;
 import java.util.function.Function;
 
@@ -134,7 +135,34 @@ public class MessagesClient {
 	 * @since 8.11.0
 	 */
 	public void ackInboundMessage(String messageId, ApiRegion region) throws MessageResponseException {
-		updateMessage.execute(new UpdateStatusRequest("read", messageId, region));
+		ackInboundMessage(messageId, region, null);
+	}
+
+	/**
+	 * Marks an inbound message as "read" and optionally displays a typing indicator.
+	 * Currently, this only applies to WhatsApp messages.
+	 * <p>
+	 * Use this method to show typing indicators (three successively blinking dots) which is a good practice
+	 * to let the user know that a response is being prepared.
+	 *
+	 * @param messageId UUID of the message to acknowledge.
+	 * @param region The regional server to use for this request. This must match the region of the message.
+	 * @param replyingIndicator Optional typing indicator settings. Use {@link ReplyingIndicator#builder()} to construct.
+	 *
+	 * @throws MessageResponseException If the acknowledgement fails. This could be for the following reasons:
+	 * <ul>
+	 *     <li><b>401:</b> Missing or invalid credentials.</li>
+	 *     <li><b>404:</b> Message not found.</li>
+	 *     <li><b>422:</b> Operation not supported for this channel.</li>
+	 *     <li><b>429:</b> Rate limit hit. Please wait and try again.</li>
+	 *     <li><b>500:</b> Internal server error.</li>
+	 * </ul>
+	 *
+	 * @since 9.8.0
+	 */
+	public void ackInboundMessage(String messageId, ApiRegion region, ReplyingIndicator replyingIndicator) 
+			throws MessageResponseException {
+		updateMessage.execute(new UpdateStatusRequest("read", messageId, region, replyingIndicator));
 	}
 
 	/**

--- a/src/main/java/com/vonage/client/messages/UpdateStatusRequest.java
+++ b/src/main/java/com/vonage/client/messages/UpdateStatusRequest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.ApiRegion;
 import com.vonage.client.JsonableBaseObject;
+import com.vonage.client.messages.whatsapp.ReplyingIndicator;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,12 +30,18 @@ import java.util.UUID;
  */
 class UpdateStatusRequest extends JsonableBaseObject {
     @JsonProperty("status") final String status;
+    @JsonProperty("replying_indicator") final ReplyingIndicator replyingIndicator;
     @JsonIgnore final UUID messageId;
     @JsonIgnore final ApiRegion region;
 
     UpdateStatusRequest(String status, String messageId, ApiRegion region) {
+        this(status, messageId, region, null);
+    }
+
+    UpdateStatusRequest(String status, String messageId, ApiRegion region, ReplyingIndicator replyingIndicator) {
         this.status = status;
         this.messageId = UUID.fromString(Objects.requireNonNull(messageId, "Message ID is required."));
         this.region = region != null ? region : ApiRegion.API_EU;
+        this.replyingIndicator = replyingIndicator;
     }
 }

--- a/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
+++ b/src/main/java/com/vonage/client/messages/mms/MmsRequest.java
@@ -21,9 +21,11 @@ import com.vonage.client.messages.MessageRequest;
 import com.vonage.client.common.MessageType;
 
 public abstract class MmsRequest extends MessageRequest {
+	protected final Boolean trustedRecipient;
 
 	protected MmsRequest(Builder<?, ?> builder, MessageType messageType) {
 		super(builder, Channel.MMS, messageType);
+		this.trustedRecipient = builder.trustedRecipient;
 		if (media != null) {
 			media.validateCaptionLength(3000);
 		}
@@ -38,7 +40,13 @@ public abstract class MmsRequest extends MessageRequest {
 		return ttl;
 	}
 
+	@JsonProperty("trusted_recipient")
+	public Boolean getTrustedRecipient() {
+		return trustedRecipient;
+	}
+
 	protected abstract static class Builder<M extends MmsRequest, B extends Builder<? extends M, ? extends B>> extends MessageRequest.Builder<M, B> {
+		protected Boolean trustedRecipient;
 
 		/**
 		 * (OPTIONAL)
@@ -54,6 +62,21 @@ public abstract class MmsRequest extends MessageRequest {
 		@Override
 		public B ttl(int ttl) {
 			return super.ttl(ttl);
+		}
+
+		/**
+		 * (OPTIONAL)
+		 * Indicates if the recipient is trusted.
+		 *
+		 * @param trustedRecipient Whether the recipient is trusted (true or false).
+		 * @return This builder.
+		 *
+		 * @since 9.8.0
+		 */
+		@SuppressWarnings("unchecked")
+		public B trustedRecipient(Boolean trustedRecipient) {
+			this.trustedRecipient = trustedRecipient;
+			return (B) this;
 		}
 	}
 }

--- a/src/main/java/com/vonage/client/messages/rcs/Rcs.java
+++ b/src/main/java/com/vonage/client/messages/rcs/Rcs.java
@@ -25,6 +25,7 @@ import com.vonage.client.JsonableBaseObject;
  */
 public final class Rcs extends JsonableBaseObject {
 	private String category;
+	Boolean trustedRecipient;
 
 	Rcs() {}
 
@@ -38,6 +39,19 @@ public final class Rcs extends JsonableBaseObject {
 	}
 
 	/**
+	 * Creates an RCS options object with the specified category and trusted recipient flag.
+	 *
+	 * @param category The RCS message category.
+	 * @param trustedRecipient Whether the recipient is trusted.
+	 *
+	 * @since 9.8.0
+	 */
+	public Rcs(String category, Boolean trustedRecipient) {
+		this.category = category;
+		this.trustedRecipient = trustedRecipient;
+	}
+
+	/**
 	 * The RCS message category.
 	 *
 	 * @return The category as a string, or {@code null} if not set.
@@ -45,5 +59,17 @@ public final class Rcs extends JsonableBaseObject {
 	@JsonProperty("category")
 	public String getCategory() {
 		return category;
+	}
+
+	/**
+	 * Whether the recipient is trusted.
+	 *
+	 * @return The trusted recipient flag as a Boolean, or {@code null} if not set.
+	 *
+	 * @since 9.8.0
+	 */
+	@JsonProperty("trusted_recipient")
+	public Boolean getTrustedRecipient() {
+		return trustedRecipient;
 	}
 }

--- a/src/main/java/com/vonage/client/messages/rcs/RcsRequest.java
+++ b/src/main/java/com/vonage/client/messages/rcs/RcsRequest.java
@@ -74,6 +74,23 @@ public abstract class RcsRequest extends MessageRequest {
 			return rcs(new Rcs(category));
 		}
 
+		/**
+		 * (OPTIONAL)
+		 * Indicates if the recipient is trusted.
+		 *
+		 * @param trustedRecipient Whether the recipient is trusted (true or false).
+		 * @return This builder.
+		 *
+		 * @since 9.8.0
+		 */
+		public B trustedRecipient(Boolean trustedRecipient) {
+			if (rcs == null) {
+				rcs = new Rcs();
+			}
+			rcs.trustedRecipient = trustedRecipient;
+			return (B) this;
+		}
+
 		@Override
 		protected B ttl(int ttl) {
 			return super.ttl(ttl);

--- a/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
+++ b/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
@@ -25,22 +25,31 @@ import com.vonage.client.JsonableBaseObject;
  */
 public final class OutboundSettings extends JsonableBaseObject {
     final EncodingType encodingType;
-    final String contentId, entityId;
+    final String contentId, entityId, poolId;
     final Boolean trustedRecipient;
 
     private OutboundSettings(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
+        this(encodingType, contentId, entityId, null, trustedRecipient);
+    }
+
+    private OutboundSettings(EncodingType encodingType, String contentId, String entityId, String poolId, Boolean trustedRecipient) {
         this.encodingType = encodingType;
         this.contentId = contentId;
         this.entityId = entityId;
+        this.poolId = poolId;
         this.trustedRecipient = trustedRecipient;
     }
 
     static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId) {
-        return construct(encodingType, contentId, entityId, null);
+        return construct(encodingType, contentId, entityId, null, null);
     }
 
     static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
-        if (encodingType == null && contentId == null && entityId == null && trustedRecipient == null) {
+        return construct(encodingType, contentId, entityId, null, trustedRecipient);
+    }
+
+    static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, String poolId, Boolean trustedRecipient) {
+        if (encodingType == null && contentId == null && entityId == null && poolId == null && trustedRecipient == null) {
             return null;
         }
         if (contentId != null && contentId.trim().isEmpty()) {
@@ -49,7 +58,10 @@ public final class OutboundSettings extends JsonableBaseObject {
         if (entityId != null && entityId.trim().isEmpty()) {
             throw new IllegalArgumentException("Entity ID cannot be blank.");
         }
-        return new OutboundSettings(encodingType, contentId, entityId, trustedRecipient);
+        if (poolId != null && poolId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Pool ID cannot be blank.");
+        }
+        return new OutboundSettings(encodingType, contentId, entityId, poolId, trustedRecipient);
     }
 
     @JsonProperty("encoding_type")
@@ -65,6 +77,11 @@ public final class OutboundSettings extends JsonableBaseObject {
     @JsonProperty("entity_id")
     public String getEntityId() {
         return entityId;
+    }
+
+    @JsonProperty("pool_id")
+    public String getPoolId() {
+        return poolId;
     }
 
     @JsonProperty("trusted_recipient")

--- a/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
+++ b/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
@@ -26,15 +26,21 @@ import com.vonage.client.JsonableBaseObject;
 public final class OutboundSettings extends JsonableBaseObject {
     final EncodingType encodingType;
     final String contentId, entityId;
+    final Boolean trustedRecipient;
 
-    private OutboundSettings(EncodingType encodingType, String contentId, String entityId) {
+    private OutboundSettings(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
         this.encodingType = encodingType;
         this.contentId = contentId;
         this.entityId = entityId;
+        this.trustedRecipient = trustedRecipient;
     }
 
     static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId) {
-        if (encodingType == null && contentId == null && entityId == null) {
+        return construct(encodingType, contentId, entityId, null);
+    }
+
+    static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
+        if (encodingType == null && contentId == null && entityId == null && trustedRecipient == null) {
             return null;
         }
         if (contentId != null && contentId.trim().isEmpty()) {
@@ -43,7 +49,7 @@ public final class OutboundSettings extends JsonableBaseObject {
         if (entityId != null && entityId.trim().isEmpty()) {
             throw new IllegalArgumentException("Entity ID cannot be blank.");
         }
-        return new OutboundSettings(encodingType, contentId, entityId);
+        return new OutboundSettings(encodingType, contentId, entityId, trustedRecipient);
     }
 
     @JsonProperty("encoding_type")
@@ -59,5 +65,10 @@ public final class OutboundSettings extends JsonableBaseObject {
     @JsonProperty("entity_id")
     public String getEntityId() {
         return entityId;
+    }
+
+    @JsonProperty("trusted_recipient")
+    public Boolean getTrustedRecipient() {
+        return trustedRecipient;
     }
 }

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -147,8 +147,8 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 		 * (OPTIONAL)
 		 * Indicates whether the recipient is a trusted recipient.
 		 *
-		 * @param trustedRecipient
-		 * @return
+		 * @param trustedRecipient {@code true} if the recipient is considered a trusted recipient, {@code false} otherwise.
+		 * @return This builder.
 		 * 
 		 * @since 9.8.0
 		 */

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -26,7 +26,7 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 
 	SmsTextRequest(Builder builder) {
 		super(builder, Channel.SMS, MessageType.TEXT);
-		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId);
+		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId, builder.trustedRecipient);
 	}
 
 	@Override
@@ -51,6 +51,7 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 	public final static class Builder extends MessageRequest.Builder<SmsTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
 		String contentId, entityId;
 		EncodingType encodingType;
+		Boolean trustedRecipient;
 
 		Builder() {}
 
@@ -123,6 +124,20 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 		@Override
 		public SmsTextRequest build() {
 			return new SmsTextRequest(this);
+		}
+
+		/**
+		 * (OPTIONAL)
+		 * Indicates whether the recipient is a trusted recipient.
+		 *
+		 * @param trustedRecipient
+		 * @return
+		 * 
+		 * @since 9.8.0
+		 */
+		public Builder trustedRecipient(Boolean trustedRecipient) {
+			this.trustedRecipient = trustedRecipient;
+			return this;
 		}
 	}
 }

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -26,7 +26,7 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 
 	SmsTextRequest(Builder builder) {
 		super(builder, Channel.SMS, MessageType.TEXT);
-		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId, builder.trustedRecipient);
+		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId, builder.poolId, builder.trustedRecipient);
 	}
 
 	@Override
@@ -49,7 +49,7 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 	}
 
 	public final static class Builder extends MessageRequest.Builder<SmsTextRequest, Builder> implements TextMessageRequest.Builder<Builder> {
-		String contentId, entityId;
+		String contentId, entityId, poolId;
 		EncodingType encodingType;
 		Boolean trustedRecipient;
 
@@ -124,6 +124,23 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 		@Override
 		public SmsTextRequest build() {
 			return new SmsTextRequest(this);
+		}
+
+		/**
+		 * (OPTIONAL)
+		 * The ID of the Number Pool to use as the sender of this message. If specified, a number from the
+		 * pool will be used as the from number. The from number is still required even when specifying a
+		 * pool_id and will be used as a fall-back if the number pool cannot be used. See the Number Pools
+		 * documentation for more information.
+		 *
+		 * @param poolId The pool ID as a string.
+		 * @return This builder.
+		 *
+		 * @since 9.9.0
+		 */
+		public Builder poolId(String poolId) {
+			this.poolId = poolId;
+			return this;
 		}
 
 		/**

--- a/src/main/java/com/vonage/client/messages/whatsapp/ReplyingIndicator.java
+++ b/src/main/java/com/vonage/client/messages/whatsapp/ReplyingIndicator.java
@@ -1,0 +1,112 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages.whatsapp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * Represents a typing indicator to display when preparing a response on WhatsApp.
+ * <p>
+ * This feature allows you to show typing indicators (three successively blinking dots)
+ * to let users know that a response is being prepared.
+ *
+ * @since 9.8.0
+ */
+public final class ReplyingIndicator extends JsonableBaseObject {
+	private final Boolean show;
+	private final String type;
+
+	ReplyingIndicator() {
+		this.show = null;
+		this.type = null;
+	}
+
+	private ReplyingIndicator(Builder builder) {
+		this.show = builder.show;
+		this.type = builder.type;
+	}
+
+	/**
+	 * Whether to show the typing indicator.
+	 *
+	 * @return {@code true} if the indicator should be shown, {@code false} otherwise, or {@code null} if not set.
+	 */
+	@JsonProperty("show")
+	public Boolean getShow() {
+		return show;
+	}
+
+	/**
+	 * The type of indicator to display.
+	 *
+	 * @return The indicator type (currently only "text" is supported), or {@code null} if not set.
+	 */
+	@JsonProperty("type")
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * Creates a new builder for constructing a ReplyingIndicator.
+	 *
+	 * @return A new Builder instance.
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Builder for constructing ReplyingIndicator instances.
+	 */
+	public static final class Builder {
+		private Boolean show;
+		private String type;
+
+		private Builder() {}
+
+		/**
+		 * Sets whether to show the typing indicator.
+		 *
+		 * @param show {@code true} to show the indicator, {@code false} to hide it.
+		 * @return This builder instance for chaining.
+		 */
+		public Builder show(boolean show) {
+			this.show = show;
+			return this;
+		}
+
+		/**
+		 * Sets the type of typing indicator to display.
+		 *
+		 * @param type The indicator type. Currently only "text" is supported.
+		 * @return This builder instance for chaining.
+		 */
+		public Builder type(String type) {
+			this.type = type;
+			return this;
+		}
+
+		/**
+		 * Builds the ReplyingIndicator instance.
+		 *
+		 * @return A new ReplyingIndicator instance.
+		 */
+		public ReplyingIndicator build() {
+			return new ReplyingIndicator(this);
+		}
+	}
+}

--- a/src/main/java/com/vonage/client/users/channels/Websocket.java
+++ b/src/main/java/com/vonage/client/users/channels/Websocket.java
@@ -87,7 +87,12 @@ public class Websocket extends Channel {
 		/**
 		 * audio/l16 with bitrate of 16000.
 		 */
-		AUDIO_L16_16K("audio/l16;rate=16000");
+		AUDIO_L16_16K("audio/l16;rate=16000"),
+
+		/**
+		 * audio/l16 with bitrate of 24000.
+		 */
+		AUDIO_L16_24K("audio/l16;rate=24000");
 
 		private final String value;
 
@@ -107,6 +112,7 @@ public class Websocket extends Channel {
 			switch (value.toLowerCase()) {
 				case ("audio/l16;rate=8000"): return AUDIO_L16_8K;
 				case ("audio/l16;rate=16000"): return AUDIO_L16_16K;
+				case ("audio/l16;rate=24000"): return AUDIO_L16_24K;
 				default: throw new IllegalArgumentException("Unknown content-type: "+value);
 			}
 		}

--- a/src/main/java/com/vonage/client/verify/VerifyClient.java
+++ b/src/main/java/com/vonage/client/verify/VerifyClient.java
@@ -16,7 +16,7 @@
 package com.vonage.client.verify;
 
 import com.vonage.client.*;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
+import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.Locale;
 
@@ -51,7 +51,7 @@ public class VerifyClient {
             Endpoint(String path, boolean formEncoded, R... type) {
                 super(DynamicEndpoint.<T, R> builder(type)
                         .wrapper(wrapper).requestMethod(HttpMethod.POST)
-                        .authMethod(ApiKeyQueryParamsAuthMethod.class)
+                        .authMethod(ApiKeyHeaderAuthMethod.class)
                         .urlFormEncodedContentType(formEncoded)
                         .pathGetter((de, req) -> de.getHttpWrapper().getHttpConfig()
                                 .getApiBaseUri() + "/verify" + path + "/json"

--- a/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
+++ b/src/main/java/com/vonage/client/verify2/SilentAuthWorkflow.java
@@ -24,6 +24,7 @@ import java.net.URI;
  * for an overview of how this works.
  */
 public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
+	@Deprecated
 	private final Boolean sandbox;
 	private final URI redirectUrl;
 
@@ -46,10 +47,25 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * Constructs a new Silent Auth verification workflow.
 	 *
 	 * @param to The number to registered to the device on the network to authenticate.
+	 * @param redirectUrl Optional final redirect added at the end of the check_url request/response lifecycle.
+	 *                    Will contain the request_id and code as a URL fragment after the URL.
+	 *
+	 * @since 8.14.0
+	 */
+	public SilentAuthWorkflow(String to, String redirectUrl) {
+		this(builder(to).redirectUrl(redirectUrl));
+	}
+
+	/**
+	 * Constructs a new Silent Auth verification workflow.
+	 *
+	 * @param to The number to registered to the device on the network to authenticate.
 	 * @param sandbox Whether the Vonage Sandbox should be used (for testing purposes).
 	 *
 	 * @since 7.10.0
+	 * @deprecated The sandbox parameter is deprecated and will be removed in a future release.
 	 */
+	@Deprecated
 	public SilentAuthWorkflow(String to, boolean sandbox) {
 		this(builder(to).sandbox(sandbox));
 	}
@@ -63,7 +79,9 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 *                    Will contain the request_id and code as a URL fragment after the URL.
 	 *
 	 * @since 8.0.0
+	 * @deprecated The sandbox parameter is deprecated and will be removed in a future release.
 	 */
+	@Deprecated
 	public SilentAuthWorkflow(String to, boolean sandbox, String redirectUrl) {
 		this(builder(to).redirectUrl(redirectUrl).sandbox(sandbox));
 	}
@@ -74,7 +92,9 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * @return Whether the Vonage Sandbox will be used, or {@code null} if not specified (the default).
 	 *
 	 * @since 7.10.0
+	 * @deprecated The sandbox parameter is deprecated and will be removed in a future release.
 	 */
+	@Deprecated
 	@JsonProperty("sandbox")
 	public Boolean getSandbox() {
 		return sandbox;
@@ -110,6 +130,7 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 	 * @since 8.2.0
 	 */
 	public static final class Builder extends AbstractNumberWorkflow.Builder<SilentAuthWorkflow, Builder> {
+		@Deprecated
 		private Boolean sandbox;
 		private String redirectUrl;
 
@@ -123,7 +144,9 @@ public final class SilentAuthWorkflow extends AbstractNumberWorkflow {
 		 * @param sandbox {@code true} to use the Vonage sandbox.
 		 *
 		 * @return This builder.
+		 * @deprecated The sandbox parameter is deprecated and will be removed in a future release.
 		 */
+		@Deprecated
 		public Builder sandbox(boolean sandbox) {
 			this.sandbox = sandbox;
 			return this;

--- a/src/main/java/com/vonage/client/voice/AnswerWebhook.java
+++ b/src/main/java/com/vonage/client/voice/AnswerWebhook.java
@@ -39,6 +39,7 @@ public class AnswerWebhook extends JsonableBaseObject {
     @JsonProperty("uuid") private String uuid;
     @JsonProperty("region_url") private URI regionUrl;
     @JsonProperty("custom_data") private Map<String, ?> customData;
+    @JsonProperty("SipHeader_User-to-User") private String sipHeaderUserToUser;
 
     protected AnswerWebhook() {}
 
@@ -109,6 +110,23 @@ public class AnswerWebhook extends JsonableBaseObject {
      */
     public Map<String, ?> getCustomData() {
         return customData;
+    }
+
+    /**
+     * The User-to-User header allows you to send contextual data during a call from your SIP equipment
+     * to your Voice API application. This header is received when your SIP equipment sends a User-to-User
+     * header to your Programmable SIP domain. The header format is: {@code 1234567890abcdef;encoding=hex}.
+     * <p>
+     * The User-to-User header is validated only to ensure it contains valid characters and does not exceed 256
+     * characters. The content itself is not otherwise validated.
+     *
+     * @return The User-to-User header content, or {@code null} if not present.
+     * @since 8.20.0
+     * @see <a href="https://developer.vonage.com/en/voice/voice-api/concepts/programmable-sip#user-to-user-header">
+     *      User-to-User Header Documentation</a>
+     */
+    public String getSipHeaderUserToUser() {
+        return sipHeaderUserToUser;
     }
 
     /**

--- a/src/main/java/com/vonage/client/voice/Authorization.java
+++ b/src/main/java/com/vonage/client/voice/Authorization.java
@@ -1,0 +1,175 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Represents authorization configuration for WebSocket connections in Voice API.
+ * Defines how the Authorization HTTP header is set in the WebSocket opening handshake.
+ *
+ * @since 9.1.0
+ */
+public class Authorization extends JsonableBaseObject {
+    private static final int MAX_VALUE_LENGTH = 8191;
+    private static final Pattern VALUE_PATTERN = Pattern.compile("^[\\x20-\\x7E]+$");
+
+    private final Type type;
+    private final String value;
+
+    /**
+     * Constructor used reflectively by Jackson for instantiation.
+     */
+    Authorization() {
+        this.type = null;
+        this.value = null;
+    }
+
+    private Authorization(Builder builder) {
+        this.type = Objects.requireNonNull(builder.type, "Authorization type is required.");
+        
+        if (type == Type.CUSTOM) {
+            this.value = Objects.requireNonNull(builder.value, 
+                "Authorization value is required when type is 'custom'.");
+            
+            if (value.length() > MAX_VALUE_LENGTH) {
+                throw new IllegalArgumentException(
+                    "Authorization value must not exceed " + MAX_VALUE_LENGTH + " characters.");
+            }
+            
+            if (!VALUE_PATTERN.matcher(value).matches()) {
+                throw new IllegalArgumentException(
+                    "Authorization value must contain only printable ASCII characters (\\x20-\\x7E).");
+            }
+        } else {
+            // For type 'vonage', ignore any provided value
+            this.value = builder.value;
+        }
+    }
+
+    /**
+     * The authorization mode.
+     *
+     * @return The authorization type.
+     */
+    @JsonProperty("type")
+    public Type getType() {
+        return type;
+    }
+
+    /**
+     * The raw header value to include in the Authorization header.
+     * Required only when type is {@link Type#CUSTOM}. Ignored when type is {@link Type#VONAGE}.
+     *
+     * @return The authorization value, or {@code null} if not set.
+     */
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Creates a new Authorization with type 'vonage'.
+     * The Voice API will include the same JWT used for signed webhooks in the Authorization header.
+     *
+     * @return A new Authorization instance with type 'vonage'.
+     */
+    public static Authorization vonage() {
+        return builder(Type.VONAGE).build();
+    }
+
+    /**
+     * Creates a new Authorization with type 'custom'.
+     * The provided value will be sent verbatim in the Authorization header.
+     *
+     * @param value The raw header value to include, e.g. "Bearer abc123" or "ApiKey X9Z...".
+     *              Must be less than 8192 characters and contain only printable ASCII characters.
+     *
+     * @return A new Authorization instance with type 'custom'.
+     */
+    public static Authorization custom(String value) {
+        return builder(Type.CUSTOM).value(value).build();
+    }
+
+    /**
+     * Entry point for constructing an instance of this class.
+     *
+     * @param type The authorization type.
+     *
+     * @return A new Builder.
+     */
+    public static Builder builder(Type type) {
+        return new Builder(type);
+    }
+
+    /**
+     * Authorization type enum.
+     */
+    public enum Type {
+        /**
+         * The Voice API includes the same JWT used for signed webhooks in the Authorization header
+         * ("Bearer &lt;JWT&gt;").
+         */
+        @JsonProperty("vonage") VONAGE,
+
+        /**
+         * A developer-supplied Authorization header value is sent verbatim.
+         */
+        @JsonProperty("custom") CUSTOM;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    /**
+     * Builder for constructing an Authorization instance.
+     */
+    public static class Builder {
+        private final Type type;
+        private String value;
+
+        Builder(Type type) {
+            this.type = type;
+        }
+
+        /**
+         * Sets the raw header value to include in the Authorization header.
+         * Required only when type is {@link Type#CUSTOM}. Ignored when type is {@link Type#VONAGE}.
+         *
+         * @param value The raw header value.
+         *
+         * @return This builder.
+         */
+        public Builder value(String value) {
+            this.value = value;
+            return this;
+        }
+
+        /**
+         * Builds the Authorization with this builder's properties.
+         *
+         * @return A new Authorization instance.
+         */
+        public Authorization build() {
+            return new Authorization(this);
+        }
+    }
+}

--- a/src/main/java/com/vonage/client/voice/EventWebhook.java
+++ b/src/main/java/com/vonage/client/voice/EventWebhook.java
@@ -40,7 +40,7 @@ public class EventWebhook extends JsonableBaseObject {
     private DtmfResult dtmf;
     private SpeechResults speech;
     private Instant timestamp, startTime, endTime;
-    private Integer duration, size;
+    private Integer duration, size, sipCode;
     private Double rate, price;
     private URI recordingUrl;
     private String to, from, network, reason,
@@ -295,6 +295,19 @@ public class EventWebhook extends JsonableBaseObject {
     @JsonProperty("reason")
     public String getReason() {
         return reason;
+    }
+
+    /**
+     * SIP code from the CS sip:hangup event sent to VAPI. This is present if {@linkplain #getStatus()}
+     * is {@linkplain CallStatus#COMPLETED}, {@linkplain CallStatus#BUSY}, {@linkplain CallStatus#UNANSWERED},
+     * {@linkplain CallStatus#REJECTED}, or {@linkplain CallStatus#FAILED}.
+     *
+     * @return The SIP code, or {@code null} if not applicable.
+     * @since 8.17.0
+     */
+    @JsonProperty("sip_code")
+    public Integer getSipCode() {
+        return sipCode;
     }
 
     /**

--- a/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/PhoneEndpoint.java
@@ -19,7 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.JsonableBaseObject;
 
 public class PhoneEndpoint extends JsonableBaseObject implements CallEndpoint {
-    private String number, dtmfAnswer;
+    private String number, dtmfAnswer, shaken;
 
     /**
      * Constructor used reflectively by Jackson for instantiation.
@@ -44,8 +44,25 @@ public class PhoneEndpoint extends JsonableBaseObject implements CallEndpoint {
      * The * and # digits are respected. You create pauses using p. Each pause is 500ms.
      */
     public PhoneEndpoint(String number, String dtmfAnswer) {
+        this(number, dtmfAnswer, null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param number The phone number to connect to in E.164 format.
+     *
+     * @param dtmfAnswer Set the digits that are sent to the user as soon as the Call is answered.
+     * The * and # digits are respected. You create pauses using p. Each pause is 500ms.
+     *
+     * @param shaken For Vonage customers who are required by the FCC to sign their own calls to the USA,
+     * this allows you to place Voice API calls with your own signature. This feature is available by request only.
+     * The STIR/SHAKEN Identity Header content that Vonage must use for this call.
+     */
+    public PhoneEndpoint(String number, String dtmfAnswer, String shaken) {
         this.number = number;
         this.dtmfAnswer = dtmfAnswer;
+        this.shaken = shaken;
     }
 
     @Override
@@ -77,5 +94,21 @@ public class PhoneEndpoint extends JsonableBaseObject implements CallEndpoint {
     @JsonProperty("dtmfAnswer")
     public String getDtmfAnswer() {
         return dtmfAnswer;
+    }
+
+    /**
+     * For Vonage customers who are required by the FCC to sign their own calls to the USA,
+     * this allows you to place Voice API calls with your own signature.
+     * This feature is available by request only. Please be aware calls with an invalid signature will be rejected.
+     * The STIR/SHAKEN Identity Header content that Vonage must use for this call.
+     * Expected format is composed of the JWT with the header, payload and signature, an info parameter with
+     * a link for the certificate, the algorithm (alg) parameter indicating which encryption type was used
+     * and the passport type (ppt) which should be shaken.
+     *
+     * @return The STIR/SHAKEN Identity Header as a string, or {@code null} if not set.
+     */
+    @JsonProperty("shaken")
+    public String getShaken() {
+        return shaken;
     }
 }

--- a/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
@@ -26,6 +26,7 @@ public class WebSocketEndpoint extends JsonableBaseObject implements CallEndpoin
     private URI uri;
     private Websocket.ContentType contentType;
     @JsonProperty("headers") private Map<String, Object> headers;
+    @JsonProperty("authorization") private Authorization authorization;
 
     /**
      * Constructor used reflectively by Jackson for instantiation.
@@ -44,7 +45,8 @@ public class WebSocketEndpoint extends JsonableBaseObject implements CallEndpoin
         this(
             URI.create(uri),
             contentType != null ? Websocket.ContentType.fromString(contentType) : null,
-            headers
+            headers,
+            null
         );
     }
 
@@ -58,9 +60,45 @@ public class WebSocketEndpoint extends JsonableBaseObject implements CallEndpoin
      * @since 8.17.0
      */
     public WebSocketEndpoint(URI uri, Websocket.ContentType contentType, Map<String, Object> headers) {
+        this(uri, contentType, headers, null);
+    }
+
+    /**
+     * Create a new WebSocket Endpoint
+     *
+     * @param uri URI to the websocket, starting with {@code ws://} or {@code wss://}.
+     * @param contentType The audio MIME type as a string.
+     * @param headers Additional headers to be sent with the request.
+     * @param authorization Optional authorization configuration for the WebSocket handshake.
+     *
+     * @since 9.1.0
+     */
+    public WebSocketEndpoint(String uri, String contentType, 
+                           Map<String, Object> headers, Authorization authorization) {
+        this(
+            URI.create(uri),
+            contentType != null ? Websocket.ContentType.fromString(contentType) : null,
+            headers,
+            authorization
+        );
+    }
+
+    /**
+     * Create a new WebSocket Endpoint
+     *
+     * @param uri URI to the websocket, starting with {@code ws://} or {@code wss://}.
+     * @param contentType The audio MIME type.
+     * @param headers Additional headers to be sent with the request.
+     * @param authorization Optional authorization configuration for the WebSocket handshake.
+     *
+     * @since 9.1.0
+     */
+    public WebSocketEndpoint(URI uri, Websocket.ContentType contentType, 
+                           Map<String, Object> headers, Authorization authorization) {
         this.uri = Objects.requireNonNull(uri, "URI is required.");
         this.contentType = contentType;
         this.headers = headers;
+        this.authorization = authorization;
     }
 
     @Override
@@ -101,5 +139,17 @@ public class WebSocketEndpoint extends JsonableBaseObject implements CallEndpoin
     @JsonProperty("headers")
     public Map<String, Object> getHeadersMap() {
         return headers;
+    }
+
+    /**
+     * Optional configuration defining how the Authorization HTTP header is set
+     * in the WebSocket opening handshake.
+     *
+     * @return The authorization configuration, or {@code null} if unspecified.
+     * @since 9.1.0
+     */
+    @JsonProperty("authorization")
+    public Authorization getAuthorization() {
+        return authorization;
     }
 }

--- a/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/WebSocketEndpoint.java
@@ -122,7 +122,7 @@ public class WebSocketEndpoint extends JsonableBaseObject implements CallEndpoin
     }
 
     /**
-     * Content type of the audio stream; either {@code audio/l16;rate=16000} or {@code audio/l16;rate=8000}.
+     * Content type of the audio stream; either {@code audio/l16;rate=8000}, {@code audio/l16;rate=16000}, or {@code audio/l16;rate=24000}.
      *
      * @return The content type.
      */

--- a/src/main/java/com/vonage/client/voice/ncco/Action.java
+++ b/src/main/java/com/vonage/client/voice/ncco/Action.java
@@ -35,7 +35,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = InputAction.class, name = "input"),
         @JsonSubTypes.Type(value = ConnectAction.class, name = "connect"),
         @JsonSubTypes.Type(value = ConversationAction.class, name = "conversation"),
-        @JsonSubTypes.Type(value = TransferAction.class, name = "transfer")
+        @JsonSubTypes.Type(value = TransferAction.class, name = "transfer"),
+        @JsonSubTypes.Type(value = WaitAction.class, name = "wait")
 })
 public interface Action {
 

--- a/src/main/java/com/vonage/client/voice/ncco/Action.java
+++ b/src/main/java/com/vonage/client/voice/ncco/Action.java
@@ -34,7 +34,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
         @JsonSubTypes.Type(value = NotifyAction.class, name = "notify"),
         @JsonSubTypes.Type(value = InputAction.class, name = "input"),
         @JsonSubTypes.Type(value = ConnectAction.class, name = "connect"),
-        @JsonSubTypes.Type(value = ConversationAction.class, name = "conversation")
+        @JsonSubTypes.Type(value = ConversationAction.class, name = "conversation"),
+        @JsonSubTypes.Type(value = TransferAction.class, name = "transfer")
 })
 public interface Action {
 

--- a/src/main/java/com/vonage/client/voice/ncco/TransferAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/TransferAction.java
@@ -1,0 +1,229 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice.ncco;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * An NCCO transfer action which enables transferring call legs from a current conversation into another existing conversation.
+ * <p>
+ * The transfer action is synchronous and terminal for the current conversation.
+ * All legs of the current conversation are transferred into the target conversation,
+ * respecting the audio settings (canHear, canSpeak, mute) if they're provided.
+ * The target conversation's NCCO continues to control the target conversation behaviour.
+ */
+public class TransferAction extends JsonableBaseObject implements Action {
+    private String conversationId;
+    private Boolean mute;
+    private Collection<String> canSpeak, canHear;
+
+    /**
+     * Constructor used reflectively by Jackson for instantiation.
+     */
+    TransferAction() {}
+
+    private TransferAction(Builder builder) {
+        conversationId = Objects.requireNonNull(builder.conversationId, "Conversation ID is required.");
+        if (conversationId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Conversation ID cannot be empty.");
+        }
+        mute = builder.mute;
+        canSpeak = builder.canSpeak;
+        canHear = builder.canHear;
+    }
+
+    @Override
+    public String getAction() {
+        return "transfer";
+    }
+
+    /**
+     * Target conversation ID to transfer the call legs into.
+     *
+     * @return The target conversation ID as a string.
+     */
+    @JsonProperty("conversationId")
+    public String getConversationId() {
+        return conversationId;
+    }
+
+    /**
+     * Whether the participant is muted. When muted, the audio from the participant will not be played to
+     * the conversation and will not be recorded. When using {@code canSpeak}, the mute parameter is not supported.
+     *
+     * @return {@code true} if the participant is muted, {@code false} if not muted, or {@code null} if unspecified.
+     */
+    @JsonProperty("mute")
+    public Boolean getMute() {
+        return mute;
+    }
+
+    /**
+     * A list of leg UUIDs that this participant can be heard by. If not provided, the participant can be heard by
+     * everyone. If an empty list is provided, the participant will not be heard by anyone.
+     *
+     * @return The leg UUIDs that can hear this participant speak, or {@code null} if unspecified.
+     */
+    @JsonProperty("canSpeak")
+    public Collection<String> getCanSpeak() {
+        return canSpeak;
+    }
+
+    /**
+     * A list of leg UUIDs that this participant can hear. If not provided, the participant can hear everyone.
+     * If an empty list is provided, the participant will not hear any other participants.
+     *
+     * @return The leg UUIDs that this participant can hear, or {@code null} if unspecified.
+     */
+    @JsonProperty("canHear")
+    public Collection<String> getCanHear() {
+        return canHear;
+    }
+
+    /**
+     * Entrypoint for constructing an instance of this class.
+     *
+     * @param conversationId The target conversation ID to transfer the call legs into.
+     *
+     * @return A new Builder with the conversation ID initialized.
+     */
+    public static Builder builder(String conversationId) {
+        return new Builder(conversationId);
+    }
+
+    /**
+     * Builder for specifying the properties of a Transfer NCCO action. The conversation ID is mandatory.
+     */
+    public static class Builder {
+        private String conversationId;
+        private Boolean mute;
+        private Collection<String> canSpeak, canHear;
+
+        Builder(String conversationId) {
+            this.conversationId = conversationId;
+        }
+
+        /**
+         * Sets the target conversation ID to transfer the call legs into.
+         *
+         * @param conversationId The target conversation ID as a string.
+         *
+         * @return This builder.
+         */
+        public Builder conversationId(String conversationId) {
+            this.conversationId = conversationId;
+            return this;
+        }
+
+        /**
+         * Whether to mute the participant. The audio from the participant will not be played to the
+         * conversation and will not be recorded. When using {@linkplain #canSpeak(Collection)}, the
+         * mute parameter is not supported.
+         *
+         * @param mute {@code true} to mute the participant.
+         *
+         * @return This builder.
+         */
+        public Builder mute(boolean mute) {
+            this.mute = mute;
+            return this;
+        }
+
+        /**
+         * Convenience method for adding a leg ID to the {@code canSpeak} collection.
+         * The added leg ID will be able to hear this participant.
+         *
+         * @param uuid The participant leg ID(s) to add as string(s).
+         *
+         * @return This builder.
+         * @see #canSpeak(Collection)
+         */
+        public Builder addCanSpeak(String... uuid) {
+            if (canSpeak == null) {
+                canSpeak = new LinkedHashSet<>();
+            }
+            canSpeak.addAll(Arrays.asList(uuid));
+            return this;
+        }
+
+        /**
+         * Convenience method for adding a leg ID to the {@code canHear} collection.
+         * This participant will be able to hear the participant associated with the provided leg ID.
+         *
+         * @param uuid The participant leg ID(s) to add as string(s).
+         *
+         * @return This builder.
+         */
+        public Builder addCanHear(String... uuid) {
+            if (canHear == null) {
+                canHear = new LinkedHashSet<>(uuid.length);
+            }
+            canHear.addAll(Arrays.asList(uuid));
+            return this;
+        }
+
+        /**
+         * A collection of leg UUIDs that this participant can be heard by. If not provided, the participant can
+         * be heard by everyone. If an empty collection is provided, the participant will not be heard by anyone.
+         * This will replace the current collection.
+         *
+         * @param canSpeak The leg UUIDs that can hear this participant speak.
+         *
+         * @return This builder.
+         * @see #addCanSpeak(String...)
+         */
+        public Builder canSpeak(Collection<String> canSpeak) {
+            this.canSpeak = canSpeak;
+            return this;
+        }
+
+        /**
+         * A collection of leg UUIDs that this participant can hear. If not provided, the participant can hear
+         * everyone. If an empty collection is provided, the participant will not hear any other participants.
+         * This will replace the current collection.
+         *
+         * @param canHear The leg UUIDs that this participant can hear.
+         *
+         * @return This builder.
+         * @see #addCanHear(String...)
+         */
+        public Builder canHear(Collection<String> canHear) {
+            this.canHear = canHear;
+            return this;
+        }
+
+        /**
+         * Builds the Transfer NCCO action.
+         *
+         * @return A new {@link TransferAction} object from the stored builder options.
+         */
+        public TransferAction build() {
+            if (canSpeak != null) {
+                canSpeak = canSpeak.stream().distinct().collect(Collectors.toList());
+            }
+            if (canHear != null) {
+                canHear = canHear.stream().distinct().collect(Collectors.toList());
+            }
+            return new TransferAction(this);
+        }
+    }
+}

--- a/src/main/java/com/vonage/client/voice/ncco/WaitAction.java
+++ b/src/main/java/com/vonage/client/voice/ncco/WaitAction.java
@@ -1,0 +1,112 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice.ncco;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.vonage.client.JsonableBaseObject;
+
+/**
+ * An NCCO wait action which pauses execution of the running NCCO for a specified number of seconds.
+ * <p>
+ * The action is synchronous. The wait period starts when the wait action is executed in the NCCO and ends after
+ * the provided or default timeout value. At this point, the NCCO resumes execution.
+ * </p>
+ */
+public class WaitAction extends JsonableBaseObject implements Action {
+    private Double timeout;
+
+    /**
+     * Constructor used reflectively by Jackson for instantiation.
+     */
+    WaitAction() {}
+
+    private WaitAction(Builder builder) {
+        this.timeout = builder.timeout;
+    }
+
+    @Override
+    public String getAction() {
+        return "wait";
+    }
+
+    /**
+     * Controls the duration of the wait period before executing the next action in the NCCO.
+     * Valid values range from 0.1 seconds to 7200 seconds. Values below 0.1 default to 0.1 seconds,
+     * and values above 7200 default to 7200 seconds. The default value is 10 seconds.
+     *
+     * @return The timeout duration in seconds, or {@code null} if unspecified (will default to 10 seconds).
+     */
+    @JsonProperty("timeout")
+    public Double getTimeout() {
+        return timeout;
+    }
+
+    /**
+     * Entrypoint for constructing an instance of this class.
+     *
+     * @param timeout The wait duration in seconds (0.1 to 7200).
+     *
+     * @return A new Builder with the timeout field initialised.
+     */
+    public static Builder builder(double timeout) {
+        return builder().timeout(timeout);
+    }
+
+    /**
+     * Entrypoint for constructing an instance of this class.
+     * The timeout defaults to 10 seconds if not specified.
+     *
+     * @return A new Builder.
+     * @since 8.17.0
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for specifying the properties of a WaitAction. All parameters are optional.
+     */
+    public static class Builder {
+        private Double timeout;
+
+        private Builder() {
+        }
+
+        /**
+         * Controls the duration of the wait period before executing the next action in the NCCO.
+         * This parameter is a float. Valid values range from 0.1 seconds to 7200 seconds.
+         * Values below 0.1 default to 0.1 seconds, and values above 7200 default to 7200 seconds.
+         * The default value is 10 seconds.
+         *
+         * @param timeout The wait duration in seconds.
+         *
+         * @return This builder.
+         */
+        public Builder timeout(double timeout) {
+            this.timeout = timeout;
+            return this;
+        }
+
+        /**
+         * Builds the WaitAction.
+         *
+         * @return A new WaitAction object from the stored builder options.
+         */
+        public WaitAction build() {
+            return new WaitAction(this);
+        }
+    }
+}

--- a/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
@@ -18,6 +18,7 @@ package com.vonage.client.voice.ncco;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.vonage.client.JsonableBaseObject;
 import com.vonage.client.users.channels.Websocket;
+import com.vonage.client.voice.Authorization;
 import com.vonage.client.voice.EndpointType;
 import java.net.URI;
 import java.util.Map;
@@ -31,11 +32,13 @@ public class WebSocketEndpoint extends JsonableBaseObject implements ConnectEndp
     private final URI uri;
     private final String contentType;
     private final Map<String, ?> headers;
+    private final Authorization authorization;
 
     private WebSocketEndpoint(Builder builder) {
         uri = builder.uri;
         contentType = builder.contentType;
         headers = builder.headers;
+        authorization = builder.authorization;
     }
 
     @Override
@@ -74,6 +77,18 @@ public class WebSocketEndpoint extends JsonableBaseObject implements ConnectEndp
     }
 
     /**
+     * Optional configuration defining how the Authorization HTTP header is set
+     * in the WebSocket opening handshake.
+     *
+     * @return The authorization configuration, or {@code null} if unspecified.
+     * @since 9.1.0
+     */
+    @JsonProperty("authorization")
+    public Authorization getAuthorization() {
+        return authorization;
+    }
+
+    /**
      * Entry point for constructing an instance of this class.
      *
      * @param uri The websocket URI.
@@ -92,6 +107,7 @@ public class WebSocketEndpoint extends JsonableBaseObject implements ConnectEndp
         private URI uri;
         private String contentType;
         private Map<String, ?> headers;
+        private Authorization authorization;
 
         Builder(String uri, String contentType) {
             this.uri = URI.create(uri);
@@ -155,6 +171,20 @@ public class WebSocketEndpoint extends JsonableBaseObject implements ConnectEndp
          */
         public Builder headers(Map<String, ?> headers) {
             this.headers = headers;
+            return this;
+        }
+
+        /**
+         * Optional configuration defining how the Authorization HTTP header is set
+         * in the WebSocket opening handshake.
+         *
+         * @param authorization The authorization configuration.
+         *
+         * @return This builder.
+         * @since 9.1.0
+         */
+        public Builder authorization(Authorization authorization) {
+            this.authorization = authorization;
             return this;
         }
 

--- a/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
+++ b/src/main/java/com/vonage/client/voice/ncco/WebSocketEndpoint.java
@@ -139,7 +139,7 @@ public class WebSocketEndpoint extends JsonableBaseObject implements ConnectEndp
 
         /**
          * The internet media type for the audio you are streaming. Possible values are:
-         * {@code audio/l16;rate=16000} or {@code audio/l16;rate=8000}.
+         * {@code audio/l16;rate=8000}, {@code audio/l16;rate=16000}, or {@code audio/l16;rate=24000}.
          *
          * @param contentType The content type as a string.
          *

--- a/src/test/java/com/vonage/client/Java8DeprecationWarningTest.java
+++ b/src/test/java/com/vonage/client/Java8DeprecationWarningTest.java
@@ -1,0 +1,99 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+/**
+ * Tests for Java 8 deprecation warning functionality.
+ * 
+ * Note: The actual warning will only appear when running on Java 8.
+ * This test verifies that the VonageClient can be instantiated without errors
+ * and that the warning mechanism is properly integrated.
+ */
+public class Java8DeprecationWarningTest extends AbstractClientTest<VonageClient> {
+    private final TestUtils testUtils = new TestUtils();
+
+    @Test
+    public void testVonageClientInstantiatesWithWarningMechanism() throws Exception {
+        // Capture System.err to check if warning would be triggered on Java 8
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+
+        try {
+            byte[] keyBytes = testUtils.loadKey("test/keys/application_key");
+            VonageClient client = VonageClient.builder()
+                    .applicationId("951614e0-eec4-4087-a6b1-3f4c2f169cb0")
+                    .privateKeyContents(keyBytes)
+                    .build();
+
+            assertNotNull(client);
+            
+            // The warning will only appear if running on Java 8 (version "1.8")
+            String javaVersion = System.getProperty("java.specification.version");
+            if ("1.8".equals(javaVersion)) {
+                String output = errContent.toString();
+                assertTrue(output.contains("[VONAGE SDK WARNING]"), 
+                    "Expected Java 8 deprecation warning on Java 8");
+                assertTrue(output.contains("June 30, 2026"), 
+                    "Warning should mention the deprecation date");
+            }
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    public void testMultipleInstantiationsOnlyWarnOnce() throws Exception {
+        // Capture System.err
+        ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+        PrintStream originalErr = System.err;
+        System.setErr(new PrintStream(errContent));
+
+        try {
+            byte[] keyBytes = testUtils.loadKey("test/keys/application_key");
+            
+            // Create multiple clients
+            VonageClient client1 = VonageClient.builder()
+                    .applicationId("951614e0-eec4-4087-a6b1-3f4c2f169cb0")
+                    .privateKeyContents(keyBytes)
+                    .build();
+                    
+            VonageClient client2 = VonageClient.builder()
+                    .applicationId("951614e0-eec4-4087-a6b1-3f4c2f169cb0")
+                    .privateKeyContents(keyBytes)
+                    .build();
+
+            assertNotNull(client1);
+            assertNotNull(client2);
+            
+            // On Java 8, the warning should only appear once
+            String javaVersion = System.getProperty("java.specification.version");
+            if ("1.8".equals(javaVersion)) {
+                String output = errContent.toString();
+                int warningCount = output.split("\\[VONAGE SDK WARNING\\]", -1).length - 1;
+                assertEquals(1, warningCount, 
+                    "Warning should only appear once despite multiple instantiations");
+            }
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+}

--- a/src/test/java/com/vonage/client/account/AccountSecretsEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/account/AccountSecretsEndpointTestSpec.java
@@ -16,16 +16,13 @@
 package com.vonage.client.account;
 
 import com.vonage.client.auth.AuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
 import java.util.Collection;
 
 abstract class AccountSecretsEndpointTestSpec<T, R> extends AccountEndpointTestSpec<T, R> {
 
 	@Override
 	protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-		Collection<Class<? extends AuthMethod>> authMethods = super.expectedAuthMethods();
-		authMethods.add(SignatureAuthMethod.class);
-		return authMethods;
+		return super.expectedAuthMethods();
 	}
 
 	@Override
@@ -36,16 +33,22 @@ abstract class AccountSecretsEndpointTestSpec<T, R> extends AccountEndpointTestS
 	@Override
 	protected String expectedEndpointUri(T request) {
 		String uri = "/accounts/%s/secrets";
-        switch (request) {
-            case SecretRequest secretRequest -> {
-                String apiKey = secretRequest.apiKey;
-                String secretId = secretRequest.secretId;
-                uri = String.format(uri, apiKey) + "/" + secretId;
-            }
-            case CreateSecretRequest createSecretRequest -> uri = String.format(uri, createSecretRequest.apiKey);
-            case String ignored -> uri = String.format(uri, request);
-            case null, default -> throw new IllegalStateException();
-        }
+		if (request instanceof SecretRequest) {
+			SecretRequest secretRequest = (SecretRequest) request;
+			String apiKey = secretRequest.apiKey;
+			String secretId = secretRequest.secretId;
+			uri = String.format(uri, apiKey) + "/" + secretId;
+		}
+		else if (request instanceof CreateSecretRequest) {
+			CreateSecretRequest createSecretRequest = (CreateSecretRequest) request;
+			uri = String.format(uri, createSecretRequest.apiKey);
+		}
+		else if (request instanceof String) {
+			uri = String.format(uri, request);
+		}
+		else {
+			throw new IllegalStateException();
+		}
 		return uri;
 	}
 }

--- a/src/test/java/com/vonage/client/conversion/ConversionClientTest.java
+++ b/src/test/java/com/vonage/client/conversion/ConversionClientTest.java
@@ -19,9 +19,8 @@ import com.vonage.client.AbstractClientTest;
 import com.vonage.client.DynamicEndpointTestSpec;
 import com.vonage.client.RestEndpoint;
 import com.vonage.client.VonageApiResponseException;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
+import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.auth.AuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -75,7 +74,7 @@ public class ConversionClientTest extends AbstractClientTest<ConversionClient> {
 
             @Override
             protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-                return Arrays.asList(SignatureAuthMethod.class, ApiKeyQueryParamsAuthMethod.class);
+                return Arrays.asList(ApiKeyHeaderAuthMethod.class);
             }
 
             @Override

--- a/src/test/java/com/vonage/client/identityinsights/IdentityInsightsClientTest.java
+++ b/src/test/java/com/vonage/client/identityinsights/IdentityInsightsClientTest.java
@@ -1,0 +1,170 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.identityinsights;
+
+import com.vonage.client.AbstractClientTest;
+import com.vonage.client.RestEndpoint;
+import com.vonage.client.TestUtils;
+import com.vonage.client.auth.JWTAuthMethod;
+import com.vonage.client.camara.CamaraResponseException;
+import com.vonage.client.common.HttpMethod;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class IdentityInsightsClientTest extends AbstractClientTest<IdentityInsightsClient> {
+    final String phoneNumber = "+14155552671";
+    
+    public IdentityInsightsClientTest() {
+        client = new IdentityInsightsClient(wrapper);
+    }
+    
+    private String loadJsonResource(String filename, String requestId) throws IOException {
+        try (InputStream is = getClass().getResourceAsStream(filename)) {
+            if (is == null) {
+                throw new IOException("Could not find resource: " + filename);
+            }
+            byte[] buffer = new byte[1024];
+            StringBuilder sb = new StringBuilder();
+            int bytesRead;
+            while ((bytesRead = is.read(buffer)) != -1) {
+                sb.append(new String(buffer, 0, bytesRead, StandardCharsets.UTF_8));
+            }
+            return sb.toString().replace("REQUEST_ID_PLACEHOLDER", requestId);
+        }
+    }
+    
+    @Test
+    public void testGetInsightsFormat() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String responseJson = loadJsonResource("format-response.json", requestId);
+        
+        stubResponse(responseJson);
+        
+        IdentityInsightsRequest request = new IdentityInsightsRequest(phoneNumber)
+                .format();
+        
+        IdentityInsightsResponse response = client.getInsights(request);
+        
+        assertNotNull(response);
+        assertEquals(requestId, response.getRequestId());
+        assertNotNull(response.getInsights());
+        assertNotNull(response.getInsights().getFormat());
+        
+        FormatInsightResponse format = response.getInsights().getFormat();
+        assertEquals("US", format.getCountryCode());
+        assertEquals("United States", format.getCountryName());
+        assertEquals("1", format.getCountryPrefix());
+        assertEquals("California", format.getOfflineLocation());
+        assertEquals(1, format.getTimeZones().size());
+        assertEquals("America/Los_Angeles", format.getTimeZones().get(0));
+        assertEquals("+14155552671", format.getNumberInternational());
+        assertEquals("(415) 555-2671", format.getNumberNational());
+        assertTrue(format.getIsFormatValid());
+        assertEquals(InsightStatusCode.OK, format.getStatus().getCode());
+        assertEquals("Success", format.getStatus().getMessage());
+    }
+    
+    @Test
+    public void testGetInsightsSimSwap() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String responseJson = loadJsonResource("sim-swap-response.json", requestId);
+        
+        stubResponse(responseJson);
+        
+        IdentityInsightsRequest request = new IdentityInsightsRequest(phoneNumber)
+                .simSwap(240);
+        
+        IdentityInsightsResponse response = client.getInsights(request);
+        
+        assertNotNull(response);
+        assertNotNull(response.getInsights().getSimSwap());
+        
+        SimSwapInsightResponse simSwap = response.getInsights().getSimSwap();
+        assertNotNull(simSwap.getLatestSimSwapAt());
+        assertTrue(simSwap.getIsSwapped());
+        assertEquals(InsightStatusCode.OK, simSwap.getStatus().getCode());
+    }
+    
+    @Test
+    public void testGetInsightsCurrentCarrier() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String responseJson = loadJsonResource("current-carrier-response.json", requestId);
+        
+        stubResponse(responseJson);
+        
+        IdentityInsightsRequest request = new IdentityInsightsRequest(phoneNumber)
+                .currentCarrier();
+        
+        IdentityInsightsResponse response = client.getInsights(request);
+        
+        assertNotNull(response);
+        assertNotNull(response.getInsights().getCurrentCarrier());
+        
+        CurrentCarrierInsightResponse carrier = response.getInsights().getCurrentCarrier();
+        assertEquals("Orange Espana, S.A. Unipersonal", carrier.getName());
+        assertEquals(NetworkType.MOBILE, carrier.getNetworkType());
+        assertEquals("ES", carrier.getCountryCode());
+        assertEquals("21403", carrier.getNetworkCode());
+        assertEquals(InsightStatusCode.OK, carrier.getStatus().getCode());
+    }
+    
+    @Test
+    public void testGetInsightsMultiple() throws Exception {
+        String requestId = UUID.randomUUID().toString();
+        String responseJson = loadJsonResource("multiple-insights-response.json", requestId);
+        
+        stubResponse(responseJson);
+        
+        IdentityInsightsRequest request = new IdentityInsightsRequest(phoneNumber)
+                .purpose("FraudPreventionAndDetection")
+                .format()
+                .simSwap()
+                .originalCarrier();
+        
+        IdentityInsightsResponse response = client.getInsights(request);
+        
+        assertNotNull(response);
+        assertEquals(requestId, response.getRequestId());
+        assertNotNull(response.getInsights().getFormat());
+        assertNotNull(response.getInsights().getSimSwap());
+        assertNotNull(response.getInsights().getOriginalCarrier());
+        
+        assertTrue(response.getInsights().getFormat().getIsFormatValid());
+        assertFalse(response.getInsights().getSimSwap().getIsSwapped());
+        assertEquals("Verizon Wireless", response.getInsights().getOriginalCarrier().getName());
+        assertEquals(NetworkType.MOBILE, response.getInsights().getOriginalCarrier().getNetworkType());
+    }
+    
+    @Test
+    public void testRequestValidation() {
+        assertThrows(NullPointerException.class, () -> new IdentityInsightsRequest(null));
+        
+        IdentityInsightsRequest request = new IdentityInsightsRequest(phoneNumber);
+        assertNotNull(request.getPhoneNumber());
+        
+        assertThrows(IllegalArgumentException.class, 
+            () -> new SimSwapInsightRequest(0));
+        assertThrows(IllegalArgumentException.class, 
+            () -> new SimSwapInsightRequest(2401));
+        
+        assertDoesNotThrow(() -> new SimSwapInsightRequest(1));
+        assertDoesNotThrow(() -> new SimSwapInsightRequest(2400));
+    }
+}

--- a/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/insight/InsightEndpointTestSpec.java
@@ -19,7 +19,6 @@ import com.vonage.client.DynamicEndpointTestSpec;
 import com.vonage.client.VonageApiResponseException;
 import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.auth.AuthMethod;
-import com.vonage.client.auth.SignatureAuthMethod;
 import com.vonage.client.common.HttpMethod;
 import java.util.Collection;
 import java.util.List;
@@ -34,7 +33,7 @@ abstract class InsightEndpointTestSpec<T, R> extends DynamicEndpointTestSpec<T, 
 
 	@Override
 	protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-		return List.of(SignatureAuthMethod.class, ApiKeyHeaderAuthMethod.class);
+		return List.of(ApiKeyHeaderAuthMethod.class);
 	}
 
 	@Override

--- a/src/test/java/com/vonage/client/messages/ReplyingIndicatorTest.java
+++ b/src/test/java/com/vonage/client/messages/ReplyingIndicatorTest.java
@@ -1,0 +1,162 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.messages;
+
+import com.vonage.client.AbstractClientTest;
+import com.vonage.client.Jsonable;
+import com.vonage.client.messages.whatsapp.ReplyingIndicator;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReplyingIndicatorTest extends AbstractClientTest<ReplyingIndicator> {
+
+	@Test
+	public void testBuilderAllParameters() {
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(true)
+				.type("text")
+				.build();
+		
+		assertTrue(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+
+	@Test
+	public void testBuilderShowOnly() {
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(true)
+				.build();
+		
+		assertTrue(indicator.getShow());
+		assertNull(indicator.getType());
+	}
+
+	@Test
+	public void testBuilderTypeOnly() {
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.type("text")
+				.build();
+		
+		assertNull(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+
+	@Test
+	public void testBuilderShowFalse() {
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(false)
+				.type("text")
+				.build();
+		
+		assertFalse(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+
+	@Test
+	public void testBuilderEmpty() {
+		ReplyingIndicator indicator = ReplyingIndicator.builder().build();
+		
+		assertNull(indicator.getShow());
+		assertNull(indicator.getType());
+	}
+
+	@Test
+	public void testSerializationAllFields() {
+		String expectedJson = "{\"show\":true,\"type\":\"text\"}";
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(true)
+				.type("text")
+				.build();
+		
+		assertEquals(expectedJson, indicator.toJson());
+	}
+
+	@Test
+	public void testSerializationShowOnly() {
+		String expectedJson = "{\"show\":true}";
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(true)
+				.build();
+		
+		assertEquals(expectedJson, indicator.toJson());
+	}
+
+	@Test
+	public void testSerializationTypeOnly() {
+		String expectedJson = "{\"type\":\"text\"}";
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.type("text")
+				.build();
+		
+		assertEquals(expectedJson, indicator.toJson());
+	}
+
+	@Test
+	public void testSerializationShowFalse() {
+		String expectedJson = "{\"show\":false,\"type\":\"text\"}";
+		ReplyingIndicator indicator = ReplyingIndicator.builder()
+				.show(false)
+				.type("text")
+				.build();
+		
+		assertEquals(expectedJson, indicator.toJson());
+	}
+
+	@Test
+	public void testDeserializationAllFields() {
+		String json = "{\"show\":true,\"type\":\"text\"}";
+		ReplyingIndicator indicator = Jsonable.fromJson(json, ReplyingIndicator.class);
+		
+		assertTrue(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+
+	@Test
+	public void testDeserializationShowOnly() {
+		String json = "{\"show\":true}";
+		ReplyingIndicator indicator = Jsonable.fromJson(json, ReplyingIndicator.class);
+		
+		assertTrue(indicator.getShow());
+		assertNull(indicator.getType());
+	}
+
+	@Test
+	public void testDeserializationTypeOnly() {
+		String json = "{\"type\":\"text\"}";
+		ReplyingIndicator indicator = Jsonable.fromJson(json, ReplyingIndicator.class);
+		
+		assertNull(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+
+	@Test
+	public void testDeserializationEmpty() {
+		String json = "{}";
+		ReplyingIndicator indicator = Jsonable.fromJson(json, ReplyingIndicator.class);
+		
+		assertNull(indicator.getShow());
+		assertNull(indicator.getType());
+	}
+
+	@Test
+	public void testDeserializationShowFalse() {
+		String json = "{\"show\":false,\"type\":\"text\"}";
+		ReplyingIndicator indicator = Jsonable.fromJson(json, ReplyingIndicator.class);
+		
+		assertFalse(indicator.getShow());
+		assertEquals("text", indicator.getType());
+	}
+}

--- a/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/mms/MmsImageRequestTest.java
@@ -109,4 +109,36 @@ public class MmsImageRequestTest {
 			assertEquals(3001, sb.length());
 		}
 	}
+
+	@Test
+	public void testWithTrustedRecipient() {
+		MmsImageRequest mms = MmsImageRequest.builder()
+				.from("447900000001").to("317900000002")
+				.url("https://example.com/image.jpg")
+				.trustedRecipient(true).build();
+
+		String json = mms.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":true"));
+	}
+
+	@Test
+	public void testTrustedRecipientFalse() {
+		MmsImageRequest mms = MmsImageRequest.builder()
+				.from("447900000001").to("317900000002")
+				.url("https://example.com/image.jpg")
+				.trustedRecipient(false).build();
+
+		String json = mms.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":false"));
+	}
+
+	@Test
+	public void testWithoutTrustedRecipient() {
+		MmsImageRequest mms = MmsImageRequest.builder()
+				.from("447900000001").to("317900000002")
+				.url("https://example.com/image.jpg").build();
+
+		String json = mms.toJson();
+		assertFalse(json.contains("\"trusted_recipient\""));
+	}
 }

--- a/src/test/java/com/vonage/client/messages/rcs/RcsTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/rcs/RcsTextRequestTest.java
@@ -193,4 +193,35 @@ public class RcsTextRequestTest {
 		String json = rcsText.toJson();
 		assertFalse(json.contains("\"suggestions\""));
 	}
+
+	@Test
+	public void testWithTrustedRecipient() {
+		RcsTextRequest rcs = RcsTextRequest.builder()
+				.from(from).to(to).text(message)
+				.trustedRecipient(true).build();
+
+		String json = rcs.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":true"));
+		assertTrue(json.contains("\"rcs\":"));
+	}
+
+	@Test
+	public void testTrustedRecipientFalse() {
+		RcsTextRequest rcs = RcsTextRequest.builder()
+				.from(from).to(to).text(message)
+				.trustedRecipient(false).build();
+
+		String json = rcs.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":false"));
+		assertTrue(json.contains("\"rcs\":"));
+	}
+
+	@Test
+	public void testWithoutTrustedRecipient() {
+		RcsTextRequest rcs = RcsTextRequest.builder()
+				.from(from).to(to).text(message).build();
+
+		String json = rcs.toJson();
+		assertFalse(json.contains("\"trusted_recipient\""));
+	}
 }

--- a/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
@@ -185,4 +185,33 @@ public class SmsTextRequestTest {
 		assertEquals(EncodingType.AUTO, EncodingType.fromString("auto"));
 		assertNull(EncodingType.fromString(null));
 	}
+
+	@Test
+	public void testWithTrustedRecipient() {
+		SmsTextRequest sms = SmsTextRequest.builder()
+			.from(from).to(to).text(msg)
+			.trustedRecipient(true).build();
+	
+		String json = sms.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":true"));
+	}
+	
+	@Test
+	public void testTrustedRecipientFalse() {
+		SmsTextRequest sms = SmsTextRequest.builder()
+			.from(from).to(to).text(msg)
+			.trustedRecipient(false).build();
+	
+		String json = sms.toJson();
+		assertTrue(json.contains("\"trusted_recipient\":false"));
+	}
+	
+	@Test
+	public void testWithoutTrustedRecipient() {
+		SmsTextRequest sms = SmsTextRequest.builder()
+			.from(from).to(to).text(msg).build();
+	
+		String json = sms.toJson();
+		assertFalse(json.contains("\"trusted_recipient\""));
+	}
 }

--- a/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
@@ -214,4 +214,61 @@ public class SmsTextRequestTest {
 		String json = sms.toJson();
 		assertFalse(json.contains("\"trusted_recipient\""));
 	}
+
+	@Test
+	public void testPoolIdOnly() {
+		String poolId = "test-pool-123";
+		var sms = SmsTextRequest.builder().from(from).to(to).text(msg).poolId(poolId).build();
+
+		String json = sms.toJson();
+		assertTrue(json.contains("\"text\":\"" + msg + "\""));
+		assertTrue(json.contains("\"from\":\"" + from + "\""));
+		assertTrue(json.contains("\"to\":\"" + to + "\""));
+		assertTrue(json.contains("\"message_type\":\"text\""));
+		assertTrue(json.contains("\"channel\":\"sms\""));
+		assertTrue(json.contains("\"sms\":{\"pool_id\":\"" + poolId + "\"}"));
+
+		assertNull(sms.getTtl());
+		OutboundSettings settings = sms.getMessageSettings();
+		assertNotNull(settings);
+		assertNull(settings.getEncodingType());
+		assertNull(settings.getEntityId());
+		assertNull(settings.getContentId());
+		assertEquals(poolId, settings.getPoolId());
+	}
+
+	@Test
+	public void testInvalidPoolId() {
+		assertThrows(IllegalArgumentException.class, () ->
+				OutboundSettings.construct(EncodingType.TEXT, contentId, entityId, " ", null)
+		);
+	}
+
+	@Test
+	public void testAllSmsFieldsIncludingPoolId() {
+		String poolId = "pool-456";
+		SmsTextRequest sms = SmsTextRequest.builder()
+				.from(from).to(to).text(msg)
+				.contentId(contentId)
+				.entityId(entityId)
+				.poolId(poolId)
+				.encodingType(EncodingType.TEXT)
+				.trustedRecipient(true)
+				.build();
+
+		String json = sms.toJson();
+		assertTrue(json.contains("\"pool_id\":\"" + poolId + "\""));
+		assertTrue(json.contains("\"content_id\":\"" + contentId + "\""));
+		assertTrue(json.contains("\"entity_id\":\"" + entityId + "\""));
+		assertTrue(json.contains("\"encoding_type\":\"text\""));
+		assertTrue(json.contains("\"trusted_recipient\":true"));
+
+		OutboundSettings settings = sms.getMessageSettings();
+		assertNotNull(settings);
+		assertEquals(poolId, settings.getPoolId());
+		assertEquals(contentId, settings.getContentId());
+		assertEquals(entityId, settings.getEntityId());
+		assertEquals(EncodingType.TEXT, settings.getEncodingType());
+		assertTrue(settings.getTrustedRecipient());
+	}
 }

--- a/src/test/java/com/vonage/client/verify/VerifyEndpointTestSpec.java
+++ b/src/test/java/com/vonage/client/verify/VerifyEndpointTestSpec.java
@@ -18,18 +18,18 @@ package com.vonage.client.verify;
 import com.vonage.client.DynamicEndpointTestSpec;
 import com.vonage.client.VonageApiResponseException;
 import com.vonage.client.VonageClientException;
-import com.vonage.client.auth.ApiKeyQueryParamsAuthMethod;
+import com.vonage.client.auth.ApiKeyHeaderAuthMethod;
 import com.vonage.client.auth.AuthMethod;
 import com.vonage.client.common.HttpMethod;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 abstract class VerifyEndpointTestSpec<T, R> extends DynamicEndpointTestSpec<T, R> {
 
 	@Override
 	protected Collection<Class<? extends AuthMethod>> expectedAuthMethods() {
-		return List.of(ApiKeyQueryParamsAuthMethod.class);
+		return Arrays.asList(ApiKeyHeaderAuthMethod.class);
 	}
 
 	@Override

--- a/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
+++ b/src/test/java/com/vonage/client/verify2/VerificationRequestTest.java
@@ -337,6 +337,14 @@ public class VerificationRequestTest {
 	}
 
 	@Test
+	public void testSilentAuthConstructorWithRedirectUrl() {
+		SilentAuthWorkflow workflow = new SilentAuthWorkflow(TO_NUMBER, REDIRECT_URL);
+		assertEquals(TO_NUMBER, workflow.getTo());
+		assertEquals(REDIRECT_URL, workflow.getRedirectUrl().toString());
+		assertNull(workflow.getSandbox());
+	}
+
+	@Test
 	public void testInvalidLocale() {
 		VerificationRequest.Builder builder = getBuilderRequiredParamsSingleWorkflow(Channel.SMS);
 		assertThrows(IllegalArgumentException.class, () -> builder.locale("--++").build());

--- a/src/test/java/com/vonage/client/voice/AnswerWebhookTest.java
+++ b/src/test/java/com/vonage/client/voice/AnswerWebhookTest.java
@@ -69,4 +69,55 @@ public class AnswerWebhookTest {
         assertEquals(EndpointType.SIP, EndpointType.fromString("sip"));
         assertEquals(EndpointType.WEBSOCKET, EndpointType.fromString("websocket"));
     }
+
+    @Test
+    public void testSipHeaderUserToUser() {
+        String userToUserHeader = "1234567890abcdef;encoding=hex",
+                json = "{\"SipHeader_User-to-User\":\"" + userToUserHeader + "\"}";
+        AnswerWebhook parsed = AnswerWebhook.fromJson(json);
+        testJsonableBaseObject(parsed);
+        assertEquals(userToUserHeader, parsed.getSipHeaderUserToUser());
+        assertNull(parsed.getEndpointType());
+        assertNull(parsed.getTo());
+        assertNull(parsed.getFrom());
+        assertNull(parsed.getUuid());
+        assertNull(parsed.getConversationUuid());
+        assertNull(parsed.getRegionUrl());
+        assertNull(parsed.getCustomData());
+    }
+
+    @Test
+    public void testSipHeaderUserToUserWithOtherFields() {
+        String userToUserHeader = "abcd1234;encoding=hex",
+                to = "442079460000",
+                from = "447700900000",
+                uuid = "f7aebf19bd374d638f3532352f48901b",
+                json = "{\n" +
+                    "  \"to\": \"" + to + "\",\n" +
+                    "  \"from\": \"" + from + "\",\n" +
+                    "  \"uuid\": \"" + uuid + "\",\n" +
+                    "  \"SipHeader_User-to-User\": \"" + userToUserHeader + "\"\n}";
+
+        AnswerWebhook parsed = AnswerWebhook.fromJson(json);
+        testJsonableBaseObject(parsed);
+        assertEquals(to, parsed.getTo());
+        assertEquals(from, parsed.getFrom());
+        assertEquals(uuid, parsed.getUuid());
+        assertEquals(userToUserHeader, parsed.getSipHeaderUserToUser());
+    }
+
+    @Test
+    public void testSipHeaderUserToUserMaxLength() {
+        // Test with a 256-character string (maximum allowed)
+        StringBuilder sb = new StringBuilder(260);
+        for (int i = 0; i < 246; i++) {
+            sb.append('a');
+        }
+        sb.append(";encoding=hex"); // 246 + 14 = 260 chars
+        String userToUserHeader = sb.toString();
+        String json = "{\"SipHeader_User-to-User\":\"" + userToUserHeader + "\"}";
+        AnswerWebhook parsed = AnswerWebhook.fromJson(json);
+        testJsonableBaseObject(parsed);
+        assertEquals(userToUserHeader, parsed.getSipHeaderUserToUser());
+    }
 }

--- a/src/test/java/com/vonage/client/voice/AuthorizationTest.java
+++ b/src/test/java/com/vonage/client/voice/AuthorizationTest.java
@@ -1,0 +1,173 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.vonage.client.VonageResponseParseException;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+
+public class AuthorizationTest {
+
+    @Test
+    public void testVonageAuthorization() {
+        Authorization auth = Authorization.vonage();
+        assertEquals(Authorization.Type.VONAGE, auth.getType());
+        assertNull(auth.getValue());
+    }
+
+    @Test
+    public void testVonageAuthorizationBuilder() {
+        Authorization auth = Authorization.builder(Authorization.Type.VONAGE).build();
+        assertEquals(Authorization.Type.VONAGE, auth.getType());
+        assertNull(auth.getValue());
+    }
+
+    @Test
+    public void testVonageAuthorizationIgnoresValue() {
+        // For type 'vonage', any provided value should be stored but not validated
+        Authorization auth = Authorization.builder(Authorization.Type.VONAGE)
+                .value("ignored-value")
+                .build();
+        assertEquals(Authorization.Type.VONAGE, auth.getType());
+        assertEquals("ignored-value", auth.getValue());
+    }
+
+    @Test
+    public void testCustomAuthorization() {
+        String customValue = "Bearer abc123xyz";
+        Authorization auth = Authorization.custom(customValue);
+        assertEquals(Authorization.Type.CUSTOM, auth.getType());
+        assertEquals(customValue, auth.getValue());
+    }
+
+    @Test
+    public void testCustomAuthorizationBuilder() {
+        String customValue = "ApiKey X9Z...";
+        Authorization auth = Authorization.builder(Authorization.Type.CUSTOM)
+                .value(customValue)
+                .build();
+        assertEquals(Authorization.Type.CUSTOM, auth.getType());
+        assertEquals(customValue, auth.getValue());
+    }
+
+    @Test
+    public void testCustomAuthorizationRequiresValue() {
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> {
+            Authorization.builder(Authorization.Type.CUSTOM).build();
+        });
+        assertTrue(ex.getMessage().contains("Authorization value is required"));
+    }
+
+    @Test
+    public void testCustomAuthorizationNullValue() {
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> {
+            Authorization.custom(null);
+        });
+        assertTrue(ex.getMessage().contains("Authorization value is required"));
+    }
+
+    @Test
+    public void testTypeRequired() {
+        NullPointerException ex = assertThrows(NullPointerException.class, () -> {
+            Authorization.builder(null).build();
+        });
+        assertTrue(ex.getMessage().contains("Authorization type is required"));
+    }
+
+    @Test
+    public void testValueMaxLength() {
+        // Create a string with exactly 8191 characters (max allowed)
+        String validValue = "x".repeat(8191);
+        Authorization auth = Authorization.custom(validValue);
+        assertEquals(validValue, auth.getValue());
+    }
+
+    @Test
+    public void testValueExceedsMaxLength() {
+        // Create a string with 8192 characters (one over the limit)
+        String tooLongValue = "x".repeat(8192);
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+            Authorization.custom(tooLongValue);
+        });
+        assertTrue(ex.getMessage().contains("must not exceed 8191 characters"));
+    }
+
+    @Test
+    public void testValueValidCharacters() {
+        // Test with all printable ASCII characters (0x20 to 0x7E)
+        String validValue = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+        Authorization auth = Authorization.custom(validValue);
+        assertEquals(validValue, auth.getValue());
+    }
+
+    @Test
+    public void testValueInvalidCharacters() {
+        // Test with tab character (0x09, not in the valid range)
+        String invalidValue = "Bearer\tabc123";
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+            Authorization.custom(invalidValue);
+        });
+        assertTrue(ex.getMessage().contains("printable ASCII characters"));
+    }
+
+    @Test
+    public void testValueInvalidNewline() {
+        // Test with newline character
+        String invalidValue = "Bearer abc123\n";
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> {
+            Authorization.custom(invalidValue);
+        });
+        assertTrue(ex.getMessage().contains("printable ASCII characters"));
+    }
+
+    @Test
+    public void testSerializationVonage() throws VonageResponseParseException {
+        Authorization auth = Authorization.vonage();
+        String json = auth.toJson();
+        assertTrue(json.contains("\"type\":\"vonage\""));
+        assertFalse(json.contains("\"value\""));
+    }
+
+    @Test
+    public void testSerializationCustom() throws VonageResponseParseException {
+        Authorization auth = Authorization.custom("Bearer token123");
+        String json = auth.toJson();
+        assertTrue(json.contains("\"type\":\"custom\""));
+        assertTrue(json.contains("\"value\":\"Bearer token123\""));
+    }
+
+    @Test
+    public void testDeserializationVonage() {
+        String json = "{\"type\":\"vonage\"}";
+        Authorization auth = com.vonage.client.Jsonable.fromJson(json, Authorization.class);
+        assertEquals(Authorization.Type.VONAGE, auth.getType());
+        assertNull(auth.getValue());
+    }
+
+    @Test
+    public void testDeserializationCustom() {
+        String json = "{\"type\":\"custom\",\"value\":\"Bearer token123\"}";
+        Authorization auth = com.vonage.client.Jsonable.fromJson(json, Authorization.class);
+        assertEquals(Authorization.Type.CUSTOM, auth.getType());
+        assertEquals("Bearer token123", auth.getValue());
+    }
+
+    @Test
+    public void testTypeToString() {
+        assertEquals("vonage", Authorization.Type.VONAGE.toString());
+        assertEquals("custom", Authorization.Type.CUSTOM.toString());
+    }
+}

--- a/src/test/java/com/vonage/client/voice/PhoneEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/PhoneEndpointTest.java
@@ -28,6 +28,30 @@ public class PhoneEndpointTest {
         TestUtils.testJsonableBaseObject(e);
         assertEquals("number", e.getNumber());
         assertEquals("dtmf", e.getDtmfAnswer());
+        assertNull(e.getShaken());
+    }
+
+    @Test
+    public void testConstructorWithShaken() {
+        String shakenHeader = "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=\"shaken\"";
+        PhoneEndpoint e = new PhoneEndpoint("14155551234", "p*123#", shakenHeader);
+        TestUtils.testJsonableBaseObject(e);
+        assertEquals("14155551234", e.getNumber());
+        assertEquals("p*123#", e.getDtmfAnswer());
+        assertEquals(shakenHeader, e.getShaken());
+    }
+
+    @Test
+    public void testSerializationWithShaken() {
+        String shakenHeader = "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=\"shaken\"";
+        PhoneEndpoint endpoint = new PhoneEndpoint("14155551234", null, shakenHeader);
+        String json = endpoint.toJson();
+        assertTrue(json.contains("\"shaken\""), "JSON should contain shaken field");
+        
+        // Test deserialization
+        PhoneEndpoint deserialized = com.vonage.client.Jsonable.fromJson(json, PhoneEndpoint.class);
+        assertEquals(endpoint.getNumber(), deserialized.getNumber());
+        assertEquals(endpoint.getShaken(), deserialized.getShaken());
     }
 
     @Test
@@ -46,6 +70,10 @@ public class PhoneEndpointTest {
         e1 = new PhoneEndpoint("number", "dtmf");
         e2 = new PhoneEndpoint("number", "dtmf1");
         assertNotEquals(e1, e2, "Endpoints with different dtmfAnswers should not be equal");
+
+        e1 = new PhoneEndpoint("number", "dtmf", "shaken1");
+        e2 = new PhoneEndpoint("number", "dtmf", "shaken2");
+        assertNotEquals(e1, e2, "Endpoints with different shaken values should not be equal");
 
         e1 = new PhoneEndpoint("number", "dtmf");
         e2 = null;

--- a/src/test/java/com/vonage/client/voice/VoiceClientTest.java
+++ b/src/test/java/com/vonage/client/voice/VoiceClientTest.java
@@ -76,6 +76,27 @@ public class VoiceClientTest extends AbstractClientTest<VoiceClient> {
     }
 
     @Test
+    public void testCreateCallWithShaken() throws Exception {
+        String shakenHeader = "eyJhbGciOiJFUzI1NiIsInBwdCI6InNoYWtlbiIsInR5cCI6InBhc3Nwb3J0IiwieDV1IjoiaHR0cHM6Ly9jZXJ0LmV4YW1wbGUuY29tL3Bhc3Nwb3J0LnBlbSJ9.eyJhdHRlc3QiOiJBIiwiZGVzdCI6eyJ0biI6WyIxMjEyNTU1MTIxMiJdfSwiaWF0IjoxNjk0ODcwNDAwLCJvcmlnIjp7InRuIjoiMTQxNTU1NTEyMzQifSwib3JpZ2lkIjoiMTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDAwIn0.MEUCIQCrfKeMtvn9I6zXjE2VfGEcdjC2sm5M6cPqBvFyV9XkpQIgLxlvLNmC8DJEKexXZqTZ;info=<https://stir-provider.example.net/cert.cer>;alg=ES256;ppt=\"shaken\"";
+        String expectedJson = "{\n" + "  \"conversation_uuid\": \"63f61863-4a51-4f6b-86e1-46edebio0391\",\n"
+                + "  \"uuid\": \"" + SAMPLE_CALL_ID + "\",\n"
+                + "  \"status\": \"started\",\n" + "  \"direction\": \"outbound\"\n" + "}";
+        stubResponse(200, expectedJson);
+        
+        PhoneEndpoint fromEndpoint = new PhoneEndpoint("14155551234", null, shakenHeader);
+        Call call = Call.builder()
+            .to(new PhoneEndpoint("12125551212"))
+            .from(fromEndpoint)
+            .answerUrl("http://api.example.com/answer")
+            .build();
+        
+        CallEvent evt = client.createCall(call);
+        assertEquals(Jsonable.fromJson(expectedJson, CallEvent.class), evt);
+        assertEquals(SAMPLE_CALL_ID, evt.getUuid());
+        assertEquals(shakenHeader, ((PhoneEndpoint) call.getFrom()).getShaken());
+    }
+
+    @Test
     public void testListCallsNoFilter() throws Exception {
         stubResponse(200,
                 "{\n" + "  \"page_size\": 10,\n" + "  \"record_index\": 0,\n" + "  \"count\": 0,\n"

--- a/src/test/java/com/vonage/client/voice/WebSocketEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/WebSocketEndpointTest.java
@@ -1,0 +1,239 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice;
+
+import com.vonage.client.users.channels.Websocket;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+public class WebSocketEndpointTest {
+
+    @Test
+    public void testBasicConstructor() {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("custom-header", "value");
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            "wss://example.com",
+            "audio/l16;rate=16000",
+            headers
+        );
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_16K, endpoint.getContentType());
+        assertEquals(headers, endpoint.getHeadersMap());
+        assertNull(endpoint.getAuthorization());
+    }
+
+    @Test
+    public void testConstructorWithURI() {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("custom-header", "value");
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_8K,
+            headers
+        );
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_8K, endpoint.getContentType());
+        assertEquals(headers, endpoint.getHeadersMap());
+        assertNull(endpoint.getAuthorization());
+    }
+
+    @Test
+    public void testConstructorWithAuthorizationVonage() {
+        Map<String, Object> headers = new HashMap<>();
+        Authorization auth = Authorization.vonage();
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            headers,
+            auth
+        );
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.VONAGE, endpoint.getAuthorization().getType());
+    }
+
+    @Test
+    public void testConstructorWithAuthorizationCustom() {
+        Map<String, Object> headers = new HashMap<>();
+        Authorization auth = Authorization.custom("Bearer token123");
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            headers,
+            auth
+        );
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.CUSTOM, endpoint.getAuthorization().getType());
+        assertEquals("Bearer token123", endpoint.getAuthorization().getValue());
+    }
+
+    @Test
+    public void testStringConstructorWithAuthorizationVonage() {
+        Map<String, Object> headers = new HashMap<>();
+        Authorization auth = Authorization.vonage();
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            "wss://example.com",
+            "audio/l16;rate=16000",
+            headers,
+            auth
+        );
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_16K, endpoint.getContentType());
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.VONAGE, endpoint.getAuthorization().getType());
+    }
+
+    @Test
+    public void testStringConstructorWithAuthorizationCustom() {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("custom-header", "value");
+        Authorization auth = Authorization.custom("Bearer abc123");
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            "wss://your-server.example.com",
+            "audio/l16;rate=8000",
+            headers,
+            auth
+        );
+        
+        assertEquals(URI.create("wss://your-server.example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_8K, endpoint.getContentType());
+        assertEquals("value", endpoint.getHeadersMap().get("custom-header"));
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.CUSTOM, endpoint.getAuthorization().getType());
+        assertEquals("Bearer abc123", endpoint.getAuthorization().getValue());
+    }
+
+    @Test
+    public void testSerializationWithVonageAuthorization() {
+        Authorization auth = Authorization.vonage();
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            null,
+            auth
+        );
+        
+        String json = endpoint.toJson();
+        assertTrue(json.contains("\"type\":\"websocket\""));
+        assertTrue(json.contains("\"uri\":\"wss://example.com\""));
+        assertTrue(json.contains("\"authorization\":{\"type\":\"vonage\"}"));
+    }
+
+    @Test
+    public void testSerializationWithCustomAuthorization() {
+        Authorization auth = Authorization.custom("Bearer abc123");
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("custom-header", "value");
+        
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://your-server.example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            headers,
+            auth
+        );
+        
+        String json = endpoint.toJson();
+        assertTrue(json.contains("\"type\":\"websocket\""));
+        assertTrue(json.contains("\"uri\":\"wss://your-server.example.com\""));
+        assertTrue(json.contains("\"content-type\":\"audio/l16;rate=16000\""));
+        assertTrue(json.contains("\"authorization\":{\"type\":\"custom\",\"value\":\"Bearer abc123\"}"));
+        assertTrue(json.contains("\"custom-header\":\"value\""));
+    }
+
+    @Test
+    public void testSerializationWithoutAuthorization() {
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            null
+        );
+        
+        String json = endpoint.toJson();
+        assertTrue(json.contains("\"type\":\"websocket\""));
+        assertTrue(json.contains("\"uri\":\"wss://example.com\""));
+        assertFalse(json.contains("\"authorization\""));
+    }
+
+    @Test
+    public void testDeserializationWithVonageAuthorization() {
+        String json = "{\"type\":\"websocket\",\"uri\":\"wss://example.com\"," +
+                      "\"content-type\":\"audio/l16;rate=16000\"," +
+                      "\"authorization\":{\"type\":\"vonage\"}}";
+        
+        WebSocketEndpoint endpoint = com.vonage.client.Jsonable.fromJson(json, WebSocketEndpoint.class);
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_16K, endpoint.getContentType());
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.VONAGE, endpoint.getAuthorization().getType());
+    }
+
+    @Test
+    public void testDeserializationWithCustomAuthorization() {
+        String json = "{\"type\":\"websocket\",\"uri\":\"wss://example.com\"," +
+                      "\"content-type\":\"audio/l16;rate=16000\"," +
+                      "\"headers\":{\"custom-header\":\"value\"}," +
+                      "\"authorization\":{\"type\":\"custom\",\"value\":\"Bearer token123\"}}";
+        
+        WebSocketEndpoint endpoint = com.vonage.client.Jsonable.fromJson(json, WebSocketEndpoint.class);
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_16K, endpoint.getContentType());
+        assertNotNull(endpoint.getAuthorization());
+        assertEquals(Authorization.Type.CUSTOM, endpoint.getAuthorization().getType());
+        assertEquals("Bearer token123", endpoint.getAuthorization().getValue());
+        assertEquals("value", endpoint.getHeadersMap().get("custom-header"));
+    }
+
+    @Test
+    public void testDeserializationWithoutAuthorization() {
+        String json = "{\"type\":\"websocket\",\"uri\":\"wss://example.com\"," +
+                      "\"content-type\":\"audio/l16;rate=16000\"}";
+        
+        WebSocketEndpoint endpoint = com.vonage.client.Jsonable.fromJson(json, WebSocketEndpoint.class);
+        
+        assertEquals(URI.create("wss://example.com"), endpoint.getUri());
+        assertEquals(Websocket.ContentType.AUDIO_L16_16K, endpoint.getContentType());
+        assertNull(endpoint.getAuthorization());
+    }
+
+    @Test
+    public void testEndpointType() {
+        WebSocketEndpoint endpoint = new WebSocketEndpoint(
+            URI.create("wss://example.com"),
+            Websocket.ContentType.AUDIO_L16_16K,
+            null
+        );
+        
+        assertEquals(EndpointType.WEBSOCKET, endpoint.getType());
+    }
+}

--- a/src/test/java/com/vonage/client/voice/ncco/TransferActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/TransferActionTest.java
@@ -1,0 +1,243 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice.ncco;
+
+import com.vonage.client.TestUtils;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
+import java.util.*;
+
+public class TransferActionTest {
+
+    private static final String CONVERSATION_ID = "CON-f972836a-550f-45fa-956c-12a2ab5b7d22";
+    private static final String UUID_1 = "9c132730-8c22-4760-a4dc-40502f05b444";
+    private static final String UUID_2 = "416dfcfc-d86a-41c2-92ad-9a4fe1266898";
+
+    @Test
+    public void testBuilderMultipleInstances() {
+        TransferAction.Builder builder = TransferAction.builder(CONVERSATION_ID);
+        assertNotSame(builder.build(), builder.build());
+    }
+
+    @Test
+    public void testGetAction() {
+        TransferAction action = TransferAction.builder(CONVERSATION_ID).build();
+        assertEquals("transfer", action.getAction());
+    }
+
+    @Test
+    public void testMinimalAction() {
+        TransferAction action = TransferAction.builder(CONVERSATION_ID).build();
+        String expectedJson = "[{\"conversationId\":\"" + CONVERSATION_ID + "\",\"action\":\"transfer\"}]";
+        assertEquals(expectedJson, new Ncco(action).toJson());
+        TestUtils.testJsonableBaseObject(action);
+    }
+
+    @Test
+    public void testAllFields() {
+        TransferAction action = TransferAction.builder(CONVERSATION_ID)
+                .mute(true)
+                .addCanSpeak(UUID_1)
+                .addCanHear(UUID_2)
+                .build();
+
+        String expectedJson = "[{\"conversationId\":\"" + CONVERSATION_ID + "\"," +
+                "\"mute\":true,\"canSpeak\":[\"" + UUID_1 + "\"]," +
+                "\"canHear\":[\"" + UUID_2 + "\"],\"action\":\"transfer\"}]";
+        assertEquals(expectedJson, new Ncco(action).toJson());
+        TestUtils.testJsonableBaseObject(action);
+    }
+
+    @Test
+    public void testConversationIdRequired() {
+        assertThrows(NullPointerException.class, () -> TransferAction.builder(null).build());
+    }
+
+    @Test
+    public void testConversationIdCannotBeEmpty() {
+        assertThrows(IllegalArgumentException.class, () -> TransferAction.builder("").build());
+        assertThrows(IllegalArgumentException.class, () -> TransferAction.builder("   ").build());
+    }
+
+    @Test
+    public void testConversationIdCanBeChanged() {
+        String newId = "CON-different-id";
+        TransferAction action = TransferAction.builder(CONVERSATION_ID)
+                .conversationId(newId)
+                .build();
+        assertEquals(newId, action.getConversationId());
+        assertTrue(action.toJson().contains("\"conversationId\":\"" + newId + "\""));
+    }
+
+    @Test
+    public void testMute() {
+        TransferAction action = TransferAction.builder(CONVERSATION_ID).mute(true).build();
+        assertEquals(true, action.getMute());
+        String expectedJson = "[{\"conversationId\":\"" + CONVERSATION_ID + "\",\"mute\":true,\"action\":\"transfer\"}]";
+        assertEquals(expectedJson, new Ncco(action).toJson());
+
+        action = TransferAction.builder(CONVERSATION_ID).mute(false).build();
+        assertEquals(false, action.getMute());
+
+        action = TransferAction.builder(CONVERSATION_ID).build();
+        assertNull(action.getMute());
+    }
+
+    @Test
+    public void testCanSpeak() {
+        String uuid1 = UUID.randomUUID().toString().replace("-", "");
+        String uuid2 = UUID.randomUUID().toString();
+
+        TransferAction.Builder builder = TransferAction.builder(CONVERSATION_ID)
+                .addCanSpeak(uuid1)
+                .addCanSpeak(uuid2);
+
+        TransferAction action = builder.build();
+        var canSpeak = action.getCanSpeak();
+        assertNotNull(canSpeak);
+        assertEquals(2, canSpeak.size());
+        Iterator<String> iter = canSpeak.iterator();
+        assertEquals(uuid1, iter.next());
+        assertEquals(uuid2, iter.next());
+        assertTrue(action.toJson().contains("\"canSpeak\":[\"" + uuid1 + "\",\"" + uuid2 + "\"]"));
+
+        action = builder.canSpeak(Collections.emptyList()).build();
+        canSpeak = action.getCanSpeak();
+        assertNotNull(canSpeak);
+        assertTrue(canSpeak.isEmpty());
+        assertTrue(action.toJson().contains("\"canSpeak\":[]"));
+
+        action = builder.canSpeak(null).build();
+        canSpeak = action.getCanSpeak();
+        assertNull(canSpeak);
+        assertFalse(action.toJson().contains("canSpeak"));
+
+        action = builder
+                .addCanSpeak(uuid1)
+                .canSpeak(new ArrayList<>())
+                .addCanSpeak(uuid2)
+                .addCanSpeak(uuid2)
+                .build();
+        canSpeak = action.getCanSpeak();
+        assertNotNull(canSpeak);
+        assertEquals(1, canSpeak.size());
+        assertTrue(action.toJson().contains("\"canSpeak\":[\"" + uuid2 + "\"]"));
+    }
+
+    @Test
+    public void testCanHear() {
+        String uuid1 = UUID.randomUUID().toString();
+        String uuid2 = UUID.randomUUID().toString().replace("-", "");
+
+        TransferAction.Builder builder = TransferAction.builder(CONVERSATION_ID)
+                .addCanHear(uuid1)
+                .addCanHear(uuid2);
+
+        TransferAction action = builder.build();
+        var canHear = action.getCanHear();
+        assertNotNull(canHear);
+        assertEquals(2, canHear.size());
+        Iterator<String> iter = canHear.iterator();
+        assertEquals(uuid1, iter.next());
+        assertEquals(uuid2, iter.next());
+        assertTrue(action.toJson().contains("\"canHear\":[\"" + uuid1 + "\",\"" + uuid2 + "\"]"));
+
+        action = builder.canHear(Collections.emptyList()).build();
+        canHear = action.getCanHear();
+        assertNotNull(canHear);
+        assertTrue(canHear.isEmpty());
+        assertTrue(action.toJson().contains("\"canHear\":[]"));
+
+        action = builder.canHear(null).build();
+        canHear = action.getCanHear();
+        assertNull(canHear);
+        assertFalse(action.toJson().contains("canHear"));
+
+        action = builder
+                .addCanHear(uuid1)
+                .canHear(new ArrayList<>())
+                .addCanHear(uuid2)
+                .addCanHear(uuid2)
+                .build();
+        canHear = action.getCanHear();
+        assertNotNull(canHear);
+        assertEquals(1, canHear.size());
+        assertTrue(action.toJson().contains("\"canHear\":[\"" + uuid2 + "\"]"));
+    }
+
+    @Test
+    public void testMultipleCanSpeakAdditions() {
+        String uuid1 = "uuid-1";
+        String uuid2 = "uuid-2";
+        String uuid3 = "uuid-3";
+
+        TransferAction action = TransferAction.builder(CONVERSATION_ID)
+                .addCanSpeak(uuid1, uuid2, uuid3)
+                .build();
+
+        var canSpeak = action.getCanSpeak();
+        assertNotNull(canSpeak);
+        assertEquals(3, canSpeak.size());
+        assertTrue(canSpeak.contains(uuid1));
+        assertTrue(canSpeak.contains(uuid2));
+        assertTrue(canSpeak.contains(uuid3));
+    }
+
+    @Test
+    public void testMultipleCanHearAdditions() {
+        String uuid1 = "uuid-1";
+        String uuid2 = "uuid-2";
+        String uuid3 = "uuid-3";
+
+        TransferAction action = TransferAction.builder(CONVERSATION_ID)
+                .addCanHear(uuid1, uuid2, uuid3)
+                .build();
+
+        var canHear = action.getCanHear();
+        assertNotNull(canHear);
+        assertEquals(3, canHear.size());
+        assertTrue(canHear.contains(uuid1));
+        assertTrue(canHear.contains(uuid2));
+        assertTrue(canHear.contains(uuid3));
+    }
+
+    @Test
+    public void testDuplicatesAreRemoved() {
+        String uuid = "duplicate-uuid";
+
+        TransferAction action = TransferAction.builder(CONVERSATION_ID)
+                .addCanSpeak(uuid, uuid, uuid)
+                .addCanHear(uuid, uuid)
+                .build();
+
+        assertEquals(1, action.getCanSpeak().size());
+        assertEquals(1, action.getCanHear().size());
+    }
+
+    @Test
+    public void testJsonRoundTrip() {
+        TransferAction original = TransferAction.builder(CONVERSATION_ID)
+                .mute(true)
+                .addCanSpeak(UUID_1)
+                .addCanHear(UUID_2)
+                .build();
+
+        String json = new Ncco(original).toJson();
+        assertNotNull(json);
+        assertTrue(json.contains("\"action\":\"transfer\""));
+        assertTrue(json.contains("\"conversationId\":\"" + CONVERSATION_ID + "\""));
+    }
+}

--- a/src/test/java/com/vonage/client/voice/ncco/WaitActionTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/WaitActionTest.java
@@ -1,0 +1,97 @@
+/*
+ *   Copyright 2025 Vonage
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+package com.vonage.client.voice.ncco;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import org.junit.jupiter.api.*;
+
+public class WaitActionTest {
+
+    @Test
+    public void testBuilderMultipleInstances() {
+        WaitAction.Builder builder = WaitAction.builder();
+        assertNotSame(builder.build(), builder.build());
+        
+        assertNotSame(
+                WaitAction.builder(0.5),
+                WaitAction.builder(0.5)
+        );
+    }
+
+    @Test
+    public void testGetAction() {
+        WaitAction wait = WaitAction.builder().build();
+        assertEquals("wait", wait.getAction());
+    }
+
+    @Test
+    public void testDefault() {
+        WaitAction wait = WaitAction.builder().build();
+        assertEquals("[{\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testWithTimeout() {
+        WaitAction wait = WaitAction.builder().timeout(0.5).build();
+        assertEquals("[{\"timeout\":0.5,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testBuilderWithTimeout() {
+        WaitAction wait = WaitAction.builder(0.5).build();
+        assertEquals("[{\"timeout\":0.5,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testMinimumTimeout() {
+        WaitAction wait = WaitAction.builder().timeout(0.1).build();
+        assertEquals("[{\"timeout\":0.1,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testMaximumTimeout() {
+        WaitAction wait = WaitAction.builder().timeout(7200.0).build();
+        assertEquals("[{\"timeout\":7200.0,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testIntegerTimeout() {
+        WaitAction wait = WaitAction.builder().timeout(10).build();
+        assertEquals("[{\"timeout\":10.0,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testDecimalTimeout() {
+        WaitAction wait = WaitAction.builder().timeout(2.5).build();
+        assertEquals("[{\"timeout\":2.5,\"action\":\"wait\"}]", new Ncco(wait).toJson());
+    }
+
+    @Test
+    public void testExampleFromDocumentation() {
+        // From the documentation example
+        TalkAction talk1 = TalkAction.builder("Welcome to a Vonage moderated conference").build();
+        WaitAction wait = WaitAction.builder(0.5).build();
+        TalkAction talk2 = TalkAction.builder("We will connect you when an agent is available").build();
+        
+        Ncco ncco = new Ncco(talk1, wait, talk2);
+        String json = ncco.toJson();
+        
+        // Verify wait action is properly serialized in the NCCO
+        assertEquals(true, json.contains("\"action\":\"wait\""));
+        assertEquals(true, json.contains("\"timeout\":0.5"));
+    }
+}

--- a/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
@@ -16,6 +16,7 @@
 package com.vonage.client.voice.ncco;
 
 import com.vonage.client.users.channels.Websocket;
+import com.vonage.client.voice.Authorization;
 import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.*;
 import java.util.Collections;
@@ -35,4 +36,57 @@ public class WebSocketEndpointTest {
                 "audio/l16;rate=8000\",\"headers\":{\"keyOne\":[1]},\"type\":\"websocket\"}],\"action\":\"connect\"}]";
         assertEquals(expectedJson, new Ncco(connect).toJson());
     }
+
+    @Test
+    public void testAuthorizationVonage() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "audio/l16;rate=16000")
+                .authorization(Authorization.vonage())
+                .build();
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\"wss://example.com\",\"content-type\":\"audio/l16;rate=16000\"," +
+                "\"authorization\":{\"type\":\"vonage\"},\"type\":\"websocket\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void testAuthorizationCustom() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "audio/l16;rate=16000")
+                .authorization(Authorization.custom("Bearer eyJhbGciOi..."))
+                .build();
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\"wss://example.com\",\"content-type\":\"audio/l16;rate=16000\"," +
+                "\"authorization\":{\"type\":\"custom\",\"value\":\"Bearer eyJhbGciOi...\"},\"type\":\"websocket\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void testAllFieldsWithAuthorization() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "audio/l16;rate=16000")
+                .uri("wss://your-server.example.com")
+                .contentType("audio/l16;rate=16000")
+                .headers(Collections.singletonMap("custom-header", "value"))
+                .authorization(Authorization.custom("Bearer eyJhbGciOi..."))
+                .build();
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String json = new Ncco(connect).toJson();
+        assertTrue(json.contains("\"uri\":\"wss://your-server.example.com\""));
+        assertTrue(json.contains("\"content-type\":\"audio/l16;rate=16000\""));
+        assertTrue(json.contains("\"custom-header\":\"value\""));
+        assertTrue(json.contains("\"authorization\":{\"type\":\"custom\",\"value\":\"Bearer eyJhbGciOi...\"}"));
+    }
+
+    @Test
+    public void testNoAuthorization() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "audio/l16;rate=16000")
+                .build();
+        
+        assertNull(endpoint.getAuthorization());
+        
+        String json = new Ncco(ConnectAction.builder(endpoint).build()).toJson();
+        assertFalse(json.contains("\"authorization\""));
+    }
 }
+

--- a/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
+++ b/src/test/java/com/vonage/client/voice/ncco/WebSocketEndpointTest.java
@@ -88,5 +88,29 @@ public class WebSocketEndpointTest {
         String json = new Ncco(ConnectAction.builder(endpoint).build()).toJson();
         assertFalse(json.contains("\"authorization\""));
     }
+
+    @Test
+    public void test24KAudioRate() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "audio/l16;rate=24000")
+                .headers(Collections.singletonMap("foo", "bar"))
+                .build();
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String expectedJson = "[{\"endpoint\":[{\"uri\":\"wss://example.com\",\"content-type\":\"audio/l16;rate=24000\"," +
+                "\"headers\":{\"foo\":\"bar\"},\"type\":\"websocket\"}],\"action\":\"connect\"}]";
+        assertEquals(expectedJson, new Ncco(connect).toJson());
+    }
+
+    @Test
+    public void test24KAudioRateWithEnum() {
+        WebSocketEndpoint endpoint = WebSocketEndpoint.builder("wss://example.com", "some-content")
+                .contentType(Websocket.ContentType.AUDIO_L16_24K)
+                .build();
+        ConnectAction connect = ConnectAction.builder(endpoint).build();
+
+        String json = new Ncco(connect).toJson();
+        assertTrue(json.contains("\"uri\":\"wss://example.com\""));
+        assertTrue(json.contains("\"content-type\":\"audio/l16;rate=24000\""));
+    }
 }
 

--- a/src/test/resources/com/vonage/client/identityinsights/current-carrier-response.json
+++ b/src/test/resources/com/vonage/client/identityinsights/current-carrier-response.json
@@ -1,0 +1,15 @@
+{
+  "request_id": "REQUEST_ID_PLACEHOLDER",
+  "insights": {
+    "current_carrier": {
+      "name": "Orange Espana, S.A. Unipersonal",
+      "network_type": "MOBILE",
+      "country_code": "ES",
+      "network_code": "21403",
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    }
+  }
+}

--- a/src/test/resources/com/vonage/client/identityinsights/format-response.json
+++ b/src/test/resources/com/vonage/client/identityinsights/format-response.json
@@ -1,0 +1,19 @@
+{
+  "request_id": "REQUEST_ID_PLACEHOLDER",
+  "insights": {
+    "format": {
+      "country_code": "US",
+      "country_name": "United States",
+      "country_prefix": "1",
+      "offline_location": "California",
+      "time_zones": ["America/Los_Angeles"],
+      "number_international": "+14155552671",
+      "number_national": "(415) 555-2671",
+      "is_format_valid": true,
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    }
+  }
+}

--- a/src/test/resources/com/vonage/client/identityinsights/multiple-insights-response.json
+++ b/src/test/resources/com/vonage/client/identityinsights/multiple-insights-response.json
@@ -1,0 +1,28 @@
+{
+  "request_id": "REQUEST_ID_PLACEHOLDER",
+  "insights": {
+    "format": {
+      "country_code": "US",
+      "is_format_valid": true,
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    },
+    "sim_swap": {
+      "is_swapped": false,
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    },
+    "original_carrier": {
+      "name": "Verizon Wireless",
+      "network_type": "MOBILE",
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    }
+  }
+}

--- a/src/test/resources/com/vonage/client/identityinsights/sim-swap-response.json
+++ b/src/test/resources/com/vonage/client/identityinsights/sim-swap-response.json
@@ -1,0 +1,13 @@
+{
+  "request_id": "REQUEST_ID_PLACEHOLDER",
+  "insights": {
+    "sim_swap": {
+      "latest_sim_swap_at": "2024-07-08T09:30:27.504Z",
+      "is_swapped": true,
+      "status": {
+        "code": "OK",
+        "message": "Success"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Playing catch-up for a bunch of outstanding work.

- Added deprecation notice for Java 8/1.8 users. Version 9.x will be the final version to support Java 8.
- Accounts: Internally switched to supporting only Basic Authorization header authentication
- Conversion: Internally switched to supporting only Basic Authorization header authentication
- Identity Insights: Added new API, covers Formatting, SimSwap, Original and Current Carrier checks
- Messages: Added `trusted_recipient` to SMS, MMS, and RCS
- Messages: Added support for Typing Indicators in WhatsApp
- Messages: Added `pool_id` support
- Number Insights: Internally switched to supporting only Basic Authorization header authentication
- Verify v1: Internally switched to supporting only Basic Authorization header authenticatio
- Verify: Deprecates the `sandbox` parameter
- Voice: Websocket Connections can now include custom authorization headers
- Voice: Answer Webhook adds support for SIP User-To-User incoming headers
- Voice: Add support for `shaken` signing on calls
- Voice: Added support for `sip_code` on incoming event webhooks
- Voice: Added support for Transfer NCCO action
- Voice: Added support for Wait NCCO action

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
