### PR TITLE
fix: Removed trailing slash for conversations URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.11.0")
+    implementation("com.vonage:server-sdk:9.12.0")
 }
 ```
 
@@ -94,7 +94,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.11.0</version>
+    <version>9.12.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.11.0</version>
+  <version>9.12.0</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -44,7 +44,7 @@ public class HttpWrapper {
 
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.11.0",
+            CLIENT_VERSION = "9.12.0",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/conversations/ConversationsClient.java
+++ b/src/main/java/com/vonage/client/conversations/ConversationsClient.java
@@ -71,7 +71,11 @@ public class ConversationsClient {
 					.responseExceptionType(ConversationsResponseException.class)
 					.requestMethod(method).wrapper(wrapper).pathGetter((de, req) -> {
 						String base = de.getHttpWrapper().getHttpConfig().getApiBaseUri();
-						return base + pathGetter.apply(req);
+						String path = base + pathGetter.apply(req);
+						// The API gateway stopped routing trailing-slash paths to their
+						// canonical form (broke ~2026-06-06), so strip a trailing slash
+						// from any Conversations route that would otherwise end in one.
+						return path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
 					})
 				);
 			}

--- a/src/test/java/com/vonage/client/conversations/ConversationsClientTest.java
+++ b/src/test/java/com/vonage/client/conversations/ConversationsClientTest.java
@@ -646,7 +646,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(ListConversationsRequest request) {
-				return "/v1/conversations/";
+				return "/v1/conversations";
 			}
 
 			@Override
@@ -748,7 +748,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(Conversation request) {
-				return "/v1/conversations/";
+				return "/v1/conversations";
 			}
 
 			@Override
@@ -1176,7 +1176,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(ListMembersRequest request) {
-				return "/v1/conversations/"+request.conversationId+"/members/";
+				return "/v1/conversations/"+request.conversationId+"/members";
 			}
 
 			@Override
@@ -1325,7 +1325,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(Member request) {
-				return "/v1/conversations/"+request.getConversationId()+"/members/";
+				return "/v1/conversations/"+request.getConversationId()+"/members";
 			}
 
 			@Override
@@ -1670,7 +1670,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(ListEventsRequest request) {
-				return "/v1/conversations/"+request.conversationId+"/events/";
+				return "/v1/conversations/"+request.conversationId+"/events";
 			}
 
 			@Override
@@ -1734,7 +1734,7 @@ public class ConversationsClientTest extends AbstractClientTest<ConversationsCli
 
 			@Override
 			protected String expectedEndpointUri(Event request) {
-				return "/v1/conversations/"+request.conversationId+"/events/";
+				return "/v1/conversations/"+request.conversationId+"/events";
 			}
 
 			@Override


### PR DESCRIPTION
fix: Removed trailing slashes on conversation URIs

Bumped to 9.12.0 for release

_Describe your changes here_

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
