### PR TITLE
fix: Keep alive issue with HttpURLConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.10.2]
+- HTTP: Fixed stale pooled connection reuse by adding connection TTL, idle/expired eviction and inactivity validation to reduce intermittent `Connection reset` errors when reusing long-lived `VonageClient` instances
+
+# [9.10.1]
+- No changes, had to create to trigger a rebuild due to build system problem
+
 # [9.10.0]
 - Exceptions: Added `getRawRequest()` and `getRawResponse()` methods to `VonageApiResponseException` for debugging API errors
 - Messages: RCS TTL is now publicly settable on all RCS message types, with validation between 300 and 2592000 seconds

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.10.1")
+    implementation("com.vonage:server-sdk:9.10.2")
 }
 ```
 
@@ -94,7 +94,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.10.1</version>
+    <version>9.10.2</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.10.1</version>
+  <version>9.10.2</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -29,15 +29,22 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import java.util.UUID;
 
 /**
  * Internal class that holds available authentication methods and a shared HttpClient.
  */
 public class HttpWrapper {
+    private static final int
+            CONNECTION_POOL_MAX = 200,
+            CONNECTION_TTL_SECONDS = 60,
+            VALIDATE_AFTER_INACTIVITY_MS = 2000,
+            EVICT_IDLE_CONNECTIONS_SECONDS = 30;
+
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.10.1",
+            CLIENT_VERSION = "9.10.2",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 
@@ -168,16 +175,16 @@ public class HttpWrapper {
     }
 
     protected CloseableHttpClient createHttpClient() {
-        PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
-        connectionManager.setDefaultMaxPerRoute(200);
-        connectionManager.setMaxTotal(200);
+        PoolingHttpClientConnectionManager connectionManager =
+                new PoolingHttpClientConnectionManager(CONNECTION_TTL_SECONDS, TimeUnit.SECONDS);
+        connectionManager.setDefaultMaxPerRoute(CONNECTION_POOL_MAX);
+        connectionManager.setMaxTotal(CONNECTION_POOL_MAX);
         connectionManager.setDefaultConnectionConfig(
             ConnectionConfig.custom().setCharset(StandardCharsets.UTF_8).build()
         );
         connectionManager.setDefaultSocketConfig(SocketConfig.custom().setTcpNoDelay(true).build());
+        connectionManager.setValidateAfterInactivity(VALIDATE_AFTER_INACTIVITY_MS);
 
-        // Need to work out a good value for the following:
-        // threadSafeClientConnManager.setValidateAfterInactivity();
         RequestConfig requestConfig = RequestConfig.custom()
                 .setConnectTimeout(httpConfig.getTimeoutMillis())
                 .setConnectionRequestTimeout(httpConfig.getTimeoutMillis())
@@ -188,6 +195,8 @@ public class HttpWrapper {
                 .setConnectionManager(connectionManager)
                 .setUserAgent(getUserAgent())
                 .setDefaultRequestConfig(requestConfig)
+            .evictExpiredConnections()
+            .evictIdleConnections(EVICT_IDLE_CONNECTIONS_SECONDS, TimeUnit.SECONDS)
                 .useSystemProperties().disableRedirectHandling();
 
         URI proxy = httpConfig.getProxy();

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -195,8 +195,8 @@ public class HttpWrapper {
                 .setConnectionManager(connectionManager)
                 .setUserAgent(getUserAgent())
                 .setDefaultRequestConfig(requestConfig)
-            .evictExpiredConnections()
-            .evictIdleConnections(EVICT_IDLE_CONNECTIONS_SECONDS, TimeUnit.SECONDS)
+                .evictExpiredConnections()
+                .evictIdleConnections(EVICT_IDLE_CONNECTIONS_SECONDS, TimeUnit.SECONDS)
                 .useSystemProperties().disableRedirectHandling();
 
         URI proxy = httpConfig.getProxy();


### PR DESCRIPTION
This patch improves reliability for long-lived client instances by hardening default HTTP connection pooling behavior in `HttpWrapper.java`,

Changes included:
* Added pooled connection TTL to avoid reusing long-lived stale sockets.
* Added validate-after-inactivity checks before reusing idle pooled connections.
* Added idle and expired connection eviction to proactively clean the pool.
* Kept behavior backward compatible for users who inject their own HTTP client.

Why:
Some customers reuse a single client in long-running processes and intermittently hit Connection reset after idle periods.

## Contribution Checklist
* [ ] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
