### PR TITLE
Devx 11561 trusted recipient sms fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+# [9.14.0]
+- SMS: Fixed `trusted_recipient` being serialized nested inside the `sms` settings object instead of at the top level of the message body, so `SmsTextRequest.builder().trustedRecipient(...)` now matches the Messages API contract (MMS and RCS were already correct). Removed the incorrectly placed `trusted_recipient` accessor from `OutboundSettings`; use `SmsTextRequest.getTrustedRecipient()` instead
+
 # [9.13.0]
 - Messages: Added WhatsApp business-scoped user ID (BSUID) support
   - Outbound WhatsApp messages can now be sent to a BSUID (or parent BSUID) in the `to` field, in addition to a phone number. The recipient is accepted as-is (phone numbers are normalised) and not validated against a client-side format, so values accepted by the API are never rejected by the SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-# [9.14.0]
+# [9.13.1]
 - SMS: Fixed `trusted_recipient` being serialized nested inside the `sms` settings object instead of at the top level of the message body, so `SmsTextRequest.builder().trustedRecipient(...)` now matches the Messages API contract (MMS and RCS were already correct). Removed the incorrectly placed `trusted_recipient` accessor from `OutboundSettings`; use `SmsTextRequest.getTrustedRecipient()` instead
 
 # [9.13.0]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Add the following to your `build.gradle` or `build.gradle.kts` file:
 
 ```groovy
 dependencies {
-    implementation("com.vonage:server-sdk:9.13.0")
+    implementation("com.vonage:server-sdk:9.13.1")
 }
 ```
 
@@ -94,7 +94,7 @@ Add the following to the `<dependencies>` section of your `pom.xml` file:
 <dependency>
     <groupId>com.vonage</groupId>
     <artifactId>server-sdk</artifactId>
-    <version>9.13.0</version>
+    <version>9.13.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,11 @@
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>${jackson.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.vonage</groupId>
   <artifactId>server-sdk</artifactId>
-  <version>9.13.0</version>
+  <version>9.13.1</version>
 
   <name>Vonage Java Server SDK</name>
   <description>Java client for Vonage APIs</description>

--- a/src/main/java/com/vonage/client/HttpWrapper.java
+++ b/src/main/java/com/vonage/client/HttpWrapper.java
@@ -44,7 +44,7 @@ public class HttpWrapper {
 
     private static final String
             CLIENT_NAME = "vonage-java-sdk",
-            CLIENT_VERSION = "9.13.0",
+            CLIENT_VERSION = "9.13.1",
             JAVA_VERSION = System.getProperty("java.version"),
             USER_AGENT = String.format("%s/%s java/%s", CLIENT_NAME, CLIENT_VERSION, JAVA_VERSION);
 

--- a/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
+++ b/src/main/java/com/vonage/client/messages/sms/OutboundSettings.java
@@ -26,30 +26,24 @@ import com.vonage.client.JsonableBaseObject;
 public final class OutboundSettings extends JsonableBaseObject {
     final EncodingType encodingType;
     final String contentId, entityId, poolId;
-    final Boolean trustedRecipient;
 
-    private OutboundSettings(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
-        this(encodingType, contentId, entityId, null, trustedRecipient);
+    private OutboundSettings(EncodingType encodingType, String contentId, String entityId) {
+        this(encodingType, contentId, entityId, null);
     }
 
-    private OutboundSettings(EncodingType encodingType, String contentId, String entityId, String poolId, Boolean trustedRecipient) {
+    private OutboundSettings(EncodingType encodingType, String contentId, String entityId, String poolId) {
         this.encodingType = encodingType;
         this.contentId = contentId;
         this.entityId = entityId;
         this.poolId = poolId;
-        this.trustedRecipient = trustedRecipient;
     }
 
     static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId) {
-        return construct(encodingType, contentId, entityId, null, null);
+        return construct(encodingType, contentId, entityId, null);
     }
 
-    static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, Boolean trustedRecipient) {
-        return construct(encodingType, contentId, entityId, null, trustedRecipient);
-    }
-
-    static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, String poolId, Boolean trustedRecipient) {
-        if (encodingType == null && contentId == null && entityId == null && poolId == null && trustedRecipient == null) {
+    static OutboundSettings construct(EncodingType encodingType, String contentId, String entityId, String poolId) {
+        if (encodingType == null && contentId == null && entityId == null && poolId == null) {
             return null;
         }
         if (contentId != null && contentId.trim().isEmpty()) {
@@ -61,7 +55,7 @@ public final class OutboundSettings extends JsonableBaseObject {
         if (poolId != null && poolId.trim().isEmpty()) {
             throw new IllegalArgumentException("Pool ID cannot be blank.");
         }
-        return new OutboundSettings(encodingType, contentId, entityId, poolId, trustedRecipient);
+        return new OutboundSettings(encodingType, contentId, entityId, poolId);
     }
 
     @JsonProperty("encoding_type")
@@ -82,10 +76,5 @@ public final class OutboundSettings extends JsonableBaseObject {
     @JsonProperty("pool_id")
     public String getPoolId() {
         return poolId;
-    }
-
-    @JsonProperty("trusted_recipient")
-    public Boolean getTrustedRecipient() {
-        return trustedRecipient;
     }
 }

--- a/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
+++ b/src/main/java/com/vonage/client/messages/sms/SmsTextRequest.java
@@ -23,10 +23,12 @@ import com.vonage.client.messages.TextMessageRequest;
 
 public final class SmsTextRequest extends MessageRequest implements TextMessageRequest {
 	final OutboundSettings sms;
+	final Boolean trustedRecipient;
 
 	SmsTextRequest(Builder builder) {
 		super(builder, Channel.SMS, MessageType.TEXT);
-		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId, builder.poolId, builder.trustedRecipient);
+		this.trustedRecipient = builder.trustedRecipient;
+		sms = OutboundSettings.construct(builder.encodingType, builder.contentId, builder.entityId, builder.poolId);
 	}
 
 	@Override
@@ -37,6 +39,11 @@ public final class SmsTextRequest extends MessageRequest implements TextMessageR
 	@JsonProperty("sms")
 	public OutboundSettings getMessageSettings() {
 		return sms;
+	}
+
+	@JsonProperty("trusted_recipient")
+	public Boolean getTrustedRecipient() {
+		return trustedRecipient;
 	}
 
 	@JsonProperty("ttl")

--- a/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
+++ b/src/test/java/com/vonage/client/messages/sms/SmsTextRequestTest.java
@@ -191,9 +191,14 @@ public class SmsTextRequestTest {
 		SmsTextRequest sms = SmsTextRequest.builder()
 			.from(from).to(to).text(msg)
 			.trustedRecipient(true).build();
-	
+
+		assertEquals(Boolean.TRUE, sms.getTrustedRecipient());
+
 		String json = sms.toJson();
+		// trusted_recipient must be a top-level field, not nested inside the "sms" settings object.
 		assertTrue(json.contains("\"trusted_recipient\":true"));
+		assertFalse(json.contains("\"sms\":{"));
+		assertNull(sms.getMessageSettings());
 	}
 	
 	@Test
@@ -201,16 +206,22 @@ public class SmsTextRequestTest {
 		SmsTextRequest sms = SmsTextRequest.builder()
 			.from(from).to(to).text(msg)
 			.trustedRecipient(false).build();
-	
+
+		assertEquals(Boolean.FALSE, sms.getTrustedRecipient());
+
 		String json = sms.toJson();
 		assertTrue(json.contains("\"trusted_recipient\":false"));
+		assertFalse(json.contains("\"sms\":{"));
+		assertNull(sms.getMessageSettings());
 	}
 	
 	@Test
 	public void testWithoutTrustedRecipient() {
 		SmsTextRequest sms = SmsTextRequest.builder()
 			.from(from).to(to).text(msg).build();
-	
+
+		assertNull(sms.getTrustedRecipient());
+
 		String json = sms.toJson();
 		assertFalse(json.contains("\"trusted_recipient\""));
 	}
@@ -240,7 +251,7 @@ public class SmsTextRequestTest {
 	@Test
 	public void testInvalidPoolId() {
 		assertThrows(IllegalArgumentException.class, () ->
-				OutboundSettings.construct(EncodingType.TEXT, contentId, entityId, " ", null)
+				OutboundSettings.construct(EncodingType.TEXT, contentId, entityId, " ")
 		);
 	}
 
@@ -261,7 +272,9 @@ public class SmsTextRequestTest {
 		assertTrue(json.contains("\"content_id\":\"" + contentId + "\""));
 		assertTrue(json.contains("\"entity_id\":\"" + entityId + "\""));
 		assertTrue(json.contains("\"encoding_type\":\"text\""));
+		// trusted_recipient is a top-level field, not part of the "sms" settings object.
 		assertTrue(json.contains("\"trusted_recipient\":true"));
+		assertEquals(Boolean.TRUE, sms.getTrustedRecipient());
 
 		OutboundSettings settings = sms.getMessageSettings();
 		assertNotNull(settings);
@@ -269,6 +282,5 @@ public class SmsTextRequestTest {
 		assertEquals(contentId, settings.getContentId());
 		assertEquals(entityId, settings.getEntityId());
 		assertEquals(EncodingType.TEXT, settings.getEncodingType());
-		assertTrue(settings.getTrustedRecipient());
 	}
 }


### PR DESCRIPTION
Corect bug where SMS had `trusted_recipient` was in the wrong section of the payload

## Contribution Checklist
* [x] Unit tests!
* [x] Updated [CHANGELOG.md](CHANGELOG.md)
* [x] My name is in [CONTRIBUTORS.md](CONTRIBUTORS.md)
